### PR TITLE
Updates charmhub upload action revision version: test-charm-rev75 -> 1.0.2

### DIFF
--- a/.github/workflows/orchestrator.accessd.charm.upload.yml
+++ b/.github/workflows/orchestrator.accessd.charm.upload.yml
@@ -16,17 +16,17 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.analytics.charm.upload.yml
+++ b/.github/workflows/orchestrator.analytics.charm.upload.yml
@@ -16,17 +16,17 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.bootstrapper.charm.upload.yml
+++ b/.github/workflows/orchestrator.bootstrapper.charm.upload.yml
@@ -16,17 +16,17 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.bundle.upload.yml
+++ b/.github/workflows/orchestrator.bundle.upload.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Upload bundle
-        uses: canonical/charming-actions/upload-bundle@test-charm-rev75
+        uses: canonical/charming-actions/upload-bundle@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           bundle-path: ./orchestrator-bundle/orc8r-bundle

--- a/.github/workflows/orchestrator.certifier.charm.upload.yml
+++ b/.github/workflows/orchestrator.certifier.charm.upload.yml
@@ -21,11 +21,11 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.configurator.charm.upload.yml
+++ b/.github/workflows/orchestrator.configurator.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.ctraced.charm.upload.yml
+++ b/.github/workflows/orchestrator.ctraced.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.device.charm.upload.yml
+++ b/.github/workflows/orchestrator.device.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.directoryd.charm.upload.yml
+++ b/.github/workflows/orchestrator.directoryd.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.dispatcher.charm.upload.yml
+++ b/.github/workflows/orchestrator.dispatcher.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.eventd.charm.upload.yml
+++ b/.github/workflows/orchestrator.eventd.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.ha.charm.upload.yml
+++ b/.github/workflows/orchestrator.ha.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.lte.charm.upload.yml
+++ b/.github/workflows/orchestrator.lte.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.metricsd.charm.upload.yml
+++ b/.github/workflows/orchestrator.metricsd.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.nginx.charm.upload.yml
+++ b/.github/workflows/orchestrator.nginx.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.nms.magmalte.charm.upload.yml
+++ b/.github/workflows/orchestrator.nms.magmalte.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.nms.nginx.proxy.charm.upload.yml
+++ b/.github/workflows/orchestrator.nms.nginx.proxy.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.obsidian.charm.upload.yml
+++ b/.github/workflows/orchestrator.obsidian.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.orchestrator.charm.upload.yml
+++ b/.github/workflows/orchestrator.orchestrator.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.policydb.charm.upload.yml
+++ b/.github/workflows/orchestrator.policydb.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.service.registry.charm.upload.yml
+++ b/.github/workflows/orchestrator.service.registry.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.smsd.charm.upload.yml
+++ b/.github/workflows/orchestrator.smsd.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.state.charm.upload.yml
+++ b/.github/workflows/orchestrator.state.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.streamer.charm.upload.yml
+++ b/.github/workflows/orchestrator.streamer.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.subscriberdb.cache.charm.upload.yml
+++ b/.github/workflows/orchestrator.subscriberdb.cache.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.subscriberdb.charm.upload.yml
+++ b/.github/workflows/orchestrator.subscriberdb.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/orchestrator.tenants.charm.upload.yml
+++ b/.github/workflows/orchestrator.tenants.charm.upload.yml
@@ -15,17 +15,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@test-charm-rev75
+        uses: canonical/charming-actions/check-libraries@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@test-charm-rev75
+        uses: canonical/charming-actions/channel@1.0.2
         id: channel
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@test-charm-rev75
+        uses: canonical/charming-actions/upload-charm@1.0.2
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/orchestrator-bundle/nms-magmalte-operator/src/charm.py
+++ b/orchestrator-bundle/nms-magmalte-operator/src/charm.py
@@ -196,7 +196,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
 
     def _create_nms_admin_user(self, email: str, password: str, organization: str):
         """
-        Creates Admin user for the master organization in NMS
+        Creates Admin user for the master organization in NMS.
         """
         logger.info("Creating admin user for NMS")
         process = self._container.exec(

--- a/orchestrator-bundle/orc8r-analytics-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-analytics-operator/src/charm.py
@@ -20,7 +20,7 @@ class MagmaOrc8rAnalyticsCharm(CharmBase):
 
     def __init__(self, *args):
         """
-        An instance of this object everytime an event occurs
+        An instance of this object everytime an event occurs.
         """
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(

--- a/orchestrator-bundle/orc8r-bundle/README.md
+++ b/orchestrator-bundle/orc8r-bundle/README.md
@@ -1,13 +1,14 @@
 # magma-orc8r
 
 ## Overview
-Orchestrator is a Magma service that provides a simple and consistent way to 
-configure and monitor the wireless network securely. The metrics acquired through the platform 
+
+Orchestrator is a Magma service that provides a simple and consistent way to
+configure and monitor the wireless network securely. The metrics acquired through the platform
 allows you to see the analytics and traffic flows of the wireless users through the Magma web UI.
 
 ## Usage
 
-In order for the bundle to be deployed with your domain, we need to create an overlay bundle file. 
+In order for the bundle to be deployed with your domain, we need to create an overlay bundle file.
 This file should contain the following:
 
 ```yaml
@@ -15,15 +16,15 @@ applications:
   orc8r-certifier:
     options:
       domain: <your domain>
-
 ```
 
-An example with the same content is provided in `overlay_examples/self_signed_certs.yaml` and you 
-can read more about overlay bundles 
+An example with the same content is provided in `overlay_examples/self_signed_certs.yaml` and you
+can read more about overlay bundles
 [here](https://discourse.charmhub.io/t/how-to-manage-charm-bundles/1058#heading--overlay-bundles).
 An example for the case where you'd want to provide your own certificates is also presented.
 
 Deploy the `magma-orc8r` bundle specifying your overlay bundle file.
+
 ```bash
 juju deploy magma-orc8r --overlay ~/self_signed_certs.yaml --trust
 ```
@@ -32,7 +33,7 @@ juju deploy magma-orc8r --overlay ~/self_signed_certs.yaml --trust
 
 ### Create Orchestrator admin user
 
-The NMS requires some basic certificate-based authentication when making calls to the Orchestrator 
+The NMS requires some basic certificate-based authentication when making calls to the Orchestrator
 API. To support this, we need to add the relevant certificate as an admin user to the controller.
 
 ```bash
@@ -41,7 +42,7 @@ juju run-action orc8r-orchestrator/0 create-orchestrator-admin-user
 
 ### Create NMS admin user
 
-Create an admin user for the master organization on the NMS. Here specify an email and password that 
+Create an admin user for the master organization on the NMS. Here specify an email and password that
 you will want to use when connecting to NMS as an admin.
 
 ```bash
@@ -49,62 +50,68 @@ juju run-action nms-magmalte/0 create-nms-admin-user email=<your email> password
 ```
 
 ### Change log verbosity
+
 You can set the log level of any service using the `set-log-verbosity` action. The default log
-level is 0 and the full log level is 10. Here is an example of setting the log level to 10 for the 
+level is 0 and the full log level is 10. Here is an example of setting the log level to 10 for the
 `obsidian` service:
 
 ```bash
 juju run-action orc8r-orchestrator/0 set-log-verbosity level=10 service=obsidian
 ```
 
-
 ## DNS Resolution
-Some services will have to be exposed to outside of the Kubernetes cluster. This is done by 
-associating LoadBalancer addresses to resolvable domains. Here is the association of Kubernetes 
+
+Some services will have to be exposed to outside of the Kubernetes cluster. This is done by
+associating LoadBalancer addresses to resolvable domains. Here is the association of Kubernetes
 service to record that you will have to implement:
 
-
-| Kubernetes service       | Record name                             | 
-|:-------------------------|:----------------------------------------|
+| Kubernetes service       | Record name                             |
+| :----------------------- | :-------------------------------------- |
 | `nginx-proxy`            | `*.nms.<your domain>`                   |
 | `orc8r-bootstrap-nginx`  | `bootstrapper-controller.<your domain>` |
 | `orc8r-clientcert-nginx` | `controller.<your domain>`              |
-| `orc8r-nginx-proxy`      | `api.<your domain>`                     | 
+| `orc8r-nginx-proxy`      | `api.<your domain>`                     |
 
-For more details, please refer to the documentation provided for your specific 
+For more details, please refer to the documentation provided for your specific
 cloud provider.
 
-
 ## Verify the Deployment
-### NMS 
-You can confirm successful deployment by visiting the master NMS organization at e.g. 
-`https://master.nms.<your domain>` and logging in with your email and password provided above 
+
+### NMS
+
+You can confirm successful deployment by visiting the master NMS organization at e.g.
+`https://master.nms.<your domain>` and logging in with your email and password provided above
 (`<your email>` and `<your password>` in this example).
-If you self-signed certs above, the browser will rightfully complain. 
-Either ignore the browser warnings at your own risk (some versions of Chrome won't 
+If you self-signed certs above, the browser will rightfully complain.
+Either ignore the browser warnings at your own risk (some versions of Chrome won't
 allow this at all), or e.g. import the root CA from above on a per-browser basis.
 
 ### Orchestrator
-For interacting with the Orchestrator REST API, a good starting point is the Swagger UI available 
+
+For interacting with the Orchestrator REST API, a good starting point is the Swagger UI available
 at `https://api.<your domain>/swagger/v1/ui/`.
 
 ### Juju
+
 You can run `juju status` and you should see all charms are in the `Active-Idle`status.
 
 ### Kubernetes
-You can run `kubectl get pods -n <your model>` and you should see that all pods are up and 
+
+You can run `kubectl get pods -n <your model>` and you should see that all pods are up and
 running.
 
 ## Debug
+
 Logs can be found by querying each individual pod. Example:
 
 ```bash
 kubectl logs nms-magmalte-0 -c magma-nms-magmalte -n <your model> --follow
 ```
 
-
 ## Detailed content
+
 Orchestrator is made up of multiple services and this bundle contains a charm per service:
+
 - [magma-nms-magmalte](https://charmhub.io/magma-nms-magmalte)
 - [magma-nms-nginx-proxy](https://charmhub.io/magma-nms-nginx-proxy)
 - [magma-orc8r-accessd](https://charmhub.io/magma-orc8r-accessd)
@@ -133,6 +140,7 @@ Orchestrator is made up of multiple services and this bundle contains a charm pe
 - [magma-orc8r-tenants](https://charmhub.io/magma-orc8r-tenants)
 
 ## References
+
 - [Juju](https://juju.is/docs)
 - [Magma](https://docs.magmacore.org/docs/basics/introduction.html)
 - [Orchestrator](https://docs.magmacore.org/docs/orc8r/architecture_overview)

--- a/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
@@ -188,7 +188,7 @@ class MagmaOrc8rCertifierCharm(CharmBase):
         return True
 
     def _delete_secrets(self) -> None:
-        """Delete Kubernetes secrets created by the create_secrets method"""
+        """Delete Kubernetes secrets created by the create_secrets method."""
         client = Client()
         for secret in self._magma_orc8r_certifier_secrets:
             client.delete(SecretRes, name=secret, namespace=self._namespace)

--- a/orchestrator-bundle/orc8r-dispatcher-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-dispatcher-operator/src/charm.py
@@ -11,7 +11,7 @@ from ops.main import main
 class MagmaOrc8rDispatcherCharm(CharmBase):
     def __init__(self, *args):
         """
-        An instance of this object everytime an event occurs
+        An instance of this object everytime an event occurs.
         """
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(

--- a/orchestrator-bundle/orc8r-eventd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-eventd-operator/src/charm.py
@@ -11,7 +11,7 @@ from ops.main import main
 class MagmaOrc8rEventdCharm(CharmBase):
     def __init__(self, *args):
         """
-        An instance of this object everytime an event occurs
+        An instance of this object everytime an event occurs.
         """
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(

--- a/orchestrator-bundle/orc8r-ha-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-ha-operator/src/charm.py
@@ -11,7 +11,7 @@ from ops.main import main
 class MagmaOrc8rHACharm(CharmBase):
     def __init__(self, *args):
         """
-        An instance of this object everytime an event occurs
+        An instance of this object everytime an event occurs.
         """
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(

--- a/orchestrator-bundle/orc8r-lte-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-lte-operator/src/charm.py
@@ -12,7 +12,7 @@ class MagmaOrc8rLteCharm(CharmBase):
 
     BASE_CONFIG_PATH = "/var/opt/magma/configs/orc8r"
 
-    # TODO: The various URL's should be provided through relationships.
+    # TODO: The various URL's should be provided through relationships
     PROMETHEUS_URL = "http://orc8r-prometheus:9090"
     PROMETHEUS_CONFIGURER_URL = "http://orc8r-prometheus:9100"
     ALERTMANAGER_URL = "http://orc8r-alertmanager:9093"

--- a/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
@@ -24,7 +24,7 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
 
     def __init__(self, *args):
         """
-        An instance of this object everytime an event occurs
+        An instance of this object everytime an event occurs.
         """
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(

--- a/orchestrator-bundle/orc8r-obsidian-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-obsidian-operator/tests/unit/test_charm.py
@@ -4,4 +4,5 @@
 
 
 def test_placeholder():
+    # TODO: write tests
     pass

--- a/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
@@ -21,7 +21,7 @@ class MagmaOrc8rOrchestratorCharm(CharmBase):
 
     BASE_CONFIG_PATH = "/var/opt/magma/configs/orc8r"
 
-    # TODO: The various URL's should be provided through relationships.
+    # TODO: The various URL's should be provided through relationships
     PROMETHEUS_URL = "http://orc8r-prometheus:9090"
     PROMETHEUS_CONFIGURER_URL = "http://orc8r-prometheus:9100"
     PROMETHEUS_CACHE_GRPC_URL = "orc8r-prometheus-cache:9092"

--- a/orchestrator-bundle/orc8r-service-registry-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-service-registry-operator/src/charm.py
@@ -11,7 +11,7 @@ from ops.main import main
 class MagmaOrc8rServiceRegistry(CharmBase):
     def __init__(self, *args):
         """
-        An instance of this object everytime an event occurs
+        An instance of this object everytime an event occurs.
         """
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(

--- a/orchestrator-bundle/orc8r-streamer-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-streamer-operator/src/charm.py
@@ -11,7 +11,7 @@ from ops.main import main
 class MagmaOrc8rStreamer(CharmBase):
     def __init__(self, *args):
         """
-        An instance of this object everytime an event occurs
+        An instance of this object everytime an event occurs.
         """
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(


### PR DESCRIPTION
# Upgrades [charming-actions](https://github.com/canonical/charming-actions) version from `test-charm-rev75` to `1.0.2`.
`test-charm-rev75` was a beta-like version that is now dropped. We are now using the latest one that gathers all the latest changes.

Reference: [charming-actions 1.0.2](https://github.com/canonical/charming-actions/releases/tag/1.0.2)