### PR TITLE
Adds validation around pebble socket actions to catch connection errors

### DIFF
--- a/orchestrator-bundle/build.sh
+++ b/orchestrator-bundle/build.sh
@@ -41,7 +41,7 @@ orc8r-tenants
 
 
 for charm in ${charms}; do
-    build ${charm} &
+    build ${charm}
 done
 
 wait

--- a/orchestrator-bundle/bundle-local.yaml
+++ b/orchestrator-bundle/bundle-local.yaml
@@ -6,136 +6,163 @@ description: |
   allows you to see the analytics and traffic flows of the wireless users through the Magma web UI.
 applications:
   nms-magmalte:
-    charm: magma-nms-magmalte
-    channel: edge
+    charm: ./nms-magmalte-operator/nms-magmalte.charm
     scale: 1
     trust: true
+    resources:
+      magma-nms-magmalte-image: docker.artifactory.magmacore.org/magmalte:1.6.0
   nms-nginx-proxy:
-    charm: magma-nms-nginx-proxy
-    channel: edge
+    charm: ./nms-nginx-proxy-operator/nms-nginx-proxy.charm
     scale: 1
     trust: true
+    resources:
+      magma-nms-nginx-proxy-image: nginx:latest
   orc8r-accessd:
-    charm: magma-orc8r-accessd
-    channel: edge
+    charm: ./orc8r-accessd-operator/orc8r-accessd.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-accessd-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-analytics:
-    charm: magma-orc8r-analytics
-    channel: edge
+    charm: ./orc8r-analytics-operator/orc8r-analytics.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-analytics-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-bootstrapper:
-    charm: magma-orc8r-bootstrapper
-    channel: edge
+    charm: ./orc8r-bootstrapper-operator/orc8r-bootstrapper.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-bootstrapper-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-configurator:
-    charm: magma-orc8r-configurator
-    channel: edge
+    charm: ./orc8r-configurator-operator/orc8r-configurator.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-configurator-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-ctraced:
-    charm: magma-orc8r-ctraced
-    channel: edge
+    charm: ./orc8r-ctraced-operator/orc8r-ctraced.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-ctraced-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-device:
-    charm: magma-orc8r-device
-    channel: edge
+    charm: ./orc8r-device-operator/orc8r-device.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-device-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-directoryd:
-    charm: magma-orc8r-directoryd
-    channel: edge
+    charm: ./orc8r-directoryd-operator/orc8r-directoryd.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-directoryd-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-dispatcher:
-    charm: magma-orc8r-dispatcher
-    channel: edge
+    charm: ./orc8r-dispatcher-operator/orc8r-dispatcher.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-dispatcher-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-eventd:
-    charm: magma-orc8r-eventd
-    channel: edge
+    charm: ./orc8r-eventd-operator/orc8r-eventd.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-eventd-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-ha:
-    charm: magma-orc8r-ha
-    channel: edge
+    charm: ./orc8r-ha-operator/orc8r-ha.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-ha-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-certifier:
-    charm: magma-orc8r-certifier
+    charm: ./orc8r-certifier-operator/orc8r-certifier.charm
     scale: 1
     trust: true
     options:
       domain: example.com
+    resources:
+      magma-orc8r-certifier-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-lte:
-    charm: magma-orc8r-lte
-    channel: edge
+    charm: ./orc8r-lte-operator/orc8r-lte.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-lte-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-metricsd:
-    charm: magma-orc8r-metricsd
-    channel: edge
+    charm: ./orc8r-metricsd-operator/orc8r-metricsd.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-metricsd-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-nginx:
-    charm: magma-orc8r-nginx
-    channel: edge
+    charm: ./orc8r-nginx-operator/orc8r-nginx.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-nginx-image: docker.artifactory.magmacore.org/nginx:1.6.0
   orc8r-obsidian:
-    charm: magma-orc8r-obsidian
-    channel: edge
+    charm: ./orc8r-obsidian-operator/orc8r-obsidian.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-obsidian-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-orchestrator:
-    charm: magma-orc8r-orchestrator
-    channel: edge
+    charm: ./orc8r-orchestrator-operator/orc8r-orchestrator.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-orchestrator-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-policydb:
-    charm: magma-orc8r-policydb
-    channel: edge
+    charm: ./orc8r-policydb-operator/orc8r-policydb.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-policydb-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-service-registry:
-    charm: magma-orc8r-service-registry
-    channel: edge
+    charm: ./orc8r-service-registry-operator/orc8r-service-registry.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-service-registry-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-smsd:
-    charm: magma-orc8r-smsd
-    channel: edge
+    charm: ./orc8r-smsd-operator/orc8r-smsd.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-smsd-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-state:
-    charm: magma-orc8r-state
-    channel: edge
+    charm: ./orc8r-state-operator/orc8r-state.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-state-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-streamer:
-    charm: magma-orc8r-streamer
-    channel: edge
+    charm: ./orc8r-streamer-operator/orc8r-streamer.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-streamer-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-subscriberdb:
-    charm: magma-orc8r-subscriberdb
-    channel: edge
+    charm: ./orc8r-subscriberdb-operator/orc8r-subscriberdb.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-subscriberdb-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-subscriberdb-cache:
-    charm: magma-orc8r-subscriberdb-cache
-    channel: edge
+    charm: ./orc8r-subscriberdb-cache-operator/orc8r-subscriberdb-cache.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-subscriberdb-cache-image: docker.artifactory.magmacore.org/controller:1.6.0
   orc8r-tenants:
-    charm: magma-orc8r-tenants
-    channel: edge
+    charm: ./orc8r-tenants-operator/orc8r-tenants.charm
     scale: 1
     trust: true
+    resources:
+      magma-orc8r-tenants-image: docker.artifactory.magmacore.org/controller:1.6.0
   postgresql-k8s:
     charm: postgresql-k8s
     series: kubernetes
@@ -153,7 +180,15 @@ applications:
     scale: 1
     trust: true
 relations:
+- - nms-magmalte:certifier
+  - orc8r-certifier:certifier
+- - nms-nginx-proxy:certifier
+  - orc8r-certifier:certifier
 - - orc8r-accessd:db
