### PR TITLE
Updates edge releasing workflow files

### DIFF
--- a/.github/workflows/orchestrator.accessd.charm.upload.yml
+++ b/.github/workflows/orchestrator.accessd.charm.upload.yml
@@ -12,15 +12,24 @@ jobs:
     runs-on: ubuntu-latest
     name: Charmhub upload orc8r-accessd-operator
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-accessd-operator
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        with:
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
           upload-image: "false"
-
-      - uses: canonical/charmhub-upload-action@0.2.1
-        with:
-          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-accessd-operator

--- a/.github/workflows/orchestrator.accessd.charm.upload.yml
+++ b/.github/workflows/orchestrator.accessd.charm.upload.yml
@@ -16,17 +16,17 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.analytics.charm.upload.yml
+++ b/.github/workflows/orchestrator.analytics.charm.upload.yml
@@ -16,17 +16,17 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.analytics.charm.upload.yml
+++ b/.github/workflows/orchestrator.analytics.charm.upload.yml
@@ -12,15 +12,24 @@ jobs:
     runs-on: ubuntu-latest
     name: Charmhub upload orc8r-analytics-operator
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-analytics-operator
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        with:
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
           upload-image: "false"
-
-      - uses: canonical/charmhub-upload-action@0.2.1
-        with:
-          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-analytics-operator

--- a/.github/workflows/orchestrator.bootstrapper.charm.upload.yml
+++ b/.github/workflows/orchestrator.bootstrapper.charm.upload.yml
@@ -16,17 +16,17 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.bootstrapper.charm.upload.yml
+++ b/.github/workflows/orchestrator.bootstrapper.charm.upload.yml
@@ -12,15 +12,24 @@ jobs:
     runs-on: ubuntu-latest
     name: Charmhub upload orc8r-bootstrapper-operator
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-bootstrapper-operator
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        with:
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
           upload-image: "false"
-
-      - uses: canonical/charmhub-upload-action@0.2.1
-        with:
-          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-bootstrapper-operator

--- a/.github/workflows/orchestrator.bundle.upload.yml
+++ b/.github/workflows/orchestrator.bundle.upload.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Upload bundle
-        uses: canonical/charming-actions/upload-bundle@test-charm-rev74
+        uses: canonical/charming-actions/upload-bundle@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           bundle-path: ./orchestrator-bundle/orc8r-bundle

--- a/.github/workflows/orchestrator.bundle.upload.yml
+++ b/.github/workflows/orchestrator.bundle.upload.yml
@@ -14,7 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Upload bundle
+        uses: canonical/charming-actions/upload-bundle@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.certifier.charm.upload.yml
+++ b/.github/workflows/orchestrator.certifier.charm.upload.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Preinstall dependencies
+        run: |
+          sudo apt-get update && sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1
+
       - uses: canonical/charmhub-upload-action@0.2.1
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"

--- a/.github/workflows/orchestrator.certifier.charm.upload.yml
+++ b/.github/workflows/orchestrator.certifier.charm.upload.yml
@@ -14,17 +14,25 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Preinstall dependencies
+      - name: Pre-install dependencies
         run: |
           sudo apt-get update && sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-certifier-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-certifier-operator

--- a/.github/workflows/orchestrator.certifier.charm.upload.yml
+++ b/.github/workflows/orchestrator.certifier.charm.upload.yml
@@ -14,22 +14,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Pre-install dependencies
-        run: |
-          sudo apt-get update && sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1
-
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.configurator.charm.upload.yml
+++ b/.github/workflows/orchestrator.configurator.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.configurator.charm.upload.yml
+++ b/.github/workflows/orchestrator.configurator.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-configurator-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-configurator-operator

--- a/.github/workflows/orchestrator.ctraced.charm.upload.yml
+++ b/.github/workflows/orchestrator.ctraced.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.ctraced.charm.upload.yml
+++ b/.github/workflows/orchestrator.ctraced.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-ctraced-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-ctraced-operator

--- a/.github/workflows/orchestrator.device.charm.upload.yml
+++ b/.github/workflows/orchestrator.device.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.device.charm.upload.yml
+++ b/.github/workflows/orchestrator.device.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-device-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-device-operator

--- a/.github/workflows/orchestrator.directoryd.charm.upload.yml
+++ b/.github/workflows/orchestrator.directoryd.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-directoryd-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-directoryd-operator

--- a/.github/workflows/orchestrator.directoryd.charm.upload.yml
+++ b/.github/workflows/orchestrator.directoryd.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.dispatcher.charm.upload.yml
+++ b/.github/workflows/orchestrator.dispatcher.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-dispatcher-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-dispatcher-operator

--- a/.github/workflows/orchestrator.dispatcher.charm.upload.yml
+++ b/.github/workflows/orchestrator.dispatcher.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.eventd.charm.upload.yml
+++ b/.github/workflows/orchestrator.eventd.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.eventd.charm.upload.yml
+++ b/.github/workflows/orchestrator.eventd.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-eventd-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-eventd-operator

--- a/.github/workflows/orchestrator.ha.charm.upload.yml
+++ b/.github/workflows/orchestrator.ha.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.ha.charm.upload.yml
+++ b/.github/workflows/orchestrator.ha.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-ha-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-ha-operator

