### PR TITLE
Fix: Adds tag prefix to every charm

### DIFF
--- a/.github/workflows/orchestrator.accessd.charm.upload.yml
+++ b/.github/workflows/orchestrator.accessd.charm.upload.yml
@@ -33,3 +33,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-accessd-operator
+          tag-prefix: "magma-orc8r-accessd"

--- a/.github/workflows/orchestrator.analytics.charm.upload.yml
+++ b/.github/workflows/orchestrator.analytics.charm.upload.yml
@@ -33,3 +33,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-analytics-operator
+          tag-prefix: "magma-orc8r-analytics"

--- a/.github/workflows/orchestrator.baseacct.charm.upload.yml
+++ b/.github/workflows/orchestrator.baseacct.charm.upload.yml
@@ -33,3 +33,5 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-base-acct-operator
+          tag-prefix: "magma-orc8r-base-acct"
+

--- a/.github/workflows/orchestrator.bootstrapper.charm.upload.yml
+++ b/.github/workflows/orchestrator.bootstrapper.charm.upload.yml
@@ -33,3 +33,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-bootstrapper-operator
+          tag-prefix: "magma-orc8r-bootstrapper"

--- a/.github/workflows/orchestrator.certifier.charm.upload.yml
+++ b/.github/workflows/orchestrator.certifier.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-certifier-operator
+          tag-prefix: "magma-orc8r-certifier"

--- a/.github/workflows/orchestrator.configurator.charm.upload.yml
+++ b/.github/workflows/orchestrator.configurator.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-configurator-operator
+          tag-prefix: "magma-orc8r-configurator"

--- a/.github/workflows/orchestrator.ctraced.charm.upload.yml
+++ b/.github/workflows/orchestrator.ctraced.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-ctraced-operator
+          tag-prefix: "magma-orc8r-ctraced"

--- a/.github/workflows/orchestrator.device.charm.upload.yml
+++ b/.github/workflows/orchestrator.device.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-device-operator
+          tag-prefix: "magma-orc8r-device"

--- a/.github/workflows/orchestrator.directoryd.charm.upload.yml
+++ b/.github/workflows/orchestrator.directoryd.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-directoryd-operator
+          tag-prefix: "magma-orc8r-directoryd"

--- a/.github/workflows/orchestrator.dispatcher.charm.upload.yml
+++ b/.github/workflows/orchestrator.dispatcher.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-dispatcher-operator
+          tag-prefix: "magma-orc8r-dispatcher"

--- a/.github/workflows/orchestrator.eventd.charm.upload.yml
+++ b/.github/workflows/orchestrator.eventd.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-eventd-operator
+          tag-prefix: "magma-orc8r-eventd"

--- a/.github/workflows/orchestrator.feg.charm.upload.yml
+++ b/.github/workflows/orchestrator.feg.charm.upload.yml
@@ -33,3 +33,5 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-feg-operator
+          tag-prefix: "magma-orc8r-feg-operator"
+

--- a/.github/workflows/orchestrator.fegrelay.charm.upload.yml
+++ b/.github/workflows/orchestrator.fegrelay.charm.upload.yml
@@ -33,3 +33,5 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-feg-relay-operator
+          tag-prefix: "magma-orc8r-feg-relay"
+

--- a/.github/workflows/orchestrator.ha.charm.upload.yml
+++ b/.github/workflows/orchestrator.ha.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-ha-operator
+          tag-prefix: "magma-orc8r-ha"

--- a/.github/workflows/orchestrator.health.charm.upload.yml
+++ b/.github/workflows/orchestrator.health.charm.upload.yml
@@ -33,3 +33,5 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-health-operator
+          tag-prefix: "magma-orc8r-health"
+

--- a/.github/workflows/orchestrator.lte.charm.upload.yml
+++ b/.github/workflows/orchestrator.lte.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-lte-operator
+          tag-prefix: "magma-orc8r-lte"

--- a/.github/workflows/orchestrator.metricsd.charm.upload.yml
+++ b/.github/workflows/orchestrator.metricsd.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-metricsd-operator
+          tag-prefix: "magma-orc8r-metricsd"