+  - postgresql-k8s:db
+- - orc8r-bootstrapper:certifier
+  - orc8r-certifier:certifier
+- - orc8r-certifier:db
   - postgresql-k8s:db
 - - orc8r-configurator:db
   - postgresql-k8s:db
@@ -177,10 +212,14 @@ relations:
   - postgresql-k8s:db
 - - orc8r-tenants:db
   - postgresql-k8s:db
+- - orc8r-nginx:certifier
+  - orc8r-certifier:certifier
 - - orc8r-nginx:bootstrapper
   - orc8r-bootstrapper:bootstrapper
 - - orc8r-nginx:obsidian
   - orc8r-obsidian:obsidian
+- - orc8r-orchestrator:certifier
+  - orc8r-certifier:certifier
 - - nms-magmalte:db
   - postgresql-k8s:db
 - - nms-nginx-proxy:magmalte

--- a/orchestrator-bundle/nms-magmalte-operator/src/charm.py
+++ b/orchestrator-bundle/nms-magmalte-operator/src/charm.py
@@ -83,13 +83,19 @@ class MagmaNmsMagmalteCharm(CharmBase):
         self.unit.status = MaintenanceStatus(
             f"Configuring pebble layer for {self._service_name}..."
         )
-        plan = self._container.get_plan()
-        layer = self._pebble_layer
-        if plan.services != layer.services:
-            self._container.add_layer(self._container_name, layer, combine=True)
-            self._container.restart(self._service_name)
-            logger.info(f"Restarted container {self._service_name}")
-            self.unit.status = ActiveStatus()
+        try:
+            plan = self._container.get_plan()
+            layer = self._pebble_layer
+            if plan.services != layer.services:
+                self._container.add_layer(self._container_name, layer, combine=True)
+                self._container.restart(self._service_name)
+                logger.info(f"Restarted container {self._service_name}")
+                self.unit.status = ActiveStatus()
+        except ConnectionError:
+            logger.error(
+                f"Could not restart {self._service_name} -- Pebble socket does "
+                f"not exist or is not responsive"
+            )
 
     def _mount_certifier_certs(self) -> None:
         """Patch the StatefulSet to include NMS certs secret mount."""

--- a/orchestrator-bundle/nms-magmalte-operator/src/charm.py
+++ b/orchestrator-bundle/nms-magmalte-operator/src/charm.py
@@ -56,7 +56,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
         if not self._relations_ready:
             event.defer()
             return
