### PR TITLE
Adds config files to charms that require them

### DIFF
--- a/orchestrator-bundle/CONTRIBUTING.md
+++ b/orchestrator-bundle/CONTRIBUTING.md
@@ -119,5 +119,5 @@ charmcraft upload magma-orc8r.zip
 - Release the bundle to charmhub:
 
 ```bash
-charmcraft release magma-orc8r --revision=2 --channel=edge
+charmcraft release magma-orc8r --revision=<revision number> --channel=edge
 ```

--- a/orchestrator-bundle/bundle-local.yaml
+++ b/orchestrator-bundle/bundle-local.yaml
@@ -174,6 +174,11 @@ applications:
     channel: edge
     scale: 1
     trust: true
+  orc8r-user-grafana:
+    charm: grafana-k8s
+    channel: edge
+    scale: 1
+    trust: true
   prometheus-cache:
     charm: prometheus-edge-hub
     channel: edge
@@ -226,3 +231,5 @@ relations:
   - nms-magmalte:magmalte
 - - orc8r-prometheus
   - prometheus-cache
+- - orc8r-prometheus
+  - orc8r-user-grafana

--- a/orchestrator-bundle/bundle-local.yaml
+++ b/orchestrator-bundle/bundle-local.yaml
@@ -186,7 +186,7 @@ applications:
     channel: edge
     scale: 1
     trust: true
-  prometheus-cache:
+  orc8r-prometheus-cache:
     charm: prometheus-edge-hub
     channel: edge
     scale: 1
@@ -237,7 +237,7 @@ relations:
 - - nms-nginx-proxy:magmalte
   - nms-magmalte:magmalte
 - - orc8r-prometheus
-  - prometheus-cache
+  - orc8r-prometheus-cache
 - - orc8r-prometheus
   - orc8r-user-grafana
 - - orc8r-prometheus:alertmanager

--- a/orchestrator-bundle/bundle-local.yaml
+++ b/orchestrator-bundle/bundle-local.yaml
@@ -174,13 +174,10 @@ applications:
     channel: edge
     scale: 1
     trust: true
-  orc8r-prometheus-configurer:
-    charm: prometheus-configurer
-    channel: edge
-    scale: 1
-    trust: true
   orc8r-user-grafana:
     charm: grafana-k8s
+    options:
+      web_external_url: "/grafana"
     channel: edge
     scale: 1
     trust: true
@@ -245,5 +242,3 @@ relations:
   - orc8r-user-grafana
 - - orc8r-prometheus:alertmanager
   - orc8r-alertmanager:alerting
-- - orc8r-prometheus-configurer
-  - orc8r-prometheus

--- a/orchestrator-bundle/bundle-local.yaml
+++ b/orchestrator-bundle/bundle-local.yaml
@@ -174,8 +174,18 @@ applications:
     channel: edge
     scale: 1
     trust: true
+  orc8r-prometheus-configurer:
+    charm: prometheus-configurer
+    channel: edge
+    scale: 1
+    trust: true
   orc8r-user-grafana:
     charm: grafana-k8s
+    channel: edge
+    scale: 1
+    trust: true
+  orc8r-alertmanager:
+    charm: alertmanager-k8s
     channel: edge
     scale: 1
     trust: true
@@ -233,3 +243,7 @@ relations:
   - prometheus-cache
 - - orc8r-prometheus
   - orc8r-user-grafana
+- - orc8r-prometheus:alertmanager
+  - orc8r-alertmanager:alerting
+- - orc8r-prometheus-configurer
+  - orc8r-prometheus

--- a/orchestrator-bundle/documentation/how-to-guides/deploy_on_aws_charmed_kubernetes.md
+++ b/orchestrator-bundle/documentation/how-to-guides/deploy_on_aws_charmed_kubernetes.md
@@ -126,13 +126,11 @@ Create the Orchestrator admin user:
 juju run-action orc8r-orchestrator/0 create-orchestrator-admin-user
 ```
 
-Create an admin user for the master organization on the NMS:
+Get the master organization's username and password:
 
 ```bash
-juju run-action nms-magmalte/0 create-nms-admin-user email=<admin email> password=<admin password>
+juju run-action nms-magmalte/0 get-admin-credentials --wait
 ```
-
-Replace `<admin email>` and `<admin password>` with your email and password of choice.
 
 ## 6. Setup DNS
 

--- a/orchestrator-bundle/documentation/how-to-guides/deploy_on_aws_eks.md
+++ b/orchestrator-bundle/documentation/how-to-guides/deploy_on_aws_eks.md
@@ -67,13 +67,11 @@ Create the Orchestrator admin user:
 juju run-action orc8r-orchestrator/0 create-orchestrator-admin-user
 ```
 
-Create an admin user for the master organization on the NMS:
+Get the master organization's username and password:
 
 ```bash
-juju run-action nms-magmalte/0 create-nms-admin-user email=<admin email> password=<admin password>
+juju run-action nms-magmalte/0 get-admin-credentials --wait
 ```
-
-Replace `<admin email>` and `<admin password>` with your email and password of choice.
 
 ## 6. Setup DNS
 

--- a/orchestrator-bundle/documentation/how-to-guides/deploy_on_gcp_gke.md
+++ b/orchestrator-bundle/documentation/how-to-guides/deploy_on_gcp_gke.md
@@ -63,13 +63,11 @@ Create the Orchestrator admin user:
 juju run-action orc8r-orchestrator/0 create-orchestrator-admin-user
 ```
 
-Create an admin user for the master organization on the NMS:
+Get the master organization's username and password:
 
 ```bash
-juju run-action nms-magmalte/0 create-nms-admin-user email=<admin email> password=<admin password>
+juju run-action nms-magmalte/0 get-admin-credentials --wait
 ```
-
-Replace `<admin email>` and `<admin password>` with your email and password of choice.
 
 ## 6. Setup DNS
 
@@ -84,12 +82,11 @@ following services:
 Create these A records in your managed domain:
 
 | Hostname                                | Address                                |
-| --------------------------------------- | -------------------------------------- |
+|-----------------------------------------| -------------------------------------- |
 | `bootstrapper-controller.<your domain>` | `<orc8r-bootstrap-nginx External IP>`  |
 | `api.<your domain>`                     | `<orc8r-nginx-proxy External IP>`      |
 | `controller.<your domain>`              | `<orc8r-clientcert-nginx External IP>` |
-| `master.nms.<your domain>`              | `<nginx-proxy External IP>`            |
-| `magma-test.nms.<your domain>`          | `<nginx-proxy External IP>`            |
+| `*.nms.<your domain>`                   | `<nginx-proxy External IP>`            |
 
 > **_NOTE:_** For Google domains, navigate to Google Domains -> DNS -> Default Name Servers and
 > fill in the 4 A records.

--- a/orchestrator-bundle/documentation/how-to-guides/deploy_on_gcp_gke.md
+++ b/orchestrator-bundle/documentation/how-to-guides/deploy_on_gcp_gke.md
@@ -82,7 +82,7 @@ following services:
 Create these A records in your managed domain:
 
 | Hostname                                | Address                                |
-|-----------------------------------------| -------------------------------------- |
+|-----------------------------------------|----------------------------------------|
 | `bootstrapper-controller.<your domain>` | `<orc8r-bootstrap-nginx External IP>`  |
 | `api.<your domain>`                     | `<orc8r-nginx-proxy External IP>`      |
 | `controller.<your domain>`              | `<orc8r-clientcert-nginx External IP>` |

--- a/orchestrator-bundle/documentation/how-to-guides/deploy_on_microk8s.md
+++ b/orchestrator-bundle/documentation/how-to-guides/deploy_on_microk8s.md
@@ -60,6 +60,14 @@ applications:
 
 Replace `<your domain name>` with your domain name.
 
+Deploy orchestrator:
+
+```bash
+juju deploy magma-orc8r --overlay overlay.yaml --trust --channel=edge
+```
+
+The deployment is completed when all services are in the `Active-Idle` state.
+
 ## 4. Setup Orchestrator
 
 Create the Orchestrator admin user:
@@ -68,13 +76,11 @@ Create the Orchestrator admin user:
 juju run-action orc8r-orchestrator/0 create-orchestrator-admin-user
 ```
 