--- a/.github/workflows/orchestrator.lte.charm.upload.yml
+++ b/.github/workflows/orchestrator.lte.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.lte.charm.upload.yml
+++ b/.github/workflows/orchestrator.lte.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-lte-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-lte-operator

--- a/.github/workflows/orchestrator.metricsd.charm.upload.yml
+++ b/.github/workflows/orchestrator.metricsd.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.metricsd.charm.upload.yml
+++ b/.github/workflows/orchestrator.metricsd.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-metricsd-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-metricsd-operator

--- a/.github/workflows/orchestrator.nginx.charm.upload.yml
+++ b/.github/workflows/orchestrator.nginx.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.nginx.charm.upload.yml
+++ b/.github/workflows/orchestrator.nginx.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-nginx-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-nginx-operator

--- a/.github/workflows/orchestrator.nms.magmalte.charm.upload.yml
+++ b/.github/workflows/orchestrator.nms.magmalte.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.nms.magmalte.charm.upload.yml
+++ b/.github/workflows/orchestrator.nms.magmalte.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/nms-magmalte-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/nms-magmalte-operator

--- a/.github/workflows/orchestrator.nms.nginx.proxy.charm.upload.yml
+++ b/.github/workflows/orchestrator.nms.nginx.proxy.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.nms.nginx.proxy.charm.upload.yml
+++ b/.github/workflows/orchestrator.nms.nginx.proxy.charm.upload.yml
@@ -14,8 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/nms-nginx-proxy-operator
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        with:
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
           upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/nms-nginx-proxy-operator

--- a/.github/workflows/orchestrator.obsidian.charm.upload.yml
+++ b/.github/workflows/orchestrator.obsidian.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-obsidian-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-obsidian-operator

--- a/.github/workflows/orchestrator.obsidian.charm.upload.yml
+++ b/.github/workflows/orchestrator.obsidian.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.orchestrator.charm.upload.yml
+++ b/.github/workflows/orchestrator.orchestrator.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.orchestrator.charm.upload.yml
+++ b/.github/workflows/orchestrator.orchestrator.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-orchestrator-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-orchestrator-operator

--- a/.github/workflows/orchestrator.policydb.charm.upload.yml
+++ b/.github/workflows/orchestrator.policydb.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.policydb.charm.upload.yml
+++ b/.github/workflows/orchestrator.policydb.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-policydb-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-policydb-operator

--- a/.github/workflows/orchestrator.service.registry.charm.upload.yml
+++ b/.github/workflows/orchestrator.service.registry.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.service.registry.charm.upload.yml
+++ b/.github/workflows/orchestrator.service.registry.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-service-registry-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-service-registry-operator

--- a/.github/workflows/orchestrator.smsd.charm.upload.yml
+++ b/.github/workflows/orchestrator.smsd.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-smsd-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-smsd-operator

--- a/.github/workflows/orchestrator.smsd.charm.upload.yml
+++ b/.github/workflows/orchestrator.smsd.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.state.charm.upload.yml
+++ b/.github/workflows/orchestrator.state.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.state.charm.upload.yml
+++ b/.github/workflows/orchestrator.state.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-state-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-state-operator

--- a/.github/workflows/orchestrator.streamer.charm.upload.yml
+++ b/.github/workflows/orchestrator.streamer.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.streamer.charm.upload.yml
+++ b/.github/workflows/orchestrator.streamer.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-streamer-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-streamer-operator

--- a/.github/workflows/orchestrator.subscriberdb.cache.charm.upload.yml
+++ b/.github/workflows/orchestrator.subscriberdb.cache.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-subscriberdb-cache-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-subscriberdb-cache-operator

--- a/.github/workflows/orchestrator.subscriberdb.cache.charm.upload.yml
+++ b/.github/workflows/orchestrator.subscriberdb.cache.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.subscriberdb.charm.upload.yml
+++ b/.github/workflows/orchestrator.subscriberdb.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.subscriberdb.charm.upload.yml
+++ b/.github/workflows/orchestrator.subscriberdb.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-subscriberdb-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-subscriberdb-operator

--- a/.github/workflows/orchestrator.tenants.charm.upload.yml
+++ b/.github/workflows/orchestrator.tenants.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev74
+        uses: canonical/charming-actions/check-libraries@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev74
+        uses: canonical/charming-actions/channel@test-charm-rev75
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev74
+        uses: canonical/charming-actions/upload-charm@test-charm-rev75
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.tenants.charm.upload.yml
+++ b/.github/workflows/orchestrator.tenants.charm.upload.yml
@@ -14,13 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-tenants-operator
-          upload-image: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: canonical/charmhub-upload-action@0.2.1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@test-charm-rev74
+        id: channel
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@test-charm-rev74
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          bundle-path: ./orchestrator-bundle/orc8r-bundle
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: ./orchestrator-bundle/orc8r-tenants-operator


### PR DESCRIPTION
- Pre-installs dependencies preventing `orc8r-certifier` to pack within the Github runner.
- Upgrades the version of the Charmhub upload action adding a new feature that will detect if there are any differences between the charm libraries part of the commit and the ones available on Charmhub. It will post a comment in any PR that fails the check, but it can also be configured to fail the entire build.