-        self._configure_pebble()
+        self._configure_pebble(event)
 
     def _on_database_relation_joined(self, event):
         """
@@ -78,12 +78,12 @@ class MagmaNmsMagmalteCharm(CharmBase):
             self.unit.status = MaintenanceStatus("Mounting NMS certificates...")
             self._mount_certifier_certs()
 
-    def _configure_pebble(self):
+    def _configure_pebble(self, event):
         """Adds layer to pebble config if the proposed config is different from the current one."""
-        self.unit.status = MaintenanceStatus(
-            f"Configuring pebble layer for {self._service_name}..."
-        )
-        try:
+        if self._container.can_connect():
+            self.unit.status = MaintenanceStatus(
+                f"Configuring pebble layer for {self._service_name}..."
+            )
             plan = self._container.get_plan()
             layer = self._pebble_layer
             if plan.services != layer.services:
@@ -91,11 +91,9 @@ class MagmaNmsMagmalteCharm(CharmBase):
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted container {self._service_name}")
                 self.unit.status = ActiveStatus()
-        except ConnectionError:
-            logger.error(
-                f"Could not restart {self._service_name} -- Pebble socket does "
-                f"not exist or is not responsive"
-            )
+        else:
+            self.unit.status = WaitingStatus("Waiting for container to be ready...")
+            event.defer()
 
     def _mount_certifier_certs(self) -> None:
         """Patch the StatefulSet to include NMS certs secret mount."""

--- a/orchestrator-bundle/nms-nginx-proxy-operator/src/charm.py
+++ b/orchestrator-bundle/nms-nginx-proxy-operator/src/charm.py
@@ -19,7 +19,7 @@ from lightkube.resources.apps_v1 import StatefulSet
 from lightkube.resources.core_v1 import ConfigMap
 from ops.charm import CharmBase
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import Layer
 
 logger = logging.getLogger(__name__)
@@ -49,24 +49,22 @@ class MagmaNmsNginxProxyCharm(CharmBase):
         if not self._relations_ready:
             event.defer()
             return
-        self._configure_pebble()
+        self._configure_pebble(event)
 
-    def _configure_pebble(self):
-        self.unit.status = MaintenanceStatus(
-            f"Configuring pebble layer for {self._service_name}..."
-        )
-        try:
+    def _configure_pebble(self, event):
+        if self._container.can_connect():
+            self.unit.status = MaintenanceStatus(
+                f"Configuring pebble layer for {self._service_name}..."
+            )
             plan = self._container.get_plan()
             if plan.services != self._pebble_layer.services:
                 self._container.add_layer(self._container_name, self._pebble_layer, combine=True)
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted container {self._service_name}")
                 self.unit.status = ActiveStatus()
-        except ConnectionError:
-            logger.error(
-                f"Could not restart {self._service_name} -- Pebble socket does "
-                f"not exist or is not responsive"
-            )
+        else:
+            self.unit.status = WaitingStatus("Waiting for container to be ready...")
+            event.defer()
 
     def _configure_nginx(self, event):
         if not self._nms_certs_mounted:

--- a/orchestrator-bundle/nms-nginx-proxy-operator/src/charm.py
+++ b/orchestrator-bundle/nms-nginx-proxy-operator/src/charm.py
@@ -55,12 +55,18 @@ class MagmaNmsNginxProxyCharm(CharmBase):
         self.unit.status = MaintenanceStatus(
             f"Configuring pebble layer for {self._service_name}..."
         )
-        plan = self._container.get_plan()
-        if plan.services != self._pebble_layer.services:
-            self._container.add_layer(self._container_name, self._pebble_layer, combine=True)
-            self._container.restart(self._service_name)
-            logger.info(f"Restarted container {self._service_name}")
-            self.unit.status = ActiveStatus()
+        try:
+            plan = self._container.get_plan()
+            if plan.services != self._pebble_layer.services:
+                self._container.add_layer(self._container_name, self._pebble_layer, combine=True)
+                self._container.restart(self._service_name)
+                logger.info(f"Restarted container {self._service_name}")
+                self.unit.status = ActiveStatus()
+        except ConnectionError:
+            logger.error(
+                f"Could not restart {self._service_name} -- Pebble socket does "
+                f"not exist or is not responsive"
+            )
 
     def _configure_nginx(self, event):
         if not self._nms_certs_mounted:

--- a/orchestrator-bundle/nms-nginx-proxy-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/nms-nginx-proxy-operator/tests/unit/test_charm.py
@@ -70,12 +70,12 @@ class TestCharm(unittest.TestCase):
             self.harness.charm.on.magma_nms_nginx_proxy_pebble_ready.emit(event)
         mock.assert_called_once()
 
-    def test_given_charm_when_certifier_relation_added_then_configure_ngnix_action_called(self):
+    def test_given_charm_when_certifier_relation_added_then_configure_nginx_action_called(self):
         event = Mock()
         with patch.object(MagmaNmsNginxProxyCharm, "_configure_nginx", event) as mock:
             relation_id = self.harness.add_relation("certifier", "orc8r-certifier")
             self.harness.add_relation_unit(relation_id, "orc8r-certifier/0")
-            self.harness.update_relation_data(relation_id, "orc8r-certifier/0", {})
+            self.harness.update_relation_data(relation_id, "orc8r-certifier/0", {"key": "value"})
         mock.assert_called_once()
 
     def test_given_charm_when_remove_event_emitted_then_on_remove_action_called(self):

--- a/orchestrator-bundle/orc8r-accessd-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orchestrator-bundle/orc8r-accessd-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -61,7 +61,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -97,9 +97,20 @@ class Orc8rBase(Object):
             self._db.on.database_relation_joined, self._on_database_relation_joined
         )
 
+    @property
+    def _db_relation_created(self) -> bool:
+        """Checks whether required relations are ready."""
+        if not self.model.get_relation("db"):
+            return False
+        return True
+
     def _on_magma_orc8r_pebble_ready(self, event):
+        if not self._db_relation_created:
+            self.charm.unit.status = BlockedStatus("Waiting for database relation to be created")
+            event.defer()
+            return
         if not self._db_relation_established():
-            self.charm.unit.status = BlockedStatus(
+            self.charm.unit.status = WaitingStatus(
                 "Waiting for database relation to be established..."
             )
             event.defer()
@@ -110,20 +121,18 @@ class Orc8rBase(Object):
         """
         Adds layer to pebble config if the proposed config is different from the current one
         """
-        self.charm.unit.status = MaintenanceStatus("Configuring pod")
-        pebble_layer = self._pebble_layer()
-        try:
+        if self._container.can_connect():
+            self.charm.unit.status = MaintenanceStatus("Configuring pod")
+            pebble_layer = self._pebble_layer()
             plan = self._container.get_plan()
             if plan.services != pebble_layer.services:
                 self._container.add_layer(self._container_name, pebble_layer, combine=True)
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted container {self._service_name}")
                 self.charm.unit.status = ActiveStatus()
-        except ConnectionError:
-            logger.error(
-                f"Could not restart {self._service_name} -- Pebble socket does "
-                f"not exist or is not responsive"
-            )
+        else:
+            self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
+            event.defer()
 
     def _pebble_layer(self) -> Layer:
         """Returns pebble layer for the charm."""
@@ -161,7 +170,6 @@ class Orc8rBase(Object):
         """Validates that database relation is ready (that there is a relation and that credentials
         have been passed)."""
         if not self._get_db_connection_string:
-            self.charm.unit.status = WaitingStatus("Waiting for db relation to be ready...")
             return False
         return True
 

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/tests/unit/test_charm.py
@@ -33,12 +33,14 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(initial_plan.to_yaml(), "{}\n")
 
     @patch("charm.MagmaOrc8rBootstrapperCharm._namespace", new_callable=PropertyMock)
+    @patch("charm.MagmaOrc8rBootstrapperCharm._orc8r_certs_mounted")
     @patch("charm.MagmaOrc8rBootstrapperCharm._certifier_relation_ready")
     def test_given_ready_when_get_plan_then_plan_is_filled_with_magma_orc8r_bootstrapper_service_content(  # noqa: E501
-        self, certifier_relation_ready, patch_namespace
+        self, certifier_relation_ready, orc8r_certs_mounted, patch_namespace
     ):
         namespace = "whatever"
         certifier_relation_ready.return_value = True
+        orc8r_certs_mounted.return_value = True
         patch_namespace.return_value = namespace
         expected_plan = {
             "services": {

--- a/orchestrator-bundle/orc8r-bundle/bundle.yaml
+++ b/orchestrator-bundle/orc8r-bundle/bundle.yaml
@@ -192,8 +192,8 @@ relations:
   - orc8r-bootstrapper:bootstrapper
 - - orc8r-nginx:obsidian
   - orc8r-obsidian:obsidian
-- - orc8r-orchestrator
-  - orc8r-certifier
+- - orc8r-orchestrator:certifier
+  - orc8r-certifier:certifier
 - - nms-magmalte:db
   - postgresql-k8s:db
 - - nms-nginx-proxy:magmalte

--- a/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
@@ -104,8 +104,8 @@ class MagmaOrc8rCertifierCharm(CharmBase):
 
     @property
     def _db_relation_established(self) -> bool:
-        """Validates that database relation is established (that there is a relation and that credentials
-        have been passed)."""
+        """Validates that database relation is established (that there is a relation and that
+        credentials have been passed)."""
         if not self._get_db_connection_string:
             return False
         return True

--- a/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
@@ -121,13 +121,19 @@ class MagmaOrc8rCertifierCharm(CharmBase):
     def _configure_magma_orc8r_certifier(self):
         """Adds layer to pebble config if the proposed config is different from the current one."""
         self.unit.status = MaintenanceStatus("Configuring pod")
-        plan = self._container.get_plan()
-        layer = self._pebble_layer
-        if plan.services != layer.services:
-            self._container.add_layer(self._container_name, layer, combine=True)
-            self._container.restart(self._service_name)
-            logger.info(f"Restarted container {self._service_name}")
-            self.unit.status = ActiveStatus()
+        try:
+            plan = self._container.get_plan()
+            layer = self._pebble_layer
+            if plan.services != layer.services:
+                self._container.add_layer(self._container_name, layer, combine=True)
+                self._container.restart(self._service_name)
+                logger.info(f"Restarted container {self._service_name}")
+                self.unit.status = ActiveStatus()
+        except ConnectionError:
+            logger.error(
+                f"Could not restart {self._service_name} -- Pebble socket does "
+                f"not exist or is not responsive"
+            )
 
     def _on_remove(self, event):
         self.unit.status = MaintenanceStatus("Removing Magma Orc8r secrets...")

--- a/orchestrator-bundle/orc8r-certifier-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/tests/unit/test_charm.py
@@ -73,12 +73,14 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(db_event.database, self.TEST_DB_NAME)
 
     @patch("charm.MagmaOrc8rCertifierCharm._namespace", new_callable=PropertyMock)
-    @patch("charm.MagmaOrc8rCertifierCharm._check_db_relation_has_been_established")
+    @patch("charm.MagmaOrc8rCertifierCharm._db_relation_created")
+    @patch("charm.MagmaOrc8rCertifierCharm._db_relation_established")
     def test_given_ready_when_get_plan_then_plan_is_filled_with_magma_orc8r_certifier_service_content(  # noqa: E501
-        self, db_relation_has_been_established, patch_namespace
+        self, db_relation_established, db_relation_created, patch_namespace
     ):
         namespace = "whatever"
-        db_relation_has_been_established.return_value = True
+        db_relation_established.return_value = True
+        db_relation_created.return_value = True
         patch_namespace.return_value = namespace
         event = Mock()
         with patch(

--- a/orchestrator-bundle/orc8r-configurator-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orchestrator-bundle/orc8r-configurator-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -61,7 +61,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -97,9 +97,20 @@ class Orc8rBase(Object):
             self._db.on.database_relation_joined, self._on_database_relation_joined
         )
 
+    @property
+    def _db_relation_created(self) -> bool:
+        """Checks whether required relations are ready."""
+        if not self.model.get_relation("db"):
+            return False
+        return True
+
     def _on_magma_orc8r_pebble_ready(self, event):
+        if not self._db_relation_created:
+            self.charm.unit.status = BlockedStatus("Waiting for database relation to be created")
+            event.defer()
+            return
         if not self._db_relation_established():
-            self.charm.unit.status = BlockedStatus(
+            self.charm.unit.status = WaitingStatus(
                 "Waiting for database relation to be established..."
             )
             event.defer()
@@ -110,20 +121,18 @@ class Orc8rBase(Object):
         """
         Adds layer to pebble config if the proposed config is different from the current one
         """
-        self.charm.unit.status = MaintenanceStatus("Configuring pod")
-        pebble_layer = self._pebble_layer()
-        try:
+        if self._container.can_connect():
+            self.charm.unit.status = MaintenanceStatus("Configuring pod")
+            pebble_layer = self._pebble_layer()
             plan = self._container.get_plan()
             if plan.services != pebble_layer.services:
                 self._container.add_layer(self._container_name, pebble_layer, combine=True)
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted container {self._service_name}")
                 self.charm.unit.status = ActiveStatus()
-        except ConnectionError:
-            logger.error(
-                f"Could not restart {self._service_name} -- Pebble socket does "
-                f"not exist or is not responsive"
-            )
+        else:
+            self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
+            event.defer()
 
     def _pebble_layer(self) -> Layer:
         """Returns pebble layer for the charm."""
@@ -161,7 +170,6 @@ class Orc8rBase(Object):
         """Validates that database relation is ready (that there is a relation and that credentials
         have been passed)."""
         if not self._get_db_connection_string:
-            self.charm.unit.status = WaitingStatus("Waiting for db relation to be ready...")
             return False
         return True
 

--- a/orchestrator-bundle/orc8r-ctraced-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orchestrator-bundle/orc8r-ctraced-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -61,7 +61,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -97,9 +97,20 @@ class Orc8rBase(Object):
             self._db.on.database_relation_joined, self._on_database_relation_joined
         )
 
+    @property
+    def _db_relation_created(self) -> bool:
+        """Checks whether required relations are ready."""
+        if not self.model.get_relation("db"):
+            return False
+        return True
+
     def _on_magma_orc8r_pebble_ready(self, event):
+        if not self._db_relation_created:
+            self.charm.unit.status = BlockedStatus("Waiting for database relation to be created")
+            event.defer()
+            return
         if not self._db_relation_established():
-            self.charm.unit.status = BlockedStatus(
+            self.charm.unit.status = WaitingStatus(
                 "Waiting for database relation to be established..."
             )
             event.defer()
@@ -110,20 +121,18 @@ class Orc8rBase(Object):
         """
         Adds layer to pebble config if the proposed config is different from the current one
         """
-        self.charm.unit.status = MaintenanceStatus("Configuring pod")
-        pebble_layer = self._pebble_layer()
-        try:
+        if self._container.can_connect():
+            self.charm.unit.status = MaintenanceStatus("Configuring pod")
+            pebble_layer = self._pebble_layer()
             plan = self._container.get_plan()
             if plan.services != pebble_layer.services:
                 self._container.add_layer(self._container_name, pebble_layer, combine=True)
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted container {self._service_name}")
                 self.charm.unit.status = ActiveStatus()
-        except ConnectionError:
-            logger.error(
-                f"Could not restart {self._service_name} -- Pebble socket does "
-                f"not exist or is not responsive"
-            )
+        else:
+            self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
+            event.defer()
 
     def _pebble_layer(self) -> Layer:
         """Returns pebble layer for the charm."""
@@ -161,7 +170,6 @@ class Orc8rBase(Object):
         """Validates that database relation is ready (that there is a relation and that credentials
         have been passed)."""
         if not self._get_db_connection_string:
-            self.charm.unit.status = WaitingStatus("Waiting for db relation to be ready...")
             return False
         return True
 

--- a/orchestrator-bundle/orc8r-device-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orchestrator-bundle/orc8r-device-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -61,7 +61,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -97,9 +97,20 @@ class Orc8rBase(Object):
             self._db.on.database_relation_joined, self._on_database_relation_joined
         )
 
+    @property
+    def _db_relation_created(self) -> bool:
+        """Checks whether required relations are ready."""
+        if not self.model.get_relation("db"):
+            return False
+        return True
+
     def _on_magma_orc8r_pebble_ready(self, event):
+        if not self._db_relation_created:
+            self.charm.unit.status = BlockedStatus("Waiting for database relation to be created")
+            event.defer()
+            return
         if not self._db_relation_established():
-            self.charm.unit.status = BlockedStatus(
+            self.charm.unit.status = WaitingStatus(
                 "Waiting for database relation to be established..."
             )
             event.defer()
@@ -110,20 +121,18 @@ class Orc8rBase(Object):
         """
         Adds layer to pebble config if the proposed config is different from the current one
         """
-        self.charm.unit.status = MaintenanceStatus("Configuring pod")
-        pebble_layer = self._pebble_layer()
-        try:
+        if self._container.can_connect():
+            self.charm.unit.status = MaintenanceStatus("Configuring pod")
+            pebble_layer = self._pebble_layer()
             plan = self._container.get_plan()
             if plan.services != pebble_layer.services:
                 self._container.add_layer(self._container_name, pebble_layer, combine=True)
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted container {self._service_name}")
                 self.charm.unit.status = ActiveStatus()
-        except ConnectionError:
-            logger.error(
-                f"Could not restart {self._service_name} -- Pebble socket does "
-                f"not exist or is not responsive"
-            )
+        else:
+            self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
+            event.defer()
 
     def _pebble_layer(self) -> Layer:
         """Returns pebble layer for the charm."""
@@ -161,7 +170,6 @@ class Orc8rBase(Object):
         """Validates that database relation is ready (that there is a relation and that credentials
         have been passed)."""
         if not self._get_db_connection_string:
-            self.charm.unit.status = WaitingStatus("Waiting for db relation to be ready...")
             return False
         return True
 

--- a/orchestrator-bundle/orc8r-directoryd-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orchestrator-bundle/orc8r-directoryd-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -61,7 +61,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -97,9 +97,20 @@ class Orc8rBase(Object):
             self._db.on.database_relation_joined, self._on_database_relation_joined
         )
 
+    @property
+    def _db_relation_created(self) -> bool:
+        """Checks whether required relations are ready."""
+        if not self.model.get_relation("db"):
+            return False
+        return True
+
     def _on_magma_orc8r_pebble_ready(self, event):
+        if not self._db_relation_created:
+            self.charm.unit.status = BlockedStatus("Waiting for database relation to be created")
+            event.defer()
+            return
         if not self._db_relation_established():
-            self.charm.unit.status = BlockedStatus(
+            self.charm.unit.status = WaitingStatus(
                 "Waiting for database relation to be established..."
             )
             event.defer()
@@ -110,20 +121,18 @@ class Orc8rBase(Object):
         """
         Adds layer to pebble config if the proposed config is different from the current one
         """
-        self.charm.unit.status = MaintenanceStatus("Configuring pod")
-        pebble_layer = self._pebble_layer()
-        try:
+        if self._container.can_connect():
+            self.charm.unit.status = MaintenanceStatus("Configuring pod")
+            pebble_layer = self._pebble_layer()
             plan = self._container.get_plan()
             if plan.services != pebble_layer.services:
                 self._container.add_layer(self._container_name, pebble_layer, combine=True)
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted container {self._service_name}")
                 self.charm.unit.status = ActiveStatus()
-        except ConnectionError:
-            logger.error(
-                f"Could not restart {self._service_name} -- Pebble socket does "
-                f"not exist or is not responsive"
-            )
+        else:
+            self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
+            event.defer()
 
     def _pebble_layer(self) -> Layer:
         """Returns pebble layer for the charm."""
@@ -161,7 +170,6 @@ class Orc8rBase(Object):
         """Validates that database relation is ready (that there is a relation and that credentials
         have been passed)."""
         if not self._get_db_connection_string:
-            self.charm.unit.status = WaitingStatus("Waiting for db relation to be ready...")
             return False
         return True
 

--- a/orchestrator-bundle/orc8r-ha-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
+++ b/orchestrator-bundle/orc8r-ha-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
@@ -62,7 +62,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -136,7 +136,7 @@ class Orc8rBase(Object):
         default_environment_variables = {
             "SERVICE_HOSTNAME": self._container_name,
             "SERVICE_REGISTRY_MODE": "k8s",
-            "SERVICE_REGISTRY_NAMESPACE": self._namespace
+            "SERVICE_REGISTRY_NAMESPACE": self._namespace,
         }
         environment_variables.update(self.additional_environment_variables)
         environment_variables.update(default_environment_variables)

--- a/orchestrator-bundle/orc8r-libs/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orchestrator-bundle/orc8r-libs/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -61,7 +61,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -97,9 +97,20 @@ class Orc8rBase(Object):
             self._db.on.database_relation_joined, self._on_database_relation_joined
         )
 
+    @property
+    def _db_relation_created(self) -> bool:
+        """Checks whether required relations are ready."""
+        if not self.model.get_relation("db"):
+            return False
+        return True
+
     def _on_magma_orc8r_pebble_ready(self, event):
+        if not self._db_relation_created:
+            self.charm.unit.status = BlockedStatus("Waiting for database relation to be created")
+            event.defer()
+            return
         if not self._db_relation_established():
-            self.charm.unit.status = BlockedStatus(
+            self.charm.unit.status = WaitingStatus(
                 "Waiting for database relation to be established..."
             )
             event.defer()
@@ -110,20 +121,18 @@ class Orc8rBase(Object):
         """
         Adds layer to pebble config if the proposed config is different from the current one
         """
-        self.charm.unit.status = MaintenanceStatus("Configuring pod")
-        pebble_layer = self._pebble_layer()
-        try:
+        if self._container.can_connect():
+            self.charm.unit.status = MaintenanceStatus("Configuring pod")
+            pebble_layer = self._pebble_layer()
             plan = self._container.get_plan()
             if plan.services != pebble_layer.services:
                 self._container.add_layer(self._container_name, pebble_layer, combine=True)
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted container {self._service_name}")
                 self.charm.unit.status = ActiveStatus()
-        except ConnectionError:
-            logger.error(
-                f"Could not restart {self._service_name} -- Pebble socket does "
-                f"not exist or is not responsive"
-            )
+        else:
+            self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
+            event.defer()
 
     def _pebble_layer(self) -> Layer:
         """Returns pebble layer for the charm."""
@@ -161,7 +170,6 @@ class Orc8rBase(Object):
         """Validates that database relation is ready (that there is a relation and that credentials
         have been passed)."""
         if not self._get_db_connection_string:
-            self.charm.unit.status = WaitingStatus("Waiting for db relation to be ready...")
             return False
         return True
 

--- a/orchestrator-bundle/orc8r-libs/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orchestrator-bundle/orc8r-libs/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -61,7 +61,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 
 logger = logging.getLogger(__name__)
@@ -109,7 +109,7 @@ class Orc8rBase(Object):
             self.charm.unit.status = BlockedStatus("Waiting for database relation to be created")
             event.defer()
             return
-        if not self._db_relation_established():
+        if not self._db_relation_established:
             self.charm.unit.status = WaitingStatus(
                 "Waiting for database relation to be established..."
             )
@@ -166,7 +166,8 @@ class Orc8rBase(Object):
         else:
             event.defer()
 
-    def _db_relation_established(self):
+    @property
+    def _db_relation_established(self) -> bool:
         """Validates that database relation is ready (that there is a relation and that credentials
         have been passed)."""
         if not self._get_db_connection_string:

--- a/orchestrator-bundle/orc8r-lte-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orchestrator-bundle/orc8r-lte-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -61,7 +61,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -97,9 +97,20 @@ class Orc8rBase(Object):
             self._db.on.database_relation_joined, self._on_database_relation_joined
         )
 
+    @property
+    def _db_relation_created(self) -> bool:
+        """Checks whether required relations are ready."""
+        if not self.model.get_relation("db"):
+            return False
+        return True
+
     def _on_magma_orc8r_pebble_ready(self, event):
+        if not self._db_relation_created:
+            self.charm.unit.status = BlockedStatus("Waiting for database relation to be created")
+            event.defer()
+            return
         if not self._db_relation_established():
-            self.charm.unit.status = BlockedStatus(
+            self.charm.unit.status = WaitingStatus(
                 "Waiting for database relation to be established..."
             )
             event.defer()
@@ -110,20 +121,18 @@ class Orc8rBase(Object):
         """
         Adds layer to pebble config if the proposed config is different from the current one
         """
-        self.charm.unit.status = MaintenanceStatus("Configuring pod")
-        pebble_layer = self._pebble_layer()
-        try:
+        if self._container.can_connect():
+            self.charm.unit.status = MaintenanceStatus("Configuring pod")
+            pebble_layer = self._pebble_layer()
             plan = self._container.get_plan()
             if plan.services != pebble_layer.services:
                 self._container.add_layer(self._container_name, pebble_layer, combine=True)
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted container {self._service_name}")
                 self.charm.unit.status = ActiveStatus()
-        except ConnectionError:
-            logger.error(
-                f"Could not restart {self._service_name} -- Pebble socket does "
-                f"not exist or is not responsive"
-            )
+        else:
+            self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
+            event.defer()
 
     def _pebble_layer(self) -> Layer:
         """Returns pebble layer for the charm."""
@@ -161,7 +170,6 @@ class Orc8rBase(Object):
         """Validates that database relation is ready (that there is a relation and that credentials
         have been passed)."""
         if not self._get_db_connection_string:
-            self.charm.unit.status = WaitingStatus("Waiting for db relation to be ready...")
             return False
         return True
 

--- a/orchestrator-bundle/orc8r-policydb-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orchestrator-bundle/orc8r-policydb-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -61,7 +61,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -97,9 +97,20 @@ class Orc8rBase(Object):
             self._db.on.database_relation_joined, self._on_database_relation_joined
         )
 
+    @property
+    def _db_relation_created(self) -> bool:
+        """Checks whether required relations are ready."""
+        if not self.model.get_relation("db"):
+            return False
+        return True
+
     def _on_magma_orc8r_pebble_ready(self, event):
+        if not self._db_relation_created:
+            self.charm.unit.status = BlockedStatus("Waiting for database relation to be created")
+            event.defer()
+            return
         if not self._db_relation_established():
-            self.charm.unit.status = BlockedStatus(
+            self.charm.unit.status = WaitingStatus(
                 "Waiting for database relation to be established..."
             )
             event.defer()
@@ -110,20 +121,18 @@ class Orc8rBase(Object):
         """
         Adds layer to pebble config if the proposed config is different from the current one
         """
-        self.charm.unit.status = MaintenanceStatus("Configuring pod")
-        pebble_layer = self._pebble_layer()
-        try:
+        if self._container.can_connect():
+            self.charm.unit.status = MaintenanceStatus("Configuring pod")
+            pebble_layer = self._pebble_layer()
             plan = self._container.get_plan()
             if plan.services != pebble_layer.services:
                 self._container.add_layer(self._container_name, pebble_layer, combine=True)
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted container {self._service_name}")
                 self.charm.unit.status = ActiveStatus()
-        except ConnectionError:
-            logger.error(
-                f"Could not restart {self._service_name} -- Pebble socket does "
-                f"not exist or is not responsive"
-            )
+        else:
+            self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
+            event.defer()
 
     def _pebble_layer(self) -> Layer:
         """Returns pebble layer for the charm."""
@@ -161,7 +170,6 @@ class Orc8rBase(Object):
         """Validates that database relation is ready (that there is a relation and that credentials
         have been passed)."""
         if not self._get_db_connection_string:
-            self.charm.unit.status = WaitingStatus("Waiting for db relation to be ready...")
             return False
         return True
 

--- a/orchestrator-bundle/orc8r-smsd-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orchestrator-bundle/orc8r-smsd-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -61,7 +61,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -97,9 +97,20 @@ class Orc8rBase(Object):
             self._db.on.database_relation_joined, self._on_database_relation_joined
         )
 
+    @property
+    def _db_relation_created(self) -> bool:
+        """Checks whether required relations are ready."""
+        if not self.model.get_relation("db"):
+            return False
+        return True
+
     def _on_magma_orc8r_pebble_ready(self, event):
+        if not self._db_relation_created:
+            self.charm.unit.status = BlockedStatus("Waiting for database relation to be created")
+            event.defer()
+            return
         if not self._db_relation_established():
-            self.charm.unit.status = BlockedStatus(
+            self.charm.unit.status = WaitingStatus(
                 "Waiting for database relation to be established..."
             )
             event.defer()
@@ -110,20 +121,18 @@ class Orc8rBase(Object):
         """
         Adds layer to pebble config if the proposed config is different from the current one
         """
-        self.charm.unit.status = MaintenanceStatus("Configuring pod")
-        pebble_layer = self._pebble_layer()
-        try:
+        if self._container.can_connect():
+            self.charm.unit.status = MaintenanceStatus("Configuring pod")
+            pebble_layer = self._pebble_layer()
             plan = self._container.get_plan()
             if plan.services != pebble_layer.services:
                 self._container.add_layer(self._container_name, pebble_layer, combine=True)
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted container {self._service_name}")
                 self.charm.unit.status = ActiveStatus()
-        except ConnectionError:
-            logger.error(
-                f"Could not restart {self._service_name} -- Pebble socket does "
-                f"not exist or is not responsive"
-            )
+        else:
+            self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
+            event.defer()
 
     def _pebble_layer(self) -> Layer:
         """Returns pebble layer for the charm."""
@@ -161,7 +170,6 @@ class Orc8rBase(Object):
         """Validates that database relation is ready (that there is a relation and that credentials
         have been passed)."""
         if not self._get_db_connection_string:
-            self.charm.unit.status = WaitingStatus("Waiting for db relation to be ready...")
             return False
         return True
 

--- a/orchestrator-bundle/orc8r-state-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orchestrator-bundle/orc8r-state-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -61,7 +61,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -97,9 +97,20 @@ class Orc8rBase(Object):
             self._db.on.database_relation_joined, self._on_database_relation_joined
         )
 
+    @property
+    def _db_relation_created(self) -> bool:
+        """Checks whether required relations are ready."""
+        if not self.model.get_relation("db"):
+            return False
+        return True
+
     def _on_magma_orc8r_pebble_ready(self, event):
+        if not self._db_relation_created:
+            self.charm.unit.status = BlockedStatus("Waiting for database relation to be created")
+            event.defer()
+            return
         if not self._db_relation_established():
-            self.charm.unit.status = BlockedStatus(
+            self.charm.unit.status = WaitingStatus(
                 "Waiting for database relation to be established..."
             )
             event.defer()
@@ -110,20 +121,18 @@ class Orc8rBase(Object):
         """
         Adds layer to pebble config if the proposed config is different from the current one
         """
-        self.charm.unit.status = MaintenanceStatus("Configuring pod")
-        pebble_layer = self._pebble_layer()
-        try:
+        if self._container.can_connect():
+            self.charm.unit.status = MaintenanceStatus("Configuring pod")
+            pebble_layer = self._pebble_layer()
             plan = self._container.get_plan()
             if plan.services != pebble_layer.services:
                 self._container.add_layer(self._container_name, pebble_layer, combine=True)
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted container {self._service_name}")
                 self.charm.unit.status = ActiveStatus()
-        except ConnectionError:
-            logger.error(
-                f"Could not restart {self._service_name} -- Pebble socket does "
-                f"not exist or is not responsive"
-            )
+        else:
+            self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
+            event.defer()
 
     def _pebble_layer(self) -> Layer:
         """Returns pebble layer for the charm."""
@@ -161,7 +170,6 @@ class Orc8rBase(Object):
         """Validates that database relation is ready (that there is a relation and that credentials
         have been passed)."""
         if not self._get_db_connection_string:
-            self.charm.unit.status = WaitingStatus("Waiting for db relation to be ready...")
             return False
         return True
 

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -61,7 +61,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -97,9 +97,20 @@ class Orc8rBase(Object):
             self._db.on.database_relation_joined, self._on_database_relation_joined
         )
 
+    @property
+    def _db_relation_created(self) -> bool:
+        """Checks whether required relations are ready."""
+        if not self.model.get_relation("db"):
+            return False
+        return True
+
     def _on_magma_orc8r_pebble_ready(self, event):
+        if not self._db_relation_created:
+            self.charm.unit.status = BlockedStatus("Waiting for database relation to be created")
+            event.defer()
+            return
         if not self._db_relation_established():
-            self.charm.unit.status = BlockedStatus(
+            self.charm.unit.status = WaitingStatus(
                 "Waiting for database relation to be established..."
             )
             event.defer()
@@ -110,20 +121,18 @@ class Orc8rBase(Object):
         """
         Adds layer to pebble config if the proposed config is different from the current one
         """
-        self.charm.unit.status = MaintenanceStatus("Configuring pod")
-        pebble_layer = self._pebble_layer()
-        try:
+        if self._container.can_connect():
+            self.charm.unit.status = MaintenanceStatus("Configuring pod")
+            pebble_layer = self._pebble_layer()
             plan = self._container.get_plan()
             if plan.services != pebble_layer.services:
                 self._container.add_layer(self._container_name, pebble_layer, combine=True)
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted container {self._service_name}")
                 self.charm.unit.status = ActiveStatus()
-        except ConnectionError:
-            logger.error(
-                f"Could not restart {self._service_name} -- Pebble socket does "
-                f"not exist or is not responsive"
-            )
+        else:
+            self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
+            event.defer()
 
     def _pebble_layer(self) -> Layer:
         """Returns pebble layer for the charm."""
@@ -161,7 +170,6 @@ class Orc8rBase(Object):
         """Validates that database relation is ready (that there is a relation and that credentials
         have been passed)."""
         if not self._get_db_connection_string:
-            self.charm.unit.status = WaitingStatus("Waiting for db relation to be ready...")
             return False
         return True
 

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -61,7 +61,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -97,9 +97,20 @@ class Orc8rBase(Object):
             self._db.on.database_relation_joined, self._on_database_relation_joined
         )
 
+    @property
+    def _db_relation_created(self) -> bool:
+        """Checks whether required relations are ready."""
+        if not self.model.get_relation("db"):
+            return False
+        return True
+
     def _on_magma_orc8r_pebble_ready(self, event):
+        if not self._db_relation_created:
+            self.charm.unit.status = BlockedStatus("Waiting for database relation to be created")
+            event.defer()
+            return
         if not self._db_relation_established():
-            self.charm.unit.status = BlockedStatus(
+            self.charm.unit.status = WaitingStatus(
                 "Waiting for database relation to be established..."
             )
             event.defer()
@@ -110,20 +121,18 @@ class Orc8rBase(Object):
         """
         Adds layer to pebble config if the proposed config is different from the current one
         """
-        self.charm.unit.status = MaintenanceStatus("Configuring pod")
-        pebble_layer = self._pebble_layer()
-        try:
+        if self._container.can_connect():
+            self.charm.unit.status = MaintenanceStatus("Configuring pod")
+            pebble_layer = self._pebble_layer()
             plan = self._container.get_plan()
             if plan.services != pebble_layer.services:
                 self._container.add_layer(self._container_name, pebble_layer, combine=True)
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted container {self._service_name}")
                 self.charm.unit.status = ActiveStatus()
-        except ConnectionError:
-            logger.error(
-                f"Could not restart {self._service_name} -- Pebble socket does "
-                f"not exist or is not responsive"
-            )
+        else:
+            self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
+            event.defer()
 
     def _pebble_layer(self) -> Layer:
         """Returns pebble layer for the charm."""
@@ -161,7 +170,6 @@ class Orc8rBase(Object):
         """Validates that database relation is ready (that there is a relation and that credentials
         have been passed)."""
         if not self._get_db_connection_string:
-            self.charm.unit.status = WaitingStatus("Waiting for db relation to be ready...")
             return False
         return True
 

--- a/orchestrator-bundle/orc8r-tenants-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orchestrator-bundle/orc8r-tenants-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -61,7 +61,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -97,9 +97,20 @@ class Orc8rBase(Object):
             self._db.on.database_relation_joined, self._on_database_relation_joined
         )
 
+    @property
+    def _db_relation_created(self) -> bool:
+        """Checks whether required relations are ready."""
+        if not self.model.get_relation("db"):
+            return False
+        return True
+
     def _on_magma_orc8r_pebble_ready(self, event):
+        if not self._db_relation_created:
+            self.charm.unit.status = BlockedStatus("Waiting for database relation to be created")
+            event.defer()
+            return
         if not self._db_relation_established():
-            self.charm.unit.status = BlockedStatus(
+            self.charm.unit.status = WaitingStatus(
                 "Waiting for database relation to be established..."
             )
             event.defer()
@@ -110,20 +121,18 @@ class Orc8rBase(Object):
         """
         Adds layer to pebble config if the proposed config is different from the current one
         """
-        self.charm.unit.status = MaintenanceStatus("Configuring pod")
-        pebble_layer = self._pebble_layer()
-        try:
+        if self._container.can_connect():
+            self.charm.unit.status = MaintenanceStatus("Configuring pod")
+            pebble_layer = self._pebble_layer()
             plan = self._container.get_plan()
             if plan.services != pebble_layer.services:
                 self._container.add_layer(self._container_name, pebble_layer, combine=True)
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted container {self._service_name}")
                 self.charm.unit.status = ActiveStatus()
-        except ConnectionError:
-            logger.error(
-                f"Could not restart {self._service_name} -- Pebble socket does "
-                f"not exist or is not responsive"
-            )
+        else:
+            self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
+            event.defer()
 
     def _pebble_layer(self) -> Layer:
         """Returns pebble layer for the charm."""
@@ -161,7 +170,6 @@ class Orc8rBase(Object):
         """Validates that database relation is ready (that there is a relation and that credentials
         have been passed)."""
         if not self._get_db_connection_string:
-            self.charm.unit.status = WaitingStatus("Waiting for db relation to be ready...")
             return False
         return True
 

--- a/orchestrator-bundle/update_libs.sh
+++ b/orchestrator-bundle/update_libs.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function fetch_orc8r_base_lib() {
+  charm="$1"
+    pushd "${charm}-operator/"
+    charmcraft fetch-lib charms.magma_orc8r_libs.v0.orc8r_base
+    popd
+}
+
+function fetch_orc8r_base_db_lib() {
+  charm="$1"
+    pushd "${charm}-operator/"
+    charmcraft fetch-lib charms.magma_orc8r_libs.v0.orc8r_base_db
+    popd
+}
+
+charms_using_orc8r_base_lib="
+orc8r-analytics
+orc8r-dispatcher
+orc8r-eventd
+orc8r-ha
+orc8r-metricsd
+orc8r-obsidian
+orc8r-service-registry
+orc8r-streamer
+"
+
+
+charms_using_orc8r_base_db_lib="
+orc8r-accessd
+orc8r-configurator
+orc8r-ctraced
+orc8r-device
+orc8r-directoryd
+orc8r-lte
+orc8r-policydb
+orc8r-smsd
+orc8r-state
+orc8r-subscriberdb-cache
+orc8r-subscriberdb
+orc8r-tenants
+"
+
+charms_using_no_base_lib="
+nms-magmalte
+nms-nginx-proxy
+orc8r-bootstrapper
+orc8r-certifier
+orc8r-nginx
+orc8r-orchestrator
+"
+
+for charm in ${charms_using_orc8r_base_lib}; do
+    fetch_orc8r_base_lib ${charm}
+done
+
+for charm in ${charms_using_orc8r_base_db_lib}; do
+    fetch_orc8r_base_db_lib ${charm}
+done
+
+wait


### PR DESCRIPTION
- Adds if `can_connect` condition around pebble socket action to catch connection errors.
- Only marks status as blocked when relations are not created. 
- Marks relations as Waiting when they are created but not yet fully established.