-Create an admin user for the master organization on the NMS:
+Get the master organization's username and password:
 
 ```bash
-juju run-action nms-magmalte/0 create-nms-admin-user email=<admin email> password=<admin password>
+juju run-action nms-magmalte/0 get-admin-credentials --wait
 ```
-
-Replace `<admin email>` and `<admin password>` with your email and password of choice.
 
 ## 5. Setup DNS
 
@@ -84,8 +90,7 @@ Add the following entries to your `/etc/hosts` file:
 <orc8r-bootstrap-nginx External IP>   bootstrapper-controller.<your domain>
 <orc8r-nginx-proxy External IP>       api.<your domain>
 <orc8r-clientcert-nginx External IP>  controller.<your domain>
-<nginx-proxy External IP>             master.nms.<your domain>
-<nginx-proxy External IP>             magma-test.nms.<your domain>
+<nginx-proxy External IP>             *.nms.<your domain>
 ```
 
 Here replace `<your domain>` with your actual domain name and `<xxx External IP>` with the external

--- a/orchestrator-bundle/nms-magmalte-operator/README.md
+++ b/orchestrator-bundle/nms-magmalte-operator/README.md
@@ -42,10 +42,10 @@ juju relate nms-magmalte postgresql-k8s:db
 
 ## Actions
 
-### Create an NMS Admin User
+### Get the master organization's username and password
 
 ```bash