--- a/.github/workflows/orchestrator.nginx.charm.upload.yml
+++ b/.github/workflows/orchestrator.nginx.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-nginx-operator
+          tag-prefix: "magma-orc8r-nginx"

--- a/.github/workflows/orchestrator.nms.magmalte.charm.upload.yml
+++ b/.github/workflows/orchestrator.nms.magmalte.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/nms-magmalte-operator
+          tag-prefix: "nms-magmalte"

--- a/.github/workflows/orchestrator.nms.nginx.proxy.charm.upload.yml
+++ b/.github/workflows/orchestrator.nms.nginx.proxy.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/nms-nginx-proxy-operator
+          tag-prefix: "nms-nginx-proxy"

--- a/.github/workflows/orchestrator.obsidian.charm.upload.yml
+++ b/.github/workflows/orchestrator.obsidian.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-obsidian-operator
+          tag-prefix: "magma-orc8r-obsidian"

--- a/.github/workflows/orchestrator.orchestrator.charm.upload.yml
+++ b/.github/workflows/orchestrator.orchestrator.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-orchestrator-operator
+          tag-prefix: "magma-orc8r-orchestrator"

--- a/.github/workflows/orchestrator.policydb.charm.upload.yml
+++ b/.github/workflows/orchestrator.policydb.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-policydb-operator
+          tag-prefix: "magma-orc8r-policydb"

--- a/.github/workflows/orchestrator.service.registry.charm.upload.yml
+++ b/.github/workflows/orchestrator.service.registry.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-service-registry-operator
+          tag-prefix: "magma-orc8r-service-registry"

--- a/.github/workflows/orchestrator.smsd.charm.upload.yml
+++ b/.github/workflows/orchestrator.smsd.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-smsd-operator
+          tag-prefix: "magma-orc8r-smsd"

--- a/.github/workflows/orchestrator.state.charm.upload.yml
+++ b/.github/workflows/orchestrator.state.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-state-operator
+          tag-prefix: "magma-orc8r-state"

--- a/.github/workflows/orchestrator.streamer.charm.upload.yml
+++ b/.github/workflows/orchestrator.streamer.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-streamer-operator
+          tag-prefix: "magma-orc8r-streamer"

--- a/.github/workflows/orchestrator.subscriberdb.cache.charm.upload.yml
+++ b/.github/workflows/orchestrator.subscriberdb.cache.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-subscriberdb-cache-operator
+          tag-prefix: "magma-orc8r-subscriberdb-cache"

--- a/.github/workflows/orchestrator.subscriberdb.charm.upload.yml
+++ b/.github/workflows/orchestrator.subscriberdb.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-subscriberdb-operator
+          tag-prefix: "magma-orc8r-subscriberdb"

--- a/.github/workflows/orchestrator.tenants.charm.upload.yml
+++ b/.github/workflows/orchestrator.tenants.charm.upload.yml
@@ -32,3 +32,4 @@ jobs:
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/orc8r-tenants-operator
+          tag-prefix: "magma-orc8r-tenants"


### PR DESCRIPTION
This PR addresses the issue of the upload actions failing because of tags being already created with the same name. If two charms had the same revision number, the revision name would be also equal, ending up with duplicated names.
By adding the tag we ensure names like the following:
- `<charm name>-rev-<revision number>`

For instance, if we are uploading `eventd`'s revision number 23 we would end up with the following tag:
- `magma-orc8r-eventd-rev-23`

```yaml
      - name: Upload charm to charmhub
        uses: canonical/charming-actions/upload-charm@1.0.2
        with:
          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
          github-token: "${{ secrets.GITHUB_TOKEN }}"
          upload-image: "false"
          channel: "${{ steps.channel.outputs.name }}"
          charm-path: ./orchestrator-bundle/orc8r-eventd-operator
          tag-prefix: "magma-orc8r-eventd" <---- NEW TAG
```

**NOTE:** When talking about "revisions" I mean Charmhub revisions.