-juju run-action nms-magmalte/0 create-nms-admin-user email=admin@example.com password=password123
+juju run-action nms-magmalte/0 get-admin-credentials --wait
 ```
 
 ## Relations

--- a/orchestrator-bundle/nms-magmalte-operator/actions.yaml
+++ b/orchestrator-bundle/nms-magmalte-operator/actions.yaml
@@ -15,6 +15,6 @@ create-nms-admin-user:
       description: password (ex. password123)
     organization:
       type: string
-      description: organization (ex. master)
+      description: organization (ex. org-1)
       default: master
   required: [email, password]

--- a/orchestrator-bundle/nms-magmalte-operator/actions.yaml
+++ b/orchestrator-bundle/nms-magmalte-operator/actions.yaml
@@ -1,6 +1,9 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+get-admin-credentials:
+  description: Returns the admin username and password for the master organization in NMS.
+
 create-nms-admin-user:
   description: Create an admin user in NMS.
   params:
@@ -10,4 +13,8 @@ create-nms-admin-user:
     password:
       type: string
       description: password (ex. password123)
+    organization:
+      type: string
+      description: organization (ex. master)
+      default: master
   required: [email, password]

--- a/orchestrator-bundle/nms-magmalte-operator/src/charm.py
+++ b/orchestrator-bundle/nms-magmalte-operator/src/charm.py
@@ -250,10 +250,9 @@ class MagmaNmsMagmalteCharm(CharmBase):
     def _relations_ready(self) -> bool:
         """Checks whether required relations are ready."""
         required_relations = ["certifier", "db"]
-        missing_relations = [
+        if missing_relations := [
             relation for relation in required_relations if not self.model.get_relation(relation)
-        ]
-        if missing_relations:
+        ]:
             self.unit.status = BlockedStatus(
                 f"Waiting for relation(s) to be created: {', '.join(missing_relations)}"
             )

--- a/orchestrator-bundle/nms-magmalte-operator/src/charm.py
+++ b/orchestrator-bundle/nms-magmalte-operator/src/charm.py
@@ -2,14 +2,14 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-# from datetime import datetime
-import time
 import logging
 import secrets
 import string
+import time
 from typing import List
 
 import ops.lib
+from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
 from lightkube import Client
 from lightkube.models.core_v1 import SecretVolumeSource, Volume, VolumeMount
 from lightkube.resources.apps_v1 import StatefulSet
@@ -19,8 +19,6 @@ from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import ExecError, Layer
 from pgconnstr import ConnectionString  # type: ignore[import]
-
-from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
 
 logger = logging.getLogger(__name__)
 pgsql = ops.lib.use("pgsql", 1, "postgresql-charmers@lists.launchpad.net")
@@ -181,7 +179,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
         self._create_nms_admin_user(
             email=event.params["email"],
             password=event.params["password"],
-            organization=event.params["organization"]
+            organization=event.params["organization"],
         )
 
     def _on_get_admin_credentials(self, event: ActionEvent) -> None:
@@ -252,9 +250,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
         """Checks whether required relations are ready."""
         required_relations = ["certifier", "db"]
         missing_relations = [
-            relation
-            for relation in required_relations
-            if not self.model.get_relation(relation)
+            relation for relation in required_relations if not self.model.get_relation(relation)
         ]
         if missing_relations:
             msg = f"Waiting for relation(s) to be created: {', '.join(missing_relations)}"

--- a/orchestrator-bundle/nms-magmalte-operator/src/charm.py
+++ b/orchestrator-bundle/nms-magmalte-operator/src/charm.py
@@ -179,7 +179,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
         self._create_nms_admin_user(
             email=event.params["email"],
             password=event.params["password"],
-            organization=event.params["organization"],
+            organization=event.params["organization"]
         )
 
     def _on_get_admin_credentials(self, event: ActionEvent) -> None:
@@ -250,7 +250,9 @@ class MagmaNmsMagmalteCharm(CharmBase):
         """Checks whether required relations are ready."""
         required_relations = ["certifier", "db"]
         missing_relations = [
-            relation for relation in required_relations if not self.model.get_relation(relation)
+            relation
+            for relation in required_relations
+            if not self.model.get_relation(relation)
         ]
         if missing_relations:
             msg = f"Waiting for relation(s) to be created: {', '.join(missing_relations)}"

--- a/orchestrator-bundle/orc8r-analytics-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-analytics-operator/metadata.yaml
@@ -12,9 +12,18 @@ summary: |
 containers:
   magma-orc8r-analytics:
     resource: magma-orc8r-analytics-image
+    mounts:
+      - storage: config
+        location: /var/opt/magma/configs/orc8r
 
 resources:
   magma-orc8r-analytics-image:
     type: oci-image
     description: OCI image for magma-orc8r-analytics (docker.artifactory.magmacore.org/controller:1.6.0)
     upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+
+storage:
+  config:
+    type: filesystem
+    description: Configs storage
+    minimum-size: 1M

--- a/orchestrator-bundle/orc8r-analytics-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-analytics-operator/src/charm.py
@@ -12,6 +12,12 @@ class MagmaOrc8rAnalyticsCharm(CharmBase):
 
     BASE_CONFIG_PATH = "/var/opt/magma/configs/orc8r"
 
+    # TODO: The various URL's should be provided through relationships.
+    PROMETHEUS_URL = "http://orc8r-prometheus:9090"
+    PROMETHEUS_CONFIGURER_URL = "http://orc8r-prometheus:9100"
+    ALERTMANAGER_URL = "http://orc8r-alertmanager:9093"
+    ALERTMANAGER_CONFIGURER_URL = "http://orc8r-alertmanager:9101"
+
     def __init__(self, *args):
         """
         An instance of this object everytime an event occurs
@@ -37,13 +43,12 @@ class MagmaOrc8rAnalyticsCharm(CharmBase):
 
     def _write_config_file(self):
         metricsd_config = (
-            'prometheusQueryAddress: "http://orc8r-prometheus:9090"\n'
-            'alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2"\n'
-            'prometheusConfigServiceURL: "http://orc8r-prometheus:9100/v1"\n'
-            'alertmanagerConfigServiceURL: "http://orc8r-alertmanager:9101/v1"\n'
+            f'prometheusQueryAddress: "{self.PROMETHEUS_URL}"\n'
+            f'alertmanagerApiURL: "{self.ALERTMANAGER_URL}/api/v2"\n'
+            f'prometheusConfigServiceURL: "{self.PROMETHEUS_CONFIGURER_URL}/v1"\n'
+            f'alertmanagerConfigServiceURL: "{self.ALERTMANAGER_CONFIGURER_URL}/v1"\n'
             '"profile": "prometheus"\n'
         )
-
         analytics_config = (
             '"appID": ""\n'
             '"appSecret": ""\n'

--- a/orchestrator-bundle/orc8r-analytics-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-analytics-operator/src/charm.py
@@ -53,7 +53,9 @@ class MagmaOrc8rAnalyticsCharm(CharmBase):
             '"metricsPrefix": ""\n'
         )
         self._orc8r_base._container.push(f"{self.BASE_CONFIG_PATH}/metricsd.yml", metricsd_config)
-        self._orc8r_base._container.push(f"{self.BASE_CONFIG_PATH}/analytics.yml", analytics_config)
+        self._orc8r_base._container.push(
+            f"{self.BASE_CONFIG_PATH}/analytics.yml", analytics_config
+        )
 
 
 if __name__ == "__main__":

--- a/orchestrator-bundle/orc8r-analytics-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-analytics-operator/tests/unit/test_charm.py
@@ -2,6 +2,49 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import unittest
+from unittest.mock import Mock, call, patch
 
-def test_placeholder():
-    pass
+from ops import testing
+
+from charm import MagmaOrc8rAnalyticsCharm
+
+testing.SIMULATE_CAN_CONNECT = True
+
+
+class Test(unittest.TestCase):
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda charm, ports, additional_labels: None,
+    )
+    def setUp(self):
+        self.harness = testing.Harness(MagmaOrc8rAnalyticsCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
+    @patch("ops.model.Container.push")
+    def test_given_new_charm_when_on_install_event_then_config_files_are_created(self, patch_push):
+        event = Mock()
+
+        self.harness.charm._on_install(event)
+
+        calls = [
+            call(
+                "/var/opt/magma/configs/orc8r/metricsd.yml",
+                'prometheusQueryAddress: "http://orc8r-prometheus:9090"\n'
+                'alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2"\n'
+                'prometheusConfigServiceURL: "http://orc8r-prometheus:9100/v1"\n'
+                'alertmanagerConfigServiceURL: "http://orc8r-alertmanager:9101/v1"\n'
+                '"profile": "prometheus"\n',
+            ),
+            call(
+                "/var/opt/magma/configs/orc8r/analytics.yml",
+                '"appID": ""\n'
+                '"appSecret": ""\n'
+                '"categoryName": "magma"\n'
+                '"exportMetrics": false\n'
+                '"metricExportURL": ""\n'
+                '"metricsPrefix": ""\n',
+            ),
+        ]
+        patch_push.assert_has_calls(calls)

--- a/orchestrator-bundle/orc8r-bundle/bundle.yaml
+++ b/orchestrator-bundle/orc8r-bundle/bundle.yaml
@@ -148,6 +148,11 @@ applications:
     channel: edge
     scale: 1
     trust: true
+  orc8r-user-grafana:
+    charm: grafana-k8s
+    channel: edge
+    scale: 1
+    trust: true
   prometheus-cache:
     charm: prometheus-edge-hub
     channel: edge
@@ -200,3 +205,5 @@ relations:
   - nms-magmalte:magmalte
 - - orc8r-prometheus
   - prometheus-cache
+- - orc8r-prometheus
+  - orc8r-user-grafana

--- a/orchestrator-bundle/orc8r-bundle/bundle.yaml
+++ b/orchestrator-bundle/orc8r-bundle/bundle.yaml
@@ -151,9 +151,16 @@ applications:
   orc8r-user-grafana:
     charm: grafana-k8s
     channel: edge
+    options:
+      web_external_url: "/grafana"
     scale: 1
     trust: true
-  prometheus-cache:
+  orc8r-alertmanager:
+    charm: alertmanager-k8s
+    channel: edge
+    scale: 1
+    trust: true
+  orc8r-prometheus-cache:
     charm: prometheus-edge-hub
     channel: edge
     scale: 1
@@ -204,6 +211,8 @@ relations:
 - - nms-nginx-proxy:magmalte
   - nms-magmalte:magmalte
 - - orc8r-prometheus
-  - prometheus-cache
+  - orc8r-prometheus-cache
 - - orc8r-prometheus
   - orc8r-user-grafana
+- - orc8r-prometheus:alertmanager
+  - orc8r-alertmanager:alerting

--- a/orchestrator-bundle/orc8r-certifier-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-certifier-operator/metadata.yaml
@@ -15,6 +15,8 @@ containers:
     mounts:
       - storage: certs
         location: /tmp/certs
+      - storage: config
+        location: /var/opt/magma/configs/orc8r
 
 resources:
   magma-orc8r-certifier-image:
@@ -28,6 +30,10 @@ storage:
     description: Temp certs storage
     minimum-size: 1M
     location: /tmp/certs
+  config:
+    type: filesystem
+    description: Configs storage
+    minimum-size: 1M
 
 provides:
   certifier:

--- a/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
@@ -74,9 +74,9 @@ class MagmaOrc8rCertifierCharm(CharmBase):
     def _on_install(self, event):
         """Runs each time the charm is installed."""
         if self._container.can_connect():
+            self._write_config_file()
             self._create_magma_orc8r_secrets()
             self._mount_certifier_certs()
-            self._write_config_file()
         else:
             self.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
@@ -36,6 +36,12 @@ class MagmaOrc8rCertifierCharm(CharmBase):
     DB_NAME = "magma_dev"
     BASE_CONFIG_PATH = "/var/opt/magma/configs/orc8r"
 
+    # TODO: The various URL's should be provided through relationships.
+    PROMETHEUS_URL = "http://orc8r-prometheus:9090"
+    PROMETHEUS_CONFIGURER_URL = "http://orc8r-prometheus:9100"
+    ALERTMANAGER_URL = "http://orc8r-alertmanager:9093"
+    ALERTMANAGER_CONFIGURER_URL = "http://orc8r-alertmanager:9101"
+
     def __init__(self, *args):
         """An instance of this object everytime an event occurs."""
         super().__init__(*args)
@@ -63,10 +69,10 @@ class MagmaOrc8rCertifierCharm(CharmBase):
 
     def _write_config_file(self):
         metricsd_config = (
-            'prometheusQueryAddress: "http://orc8r-prometheus:9090"\n'
-            'alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2"\n'
-            'prometheusConfigServiceURL: "http://orc8r-prometheus:9100/v1"\n'
-            'alertmanagerConfigServiceURL: "http://orc8r-alertmanager:9101/v1"\n'
+            f'prometheusQueryAddress: "{self.PROMETHEUS_URL}"\n'
+            f'alertmanagerApiURL: "{self.ALERTMANAGER_URL}/api/v2"\n'
+            f'prometheusConfigServiceURL: "{self.PROMETHEUS_CONFIGURER_URL}/v1"\n'
+            f'alertmanagerConfigServiceURL: "{self.ALERTMANAGER_CONFIGURER_URL}/v1"\n'
             '"profile": "prometheus"\n'
         )
         self._container.push(f"{self.BASE_CONFIG_PATH}/metricsd.yml", metricsd_config)

--- a/orchestrator-bundle/orc8r-lte-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-lte-operator/metadata.yaml
@@ -14,6 +14,9 @@ summary: |
 containers:
   magma-orc8r-lte:
     resource: magma-orc8r-lte-image
+    mounts:
+      - storage: config
+        location: /var/opt/magma/configs/orc8r
 
 resources:
   magma-orc8r-lte-image:
@@ -24,3 +27,9 @@ resources:
 requires:
   db:
     interface: pgsql
+
+storage:
+  config:
+    type: filesystem
+    description: Configs storage
+    minimum-size: 1M

--- a/orchestrator-bundle/orc8r-lte-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-lte-operator/src/charm.py
@@ -70,7 +70,9 @@ class MagmaOrc8rLteCharm(CharmBase):
             '"metricsPrefix": ""\n'
         )
         self._orc8r_base._container.push(f"{self.BASE_CONFIG_PATH}/metricsd.yml", metricsd_config)
-        self._orc8r_base._container.push(f"{self.BASE_CONFIG_PATH}/analytics.yml", analytics_config)
+        self._orc8r_base._container.push(
+            f"{self.BASE_CONFIG_PATH}/analytics.yml", analytics_config
+        )
 
 
 if __name__ == "__main__":

--- a/orchestrator-bundle/orc8r-lte-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-lte-operator/src/charm.py
@@ -9,7 +9,14 @@ from ops.main import main
 
 
 class MagmaOrc8rLteCharm(CharmBase):
+
     BASE_CONFIG_PATH = "/var/opt/magma/configs/orc8r"
+
+    # TODO: The various URL's should be provided through relationships.
+    PROMETHEUS_URL = "http://orc8r-prometheus:9090"
+    PROMETHEUS_CONFIGURER_URL = "http://orc8r-prometheus:9100"
+    ALERTMANAGER_URL = "http://orc8r-alertmanager:9093"
+    ALERTMANAGER_CONFIGURER_URL = "http://orc8r-alertmanager:9101"
 
     def __init__(self, *args):
         """Creates a new instance of this object for each event."""
@@ -55,10 +62,10 @@ class MagmaOrc8rLteCharm(CharmBase):
 
     def _write_config_file(self):
         metricsd_config = (
-            'prometheusQueryAddress: "http://orc8r-prometheus:9090"\n'
-            'alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2"\n'
-            'prometheusConfigServiceURL: "http://orc8r-prometheus:9100/v1"\n'
-            'alertmanagerConfigServiceURL: "http://orc8r-alertmanager:9101/v1"\n'
+            f'prometheusQueryAddress: "{self.PROMETHEUS_URL}"\n'
+            f'alertmanagerApiURL: "{self.ALERTMANAGER_URL}/api/v2"\n'
+            f'prometheusConfigServiceURL: "{self.PROMETHEUS_CONFIGURER_URL}/v1"\n'
+            f'alertmanagerConfigServiceURL: "{self.ALERTMANAGER_CONFIGURER_URL}/v1"\n'
             '"profile": "prometheus"\n'
         )
         analytics_config = (

--- a/orchestrator-bundle/orc8r-lte-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-lte-operator/src/charm.py
@@ -9,6 +9,8 @@ from ops.main import main
 
 
 class MagmaOrc8rLteCharm(CharmBase):
+    BASE_CONFIG_PATH = "/var/opt/magma/configs/orc8r"
+
     def __init__(self, *args):
         """Creates a new instance of this object for each event."""
         super().__init__(*args)
@@ -46,6 +48,29 @@ class MagmaOrc8rLteCharm(CharmBase):
             "-v=0"
         )
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
+        self.framework.observe(self.on.install, self._on_install)
+
+    def _on_install(self, event):
+        self._write_config_file()
+
+    def _write_config_file(self):
+        metricsd_config = (
+            'prometheusQueryAddress: "http://orc8r-prometheus:9090"\n'
+            'alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2"\n'
+            'prometheusConfigServiceURL: "http://orc8r-prometheus:9100/v1"\n'
+            'alertmanagerConfigServiceURL: "http://orc8r-alertmanager:9101/v1"\n'
+            '"profile": "prometheus"\n'
+        )
+        analytics_config = (
+            '"appID": ""\n'
+            '"appSecret": ""\n'
+            '"categoryName": "magma"\n'
+            '"exportMetrics": false\n'
+            '"metricExportURL": ""\n'
+            '"metricsPrefix": ""\n'
+        )
+        self._orc8r_base._container.push(f"{self.BASE_CONFIG_PATH}/metricsd.yml", metricsd_config)
+        self._orc8r_base._container.push(f"{self.BASE_CONFIG_PATH}/analytics.yml", analytics_config)
 
 
 if __name__ == "__main__":

--- a/orchestrator-bundle/orc8r-lte-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-lte-operator/tests/unit/test_charm.py
@@ -2,6 +2,47 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import unittest
+from unittest.mock import Mock, call, patch
 
-def test_placeholder():
-    pass
+from ops.testing import Harness
+
+from charm import MagmaOrc8rLteCharm
+
+
+class Test(unittest.TestCase):
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda charm, ports, additional_labels, additional_annotations: None,
+    )
+    def setUp(self):
+        self.harness = Harness(MagmaOrc8rLteCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
+    @patch("ops.model.Container.push")
+    def test_given_new_charm_when_on_install_event_then_config_files_are_created(self, patch_push):
+        event = Mock()
+
+        self.harness.charm._on_install(event)
+
+        calls = [
+            call(
+                "/var/opt/magma/configs/orc8r/metricsd.yml",
+                'prometheusQueryAddress: "http://orc8r-prometheus:9090"\n'
+                'alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2"\n'
+                'prometheusConfigServiceURL: "http://orc8r-prometheus:9100/v1"\n'
+                'alertmanagerConfigServiceURL: "http://orc8r-alertmanager:9101/v1"\n'
+                '"profile": "prometheus"\n',
+            ),
+            call(
+                "/var/opt/magma/configs/orc8r/analytics.yml",
+                '"appID": ""\n'
+                '"appSecret": ""\n'
+                '"categoryName": "magma"\n'
+                '"exportMetrics": false\n'
+                '"metricExportURL": ""\n'
+                '"metricsPrefix": ""\n',
+            ),
+        ]
+        patch_push.assert_has_calls(calls)

--- a/orchestrator-bundle/orc8r-lte-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-lte-operator/tests/unit/test_charm.py
@@ -5,9 +5,11 @@
 import unittest
 from unittest.mock import Mock, call, patch
 
-from ops.testing import Harness
+from ops import testing
 
 from charm import MagmaOrc8rLteCharm
+
+testing.SIMULATE_CAN_CONNECT = True
 
 
 class Test(unittest.TestCase):
@@ -16,7 +18,7 @@ class Test(unittest.TestCase):
         lambda charm, ports, additional_labels, additional_annotations: None,
     )
     def setUp(self):
-        self.harness = Harness(MagmaOrc8rLteCharm)
+        self.harness = testing.Harness(MagmaOrc8rLteCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 

--- a/orchestrator-bundle/orc8r-metricsd-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-metricsd-operator/metadata.yaml
@@ -10,9 +10,18 @@ summary: |
 containers:
   magma-orc8r-metricsd:
     resource: magma-orc8r-metricsd-image
+    mounts:
+      - storage: config
+        location: /var/opt/magma/configs/orc8r
 
 resources:
   magma-orc8r-metricsd-image:
     type: oci-image
     description: OCI image for magma-orc8r-metricsd (docker.artifactory.magmacore.org/controller:1.6.0)
     upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+
+storage:
+  config:
+    type: filesystem
+    description: Configs storage
+    minimum-size: 1M

--- a/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
@@ -5,11 +5,10 @@
 import base64
 import logging
 
-from ops.charm import CharmBase
-from ops.main import main
-
 from charms.magma_orc8r_libs.v0.orc8r_base import Orc8rBase
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
+from ops.charm import CharmBase
+from ops.main import main
 
 logger = logging.getLogger(__name__)
 

--- a/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
@@ -2,7 +2,6 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import base64
 import logging
 
 from charms.magma_orc8r_libs.v0.orc8r_base import Orc8rBase
@@ -15,8 +14,6 @@ logger = logging.getLogger(__name__)
 
 class MagmaOrc8rMetricsdCharm(CharmBase):
 
-    METRICSD_SECRET_NAME = "metricsd-config"
-    METRICSD_VOLUME_NAME = "metricsd-config-volume"
     BASE_CONFIG_PATH = "/var/opt/magma/configs/orc8r"
 
     def __init__(self, *args):
@@ -24,8 +21,6 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
         An instance of this object everytime an event occurs
         """
         super().__init__(*args)
-        self._container_name = self._service_name = "magma-orc8r-metricsd"
-        self._container = self.unit.get_container(self._container_name)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
             ports=[("grpc", 9180, 9084), ("http", 8080, 10084)],
@@ -64,12 +59,7 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
             'alertmanagerConfigServiceURL: "http://orc8r-alertmanager:9101/v1"\n'
             '"profile": "prometheus"\n'
         )
-        self._container.push(f"{self.BASE_CONFIG_PATH}/metricsd.yml", metricsd_config)
-
-    @staticmethod
-    def _encode_in_base64(byte_string: bytes):
-        """Encodes given byte string in Base64"""
-        return base64.b64encode(byte_string).decode("utf-8")
+        self._orc8r_base._container.push(f"{self.BASE_CONFIG_PATH}/metricsd.yml", metricsd_config)
 
     @property
     def _namespace(self) -> str:

--- a/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
@@ -16,6 +16,12 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
 
     BASE_CONFIG_PATH = "/var/opt/magma/configs/orc8r"
 
+    # TODO: The various URL's should be provided through relationships.
+    PROMETHEUS_URL = "http://orc8r-prometheus:9090"
+    PROMETHEUS_CONFIGURER_URL = "http://orc8r-prometheus:9100"
+    ALERTMANAGER_URL = "http://orc8r-alertmanager:9093"
+    ALERTMANAGER_CONFIGURER_URL = "http://orc8r-alertmanager:9101"
+
     def __init__(self, *args):
         """
         An instance of this object everytime an event occurs
@@ -53,10 +59,10 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
 
     def _write_config_file(self):
         metricsd_config = (
-            'prometheusQueryAddress: "http://orc8r-prometheus:9090"\n'
-            'alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2"\n'
-            'prometheusConfigServiceURL: "http://orc8r-prometheus:9100/v1"\n'
-            'alertmanagerConfigServiceURL: "http://orc8r-alertmanager:9101/v1"\n'
+            f'prometheusQueryAddress: "{self.PROMETHEUS_URL}"\n'
+            f'alertmanagerApiURL: "{self.ALERTMANAGER_URL}/api/v2"\n'
+            f'prometheusConfigServiceURL: "{self.PROMETHEUS_CONFIGURER_URL}/v1"\n'
+            f'alertmanagerConfigServiceURL: "{self.ALERTMANAGER_CONFIGURER_URL}/v1"\n'
             '"profile": "prometheus"\n'
         )
         self._orc8r_base._container.push(f"{self.BASE_CONFIG_PATH}/metricsd.yml", metricsd_config)

--- a/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
@@ -2,19 +2,37 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import base64
+import logging
+from typing import List
 
 from charms.magma_orc8r_libs.v0.orc8r_base import Orc8rBase
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
+from lightkube import Client
+from lightkube.core.exceptions import ApiError
+from lightkube.models.core_v1 import SecretVolumeSource, Volume, VolumeMount
+from lightkube.models.meta_v1 import ObjectMeta
+from lightkube.resources.apps_v1 import StatefulSet
+from lightkube.resources.core_v1 import Secret
 from ops.charm import CharmBase
 from ops.main import main
+from ops.model import MaintenanceStatus, WaitingStatus
+
+logger = logging.getLogger(__name__)
 
 
 class MagmaOrc8rMetricsdCharm(CharmBase):
+
+    METRICSD_SECRET_NAME = "metricsd-config"
+    METRICSD_VOLUME_NAME = "metricsd-config-volume"
+
     def __init__(self, *args):
         """
         An instance of this object everytime an event occurs
         """
         super().__init__(*args)
+        self._container_name = self._service_name = "magma-orc8r-metricsd"
+        self._container = self.unit.get_container(self._container_name)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
             ports=[("grpc", 9180, 9084), ("http", 8080, 10084)],
@@ -40,6 +58,80 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
             "-v=0"
         )
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
+        self.framework.observe(self.on.install, self._on_install)
+
+    def _on_install(self, event):
+        if self._container.can_connect():
+            self._create_secret()
+            self._mount_metricsd_volume()
+        else:
+            self.unit.status = WaitingStatus("Waiting for container to be ready...")
+            event.defer()
+            return
+
+    def _create_secret(self):
+        self.unit.status = MaintenanceStatus("Creating metricsd secret")
+        client = Client()
+        secret_data = {
+            "metricsd.yml": self._encode_in_base64(open("src/metricsd.yml", "rb").read())
+        }
+        metadata = ObjectMeta(
+            namespace=self._namespace,
+            name=self.METRICSD_SECRET_NAME,
+        )
+        secret = Secret(metadata=metadata, data=secret_data)
+        try:
+            client.create(secret)
+        except ApiError as e:
+            logger.info("Failed to create Secret: %s.", str(secret.to_dict()))
+            raise e
+
+    @property
+    def _metricsd_volumes(self) -> List[Volume]:
+        """Returns a list of volumes required by metricsd"""
+        return [
+            Volume(
+                name=self.METRICSD_VOLUME_NAME,
+                secret=SecretVolumeSource(secretName=self.METRICSD_SECRET_NAME),
+            )
+        ]
+
+    @property
+    def _metricsd_volume_mounts(self) -> List[VolumeMount]:
+        """Returns a list of volume mounts required by metricsd"""
+        return [
+            VolumeMount(
+                mountPath="/var/opt/magma/configs/orc8r",
+                name=self.METRICSD_VOLUME_NAME,
+            )
+        ]
+
+    def _mount_metricsd_volume(self) -> None:
+        """Patch the StatefulSet to include volume mounts"""
+        self.unit.status = MaintenanceStatus("Mounting additional volumes required by metricsd...")
+        client = Client()
+        try:
+            stateful_set = client.get(StatefulSet, name=self.app.name, namespace=self._namespace)
+            stateful_set.spec.template.spec.volumes.extend(self._metricsd_volumes)  # type: ignore[attr-defined]  # noqa: E501
+            stateful_set.spec.template.spec.containers[1].volumeMounts.extend(  # type: ignore[attr-defined]  # noqa: E501
+                self._metricsd_volume_mounts
+            )
+            client.patch(
+                StatefulSet, name=self.app.name, obj=stateful_set, namespace=self._namespace
+            )
+        except ApiError as e:
+            logger.debug("Failed to mount additional volumes required by metricsd")
+            raise e
+        logger.info("Additional K8s resources for magma-nms-nginx-proxy container applied!")
+
+    @staticmethod
+    def _encode_in_base64(byte_string: bytes):
+        """Encodes given byte string in Base64"""
+        return base64.b64encode(byte_string).decode("utf-8")
+
+    @property
+    def _namespace(self) -> str:
+        return self.model.name
 
 
 if __name__ == "__main__":

--- a/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
@@ -4,19 +4,12 @@
 
 import base64
 import logging
-from typing import List
+
+from ops.charm import CharmBase
+from ops.main import main
 
 from charms.magma_orc8r_libs.v0.orc8r_base import Orc8rBase
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
-from lightkube import Client
-from lightkube.core.exceptions import ApiError
-from lightkube.models.core_v1 import SecretVolumeSource, Volume, VolumeMount
-from lightkube.models.meta_v1 import ObjectMeta
-from lightkube.resources.apps_v1 import StatefulSet
-from lightkube.resources.core_v1 import Secret
-from ops.charm import CharmBase
-from ops.main import main
-from ops.model import MaintenanceStatus, WaitingStatus
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +18,7 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
 
     METRICSD_SECRET_NAME = "metricsd-config"
     METRICSD_VOLUME_NAME = "metricsd-config-volume"
+    BASE_CONFIG_PATH = "/var/opt/magma/configs/orc8r"
 
     def __init__(self, *args):
         """
@@ -61,68 +55,17 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
         self.framework.observe(self.on.install, self._on_install)
 
     def _on_install(self, event):
-        if self._container.can_connect():
-            self._create_secret()
-            self._mount_metricsd_volume()
-        else:
-            self.unit.status = WaitingStatus("Waiting for container to be ready...")
-            event.defer()
-            return
+        self._write_config_file()
 
-    def _create_secret(self):
-        self.unit.status = MaintenanceStatus("Creating metricsd secret")
-        client = Client()
-        secret_data = {
-            "metricsd.yml": self._encode_in_base64(open("src/metricsd.yml", "rb").read())
-        }
-        metadata = ObjectMeta(
-            namespace=self._namespace,
-            name=self.METRICSD_SECRET_NAME,
+    def _write_config_file(self):
+        metricsd_config = (
+            'prometheusQueryAddress: "http://orc8r-prometheus:9090"\n'
+            'alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2"\n'
+            'prometheusConfigServiceURL: "http://orc8r-prometheus:9100/v1"\n'
+            'alertmanagerConfigServiceURL: "http://orc8r-alertmanager:9101/v1"\n'
+            '"profile": "prometheus"\n'
         )
-        secret = Secret(metadata=metadata, data=secret_data)
-        try:
-            client.create(secret)
-        except ApiError as e:
-            logger.info("Failed to create Secret: %s.", str(secret.to_dict()))
-            raise e
-
-    @property
-    def _metricsd_volumes(self) -> List[Volume]:
-        """Returns a list of volumes required by metricsd"""
-        return [
-            Volume(
-                name=self.METRICSD_VOLUME_NAME,
-                secret=SecretVolumeSource(secretName=self.METRICSD_SECRET_NAME),
-            )
-        ]
-
-    @property
-    def _metricsd_volume_mounts(self) -> List[VolumeMount]:
-        """Returns a list of volume mounts required by metricsd"""
-        return [
-            VolumeMount(
-                mountPath="/var/opt/magma/configs/orc8r",
-                name=self.METRICSD_VOLUME_NAME,
-            )
-        ]
-
-    def _mount_metricsd_volume(self) -> None:
-        """Patch the StatefulSet to include volume mounts"""
-        self.unit.status = MaintenanceStatus("Mounting additional volumes required by metricsd...")
-        client = Client()
-        try:
-            stateful_set = client.get(StatefulSet, name=self.app.name, namespace=self._namespace)
-            stateful_set.spec.template.spec.volumes.extend(self._metricsd_volumes)  # type: ignore[attr-defined]  # noqa: E501
-            stateful_set.spec.template.spec.containers[1].volumeMounts.extend(  # type: ignore[attr-defined]  # noqa: E501
-                self._metricsd_volume_mounts
-            )
-            client.patch(
-                StatefulSet, name=self.app.name, obj=stateful_set, namespace=self._namespace
-            )
-        except ApiError as e:
-            logger.debug("Failed to mount additional volumes required by metricsd")
-            raise e
-        logger.info("Additional K8s resources for magma-nms-nginx-proxy container applied!")
+        self._container.push(f"{self.BASE_CONFIG_PATH}/metricsd.yml", metricsd_config)
 
     @staticmethod
     def _encode_in_base64(byte_string: bytes):

--- a/orchestrator-bundle/orc8r-metricsd-operator/src/metricsd.yml
+++ b/orchestrator-bundle/orc8r-metricsd-operator/src/metricsd.yml
@@ -1,0 +1,6 @@
+---
+prometheusQueryAddress: "http://prometheus:9090"
+alertmanagerApiURL: "http://alertmanager:9093/api/v2"
+prometheusConfigServiceURL: "http://prometheus-configurer:9100/v1"
+alertmanagerConfigServiceURL: "http://alertmanager-configurer:9101/v1"
+useSeriesCache: true

--- a/orchestrator-bundle/orc8r-metricsd-operator/src/metricsd.yml
+++ b/orchestrator-bundle/orc8r-metricsd-operator/src/metricsd.yml
@@ -1,6 +1,0 @@
----
-prometheusQueryAddress: "http://prometheus:9090"
-alertmanagerApiURL: "http://alertmanager:9093/api/v2"
-prometheusConfigServiceURL: "http://prometheus-configurer:9100/v1"
-alertmanagerConfigServiceURL: "http://alertmanager-configurer:9101/v1"
-useSeriesCache: true

--- a/orchestrator-bundle/orc8r-metricsd-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tests/unit/test_charm.py
@@ -31,9 +31,7 @@ class TestCharm(unittest.TestCase):
         self.maxDiff = None
 
     @patch("ops.model.Container.push")
-    def test_given_new_charm_when_on_install_event_then_config_file_is_created(
-        self, patch_push
-    ):
+    def test_given_new_charm_when_on_install_event_then_config_file_is_created(self, patch_push):
         event = Mock()
 
         self.harness.charm._on_install(event)

--- a/orchestrator-bundle/orc8r-metricsd-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tests/unit/test_charm.py
@@ -5,9 +5,11 @@
 import unittest
 from unittest.mock import Mock, call, patch
 
-from ops.testing import Harness
+from ops import testing
 
 from charm import MagmaOrc8rMetricsdCharm
+
+testing.SIMULATE_CAN_CONNECT = True
 
 
 class MockModel:
@@ -25,7 +27,7 @@ class TestCharm(unittest.TestCase):
         lambda charm, ports, additional_labels, additional_annotations: None,
     )
     def setUp(self):
-        self.harness = Harness(MagmaOrc8rMetricsdCharm)
+        self.harness = testing.Harness(MagmaOrc8rMetricsdCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
         self.maxDiff = None

--- a/orchestrator-bundle/orc8r-metricsd-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tests/unit/test_charm.py
@@ -3,7 +3,7 @@
 # See LICENSE file for licensing details.
 
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 from ops.testing import Harness
 
@@ -36,13 +36,14 @@ class TestCharm(unittest.TestCase):
 
         self.harness.charm._on_install(event)
 
-        args, kwargs = patch_push.call_args
-
-        assert args[0] == "/var/opt/magma/configs/orc8r/metricsd.yml"
-        assert args[1] == (
-            'prometheusQueryAddress: "http://orc8r-prometheus:9090"\n'
-            'alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2"\n'
-            'prometheusConfigServiceURL: "http://orc8r-prometheus:9100/v1"\n'
-            'alertmanagerConfigServiceURL: "http://orc8r-alertmanager:9101/v1"\n'
-            '"profile": "prometheus"\n'
-        )
+        calls = [
+            call(
+                "/var/opt/magma/configs/orc8r/metricsd.yml",
+                'prometheusQueryAddress: "http://orc8r-prometheus:9090"\n'
+                'alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2"\n'
+                'prometheusConfigServiceURL: "http://orc8r-prometheus:9100/v1"\n'
+                'alertmanagerConfigServiceURL: "http://orc8r-alertmanager:9101/v1"\n'
+                '"profile": "prometheus"\n',
+            ),
+        ]
+        patch_push.assert_has_calls(calls)

--- a/orchestrator-bundle/orc8r-metricsd-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tests/unit/test_charm.py
@@ -2,6 +2,125 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import base64
+import unittest
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
-def test_placeholder():
-    pass
+from lightkube.models.apps_v1 import StatefulSetSpec
+from lightkube.models.core_v1 import Container, PodSpec, PodTemplateSpec
+from lightkube.models.meta_v1 import LabelSelector
+from lightkube.resources.apps_v1 import StatefulSet
+from ops.testing import Harness
+
+from charm import MagmaOrc8rMetricsdCharm
+
+
+class MockModel:
+    def __init__(self, name: str):
+        self._name = name
+
+    @property
+    def name(self):
+        return self._name
+
+
+class TestCharm(unittest.TestCase):
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda charm, ports, additional_labels, additional_annotations: None,
+    )
+    def setUp(self):
+        self.harness = Harness(MagmaOrc8rMetricsdCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+        self.maxDiff = None
+
+    @patch("lightkube.core.client.GenericSyncClient", MagicMock)
+    @patch("lightkube.Client.create")
+    @patch("charm.MagmaOrc8rMetricsdCharm.model", new_callable=PropertyMock)
+    def test_given_new_charm_when_on_install_event_then_secret_is_created(
+        self, patch_model, patch_create
+    ):
+        event = Mock()
+        namespace = "whatever namespace"
+        patch_model.return_value = MockModel(namespace)
+
+        self.harness.charm._on_install(event)
+
+        args, kwargs = patch_create.call_args
+        expected_secret_data = {
+            "metricsd.yml": base64.b64encode(open("src/metricsd.yml", "rb").read()).decode("utf-8")
+        }
+        secret = args[0]
+        assert secret.data == expected_secret_data
+        assert secret.metadata.name == "metricsd-config"
+        assert secret.metadata.namespace == namespace
+
+    @patch("lightkube.core.client.GenericSyncClient", Mock)
+    @patch("lightkube.Client.patch")
+    @patch("lightkube.Client.get")
+    @patch("charm.MagmaOrc8rMetricsdCharm.model", new_callable=PropertyMock)
+    def test_given_new_charm_when_on_install_event_then_volume_is_added_to_statefulset(
+        self, patch_model, patch_get, patch_patch
+    ):
+        event = Mock()
+        namespace = "whatever namespace"
+        patch_get.return_value = StatefulSet(
+            spec=StatefulSetSpec(
+                serviceName="whatever",
+                selector=LabelSelector(),
+                template=PodTemplateSpec(
+                    spec=PodSpec(
+                        containers=[
+                            Container(name="charm"),
+                            Container(name="workload", volumeMounts=[]),
+                        ],
+                        volumes=[],
+                    )
+                ),
+            )
+        )
+        patch_model.return_value = MockModel(namespace)
+
+        self.harness.charm._on_install(event)
+
+        args, kwargs = patch_patch.call_args
+        statefulset = kwargs["obj"]
+        volumes = statefulset.spec.template.spec.volumes
+        assert len(volumes) == 1
+        assert volumes[0].name == "metricsd-config-volume"
+        assert volumes[0].secret.secretName == "metricsd-config"
+
+    @patch("lightkube.core.client.GenericSyncClient", Mock)
+    @patch("lightkube.Client.patch")
+    @patch("lightkube.Client.get")
+    @patch("charm.MagmaOrc8rMetricsdCharm.model", new_callable=PropertyMock)
+    def test_given_new_charm_when_on_install_event_then_volume_is_mounted(
+        self, patch_model, patch_get, patch_patch
+    ):
+        event = Mock()
+        namespace = "whatever namespace"
+        patch_get.return_value = StatefulSet(
+            spec=StatefulSetSpec(
+                serviceName="whatever",
+                selector=LabelSelector(),
+                template=PodTemplateSpec(
+                    spec=PodSpec(
+                        containers=[
+                            Container(name="charm"),
+                            Container(name="workload", volumeMounts=[]),
+                        ],
+                        volumes=[],
+                    )
+                ),
+            )
+        )
+        patch_model.return_value = MockModel(namespace)
+
+        self.harness.charm._on_install(event)
+
+        args, kwargs = patch_patch.call_args
+        statefulset = kwargs["obj"]
+        volume_mounts = statefulset.spec.template.spec.containers[1].volumeMounts
+        assert len(volume_mounts) == 1
+        assert volume_mounts[0].name == "metricsd-config-volume"

--- a/orchestrator-bundle/orc8r-orchestrator-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/metadata.yaml
@@ -13,6 +13,9 @@ summary: |
 containers:
   magma-orc8r-orchestrator:
     resource: magma-orc8r-orchestrator-image
+    mounts:
+      - storage: config
+        location: /var/opt/magma/configs/orc8r
 
 resources:
   magma-orc8r-orchestrator-image:
@@ -23,3 +26,9 @@ resources:
 requires:
   certifier:
     interface: certs
+
+storage:
+  config:
+    type: filesystem
+    description: Configs storage
+    minimum-size: 1M

--- a/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
@@ -2,7 +2,6 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import base64
 import logging
 from typing import List
 
@@ -91,10 +90,7 @@ class MagmaOrc8rOrchestratorCharm(CharmBase):
             '"metricExportURL": ""\n'
             '"metricsPrefix": ""\n'
         )
-        elastic_config = (
-            '"elasticHost": "orc8r-elasticsearch"\n'
-            '"elasticPort": 80\n'
-        )
+        elastic_config = '"elasticHost": "orc8r-elasticsearch"\n' '"elasticPort": 80\n'
 
         self._container.push(f"{self.BASE_CONFIG_PATH}/orchestrator.yml", orchestrator_config)
         self._container.push(f"{self.BASE_CONFIG_PATH}/metricsd.yml", metricsd_config)

--- a/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
@@ -21,6 +21,16 @@ class MagmaOrc8rOrchestratorCharm(CharmBase):
 
     BASE_CONFIG_PATH = "/var/opt/magma/configs/orc8r"
 
+    # TODO: The various URL's should be provided through relationships.
+    PROMETHEUS_URL = "http://orc8r-prometheus:9090"
+    PROMETHEUS_CONFIGURER_URL = "http://orc8r-prometheus:9100"
+    PROMETHEUS_CACHE_GRPC_URL = "orc8r-prometheus-cache:9092"
+    PROMETHEUS_CACHE_METRICS_URL = "http://orc8r-prometheus-cache:9091"
+    ALERTMANAGER_URL = "http://orc8r-alertmanager:9093"
+    ALERTMANAGER_CONFIGURER_URL = "http://orc8r-alertmanager:9101"
+    ELASTICSEARCH_URL = "orc8r-elasticsearch"
+    ELASTICSEARCH_PORT = 80
+
     def __init__(self, *args):
         """An instance of this object everytime an event occurs."""
         super().__init__(*args)
@@ -68,16 +78,16 @@ class MagmaOrc8rOrchestratorCharm(CharmBase):
 
     def _write_config_file(self):
         orchestrator_config = (
-            '"prometheusGRPCPushAddress": "orc8r-prometheus-cache:9092"\n'
+            f'"prometheusGRPCPushAddress": "{self.PROMETHEUS_CACHE_GRPC_URL}"\n'
             '"prometheusPushAddresses":\n'
-            '- "http://orc8r-prometheus-cache:9091/metrics"\n'
+            f'- "{self.PROMETHEUS_CACHE_METRICS_URL}/metrics"\n'
             '"useGRPCExporter": true\n'
         )
         metricsd_config = (
-            'prometheusQueryAddress: "http://orc8r-prometheus:9090"\n'
-            'alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2"\n'
-            'prometheusConfigServiceURL: "http://orc8r-prometheus:9100/v1"\n'
-            'alertmanagerConfigServiceURL: "http://orc8r-alertmanager:9101/v1"\n'
+            f'prometheusQueryAddress: "{self.PROMETHEUS_URL}"\n'
+            f'alertmanagerApiURL: "{self.ALERTMANAGER_URL}/api/v2"\n'
+            f'prometheusConfigServiceURL: "{self.PROMETHEUS_CONFIGURER_URL}/v1"\n'
+            f'alertmanagerConfigServiceURL: "{self.ALERTMANAGER_CONFIGURER_URL}/v1"\n'
             '"profile": "prometheus"\n'
         )
         analytics_config = (
@@ -88,7 +98,10 @@ class MagmaOrc8rOrchestratorCharm(CharmBase):
             '"metricExportURL": ""\n'
             '"metricsPrefix": ""\n'
         )
-        elastic_config = '"elasticHost": "orc8r-elasticsearch"\n' '"elasticPort": 80\n'
+        elastic_config = (
+            f'"elasticHost": "{self.ELASTICSEARCH_URL}"\n'
+            f'"elasticPort": {self.ELASTICSEARCH_PORT}\n'
+        )
 
         self._container.push(f"{self.BASE_CONFIG_PATH}/orchestrator.yml", orchestrator_config)
         self._container.push(f"{self.BASE_CONFIG_PATH}/metricsd.yml", metricsd_config)

--- a/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
@@ -19,8 +19,6 @@ logger = logging.getLogger(__name__)
 
 class MagmaOrc8rOrchestratorCharm(CharmBase):
 
-    ORCHESTRATOR_SECRET_NAME = "orchestrator-config"
-    ORCHESTRATOR_VOLUME_NAME = "orchestrator-config-volume"
     BASE_CONFIG_PATH = "/var/opt/magma/configs/orc8r"
 
     def __init__(self, *args):

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tests/unit/test_charm.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 import unittest
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import Mock, PropertyMock, call, patch
 
 from ops.testing import Harness
 
@@ -55,19 +55,39 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(expected_plan, updated_plan)
 
     @patch("ops.model.Container.push")
-    def test_given_new_charm_when_on_install_event_then_config_file_is_created(
-            self, patch_push
-    ):
+    def test_given_new_charm_when_on_install_event_then_config_file_is_created(self, patch_push):
         event = Mock()
 
         self.harness.charm._on_install(event)
 
-        args, kwargs = patch_push.call_args
-
-        assert args[0] == "/var/opt/magma/configs/orc8r/orchestrator.yml"
-        assert args[1] == (
-            '"prometheusGRPCPushAddress": "orc8r-prometheus-cache:9092"\n'
-            '"prometheusPushAddresses":\n'
-            '- "http://orc8r-prometheus-cache:9091/metrics"\n'
-            '"useGRPCExporter": true\n'
-        )
+        calls = [
+            call(
+                "/var/opt/magma/configs/orc8r/orchestrator.yml",
+                '"prometheusGRPCPushAddress": "orc8r-prometheus-cache:9092"\n'
+                '"prometheusPushAddresses":\n'
+                '- "http://orc8r-prometheus-cache:9091/metrics"\n'
+                '"useGRPCExporter": true\n',
+            ),
+            call(
+                "/var/opt/magma/configs/orc8r/metricsd.yml",
+                'prometheusQueryAddress: "http://orc8r-prometheus:9090"\n'
+                'alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2"\n'
+                'prometheusConfigServiceURL: "http://orc8r-prometheus:9100/v1"\n'
+                'alertmanagerConfigServiceURL: "http://orc8r-alertmanager:9101/v1"\n'
+                '"profile": "prometheus"\n',
+            ),
+            call(
+                "/var/opt/magma/configs/orc8r/analytics.yml",
+                '"appID": ""\n'
+                '"appSecret": ""\n'
+                '"categoryName": "magma"\n'
+                '"exportMetrics": false\n'
+                '"metricExportURL": ""\n'
+                '"metricsPrefix": ""\n',
+            ),
+            call(
+                "/var/opt/magma/configs/orc8r/elastic.yml",
+                '"elasticHost": "orc8r-elasticsearch"\n' '"elasticPort": 80\n',
+            ),
+        ]
+        patch_push.assert_has_calls(calls)

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tests/unit/test_charm.py
@@ -53,3 +53,21 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.on.magma_orc8r_orchestrator_pebble_ready.emit(event)
         updated_plan = self.harness.get_container_pebble_plan("magma-orc8r-orchestrator").to_dict()
         self.assertEqual(expected_plan, updated_plan)
+
+    @patch("ops.model.Container.push")
+    def test_given_new_charm_when_on_install_event_then_config_file_is_created(
+            self, patch_push
+    ):
+        event = Mock()
+
+        self.harness.charm._on_install(event)
+
+        args, kwargs = patch_push.call_args
+
+        assert args[0] == "/var/opt/magma/configs/orc8r/orchestrator.yml"
+        assert args[1] == (
+            '"prometheusGRPCPushAddress": "orc8r-prometheus-cache:9092"\n'
+            '"prometheusPushAddresses":\n'
+            '- "http://orc8r-prometheus-cache:9091/metrics"\n'
+            '"useGRPCExporter": true\n'
+        )


### PR DESCRIPTION
**Charms**
- Adds get-admin-credentials action to nms-magmalte instead of forcing the operator to users and credentials.
- Adds config files to charms that require them:
  - metricsd.yml
    - metricsd
    - analytics
    - certifier
    - lte
    - orchestrator
  - analytics.yml
    - analytics
    - lte
    - orchestrator
  - elastic.yml
    - orchestrator
  - orchestrator.yml
    - orchestrator
- Fetches the most recent version of charm libraries.

**Bundle**
- Adds Grafana and Alertmanager and corresponding relationships to the bundle.

**Documentation**
- Fixes bug in how-to guide where `deploy` command was missing.
- Improves how-to guides to reflect the fact that nms credentials are now retrieved instead of set.