### PR TITLE
Integration tests setup

### DIFF
--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -108,7 +108,6 @@ jobs:
           #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
           #charms="./orchestrator-bundle/orc8r-bootstrapper-operator ./orchestrator-bundle/orc8r-nginx-operator"
           charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
-
           for charm in ${charms}; do
             tox -c ./orchestrator-bundle/magma-${charm}-operator -e integration
           done

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -109,8 +109,7 @@ jobs:
         run: |
           set -eux
           #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
-          #charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
-          charms="lte"
+          charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
           for charm in ${charms}; do
             tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
           done

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -105,7 +105,7 @@ jobs:
           /usr/bin/sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
           /usr/bin/sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libffi-dev=3.3-4 libssh2-1=1.8.0-2.1build1 libssl-dev=1.1.1f-1ubuntu2.13 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1
 
-      # TODO: Add certifier and certifier-related charms
+      # TODO: Add certifier and certifier-related charms.
       - name: Run integration tests.
         run: |
           set -eux

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -6,50 +6,50 @@ on:
       - fix-integration-tests
 
 jobs:
-    # orchestrator-lint-report:
-    #   name: Lint report
-    #   runs-on: ubuntu-latest
-    #   steps:
-    #     - uses: actions/checkout@v2
-    #     - name: Install tox
-    #       run: pip install tox
-    #     - name: Run tests using tox
-    #       run: |
-    #         set -eux
-    #         charms="$(find ./orchestrator-bundle/ -name tox.ini)"
-    #         for charm in ${charms}; do
-    #           tox -c "${charm}" -e lint
-    #         done
+  # orchestrator-lint-report:
+  #   name: Lint report
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install tox
+  #       run: pip install tox
+  #     - name: Run tests using tox
+  #       run: |
+  #         set -eux
+  #         charms="$(find ./orchestrator-bundle/ -name tox.ini)"
+  #         for charm in ${charms}; do
+  #           tox -c "${charm}" -e lint
+  #         done
 
-    # orchestrator-static-analysis:
-    #   name: Static analysis
-    #   runs-on: ubuntu-latest
-    #   steps:
-    #     - uses: actions/checkout@v2
-    #     - name: Install tox
-    #       run: pip install tox
-    #     - name: Run tests using tox
-    #       run: |
-    #         set -eux
-    #         charms="$(find ./orchestrator-bundle/ -name tox.ini)"
-    #         for charm in ${charms}; do
-    #           tox -c "${charm}" -e static
-    #         done
+  # orchestrator-static-analysis:
+  #   name: Static analysis
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install tox
+  #       run: pip install tox
+  #     - name: Run tests using tox
+  #       run: |
+  #         set -eux
+  #         charms="$(find ./orchestrator-bundle/ -name tox.ini)"
+  #         for charm in ${charms}; do
+  #           tox -c "${charm}" -e static
+  #         done
 
-    # orchestrator-unit-tests-with-coverage:
-    #   name: Unit tests
-    #   runs-on: ubuntu-latest
-    #   steps:
-    #     - uses: actions/checkout@v2
-    #     - name: Install tox
-    #       run: pip install tox
-    #     - name: Run tests using tox
-    #       run: |
-    #         set -eux
-    #         charms="$(find ./orchestrator-bundle/ -name tox.ini)"
-    #         for charm in ${charms}; do
-    #           tox -c "${charm}" -e unit
-    #         done
+  # orchestrator-unit-tests-with-coverage:
+  #   name: Unit tests
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install tox
+  #       run: pip install tox
+  #     - name: Run tests using tox
+  #       run: |
+  #         set -eux
+  #         charms="$(find ./orchestrator-bundle/ -name tox.ini)"
+  #         for charm in ${charms}; do
+  #           tox -c "${charm}" -e unit
+  #         done
 
   orchestrator-integration-test:
     name: Integration tests
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
+
       - name: Setup operator environment
         run: |
           echo "# Install core snap"
@@ -101,15 +101,16 @@ jobs:
           echo "# Bootstrap controller"
           sleep 180  # Microk8s needs time to initialize properly
           /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
+
       # TODO: Add certifier and certifier-related charms
       - name: Run integration tests
-      run: |
-        set -eux
-        #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
-        charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
-        for charm in ${charms}; do
-          tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
-        done
+        run: |
+          set -eux
+          #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
+          charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
+          for charm in ${charms}; do
+            tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
+          done
       - name: Clean up
         if: always()
         run: |

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -51,67 +51,65 @@ jobs:
     #           tox -c "${charm}" -e unit
     #         done
 
-    orchestrator-integration-test:
-      name: Integration tests
-      runs-on: integration-testing
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v2
-          
-        - name: Setup operator environment
-          run: |
-            echo "# Install core snap"
-            /usr/bin/sudo snap install core
-            echo "# Install LXD"
-            /usr/bin/sudo apt-get remove -qy lxd lxd-client || true
-            /usr/bin/sudo snap install lxd
-            echo "# Initialize LXD"
-            /usr/bin/sudo lxd waitready
-            /usr/bin/sudo lxd init --auto
-            /usr/bin/sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
-            /snap/bin/lxc network set lxdbr0 ipv6.address none
-            /usr/bin/sudo usermod -a -G lxd $USER
-            echo "# Configure LXD"
-            /usr/bin/sudo lxc --project charmcraft project create local:charmcraft || true
-            /usr/bin/sudo lxc --project charmcraft profile device add default root disk path=/ pool=default type=disk || true
-            /usr/bin/sudo lxc --project charmcraft profile device add default eth0 nic name=eth0 network=lxdbr0 || true
-            /usr/bin/sudo lxc --project charmcraft profile set default environment.http_proxy http://squid.internal:3128/
-            /usr/bin/sudo lxc --project charmcraft profile set default environment.https_proxy http://squid.internal:3128/
-            /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTP_PROXY http://squid.internal:3128/
-            /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTPS_PROXY http://squid.internal:3128/
-            echo "# Install tox"
-            /usr/bin/sudo apt-get update -yqq
-            /usr/bin/sudo apt-get install -yqq python3-pip
-            /usr/bin/sudo --preserve-env=http_proxy,https_proxy,no_proxy pip3 install tox
-            echo "# Install Juju"
-            /usr/bin/sudo snap install juju --classic --channel=latest/stable
-            echo "# Install tools"
-            /usr/bin/sudo snap install jq
-            /usr/bin/sudo snap install charm --classic --channel=latest/stable
-            /usr/bin/sudo snap install charmcraft --classic --channel=latest/stable
-            /usr/bin/sudo snap install juju-bundle --classic --channel=latest/stable
-            echo "# Install microk8s"
-            /usr/bin/sudo snap install microk8s --classic
-            echo "# Initialize microk8s"
-            /usr/bin/bash -c "sudo usermod -a -G microk8s $USER"
-            /usr/bin/sg microk8s -c "microk8s status --wait-ready"
-            /usr/bin/sg microk8s -c "microk8s enable storage rbac dns:185.125.188.1"
-            /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/coredns"
-            /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/hostpath-provisioner"
-            echo "# Bootstrap controller"
-            sleep 180  # Microk8s needs time to initialize properly
-            /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
-
+  orchestrator-integration-test:
+    name: Integration tests
+    runs-on: integration-testing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        
+      - name: Setup operator environment
+        run: |
+          echo "# Install core snap"
+          /usr/bin/sudo snap install core
+          echo "# Install LXD"
+          /usr/bin/sudo apt-get remove -qy lxd lxd-client || true
+          /usr/bin/sudo snap install lxd
+          echo "# Initialize LXD"
+          /usr/bin/sudo lxd waitready
+          /usr/bin/sudo lxd init --auto
+          /usr/bin/sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
+          /snap/bin/lxc network set lxdbr0 ipv6.address none
+          /usr/bin/sudo usermod -a -G lxd $USER
+          echo "# Configure LXD"
+          /usr/bin/sudo lxc --project charmcraft project create local:charmcraft || true
+          /usr/bin/sudo lxc --project charmcraft profile device add default root disk path=/ pool=default type=disk || true
+          /usr/bin/sudo lxc --project charmcraft profile device add default eth0 nic name=eth0 network=lxdbr0 || true
+          /usr/bin/sudo lxc --project charmcraft profile set default environment.http_proxy http://squid.internal:3128/
+          /usr/bin/sudo lxc --project charmcraft profile set default environment.https_proxy http://squid.internal:3128/
+          /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTP_PROXY http://squid.internal:3128/
+          /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTPS_PROXY http://squid.internal:3128/
+          echo "# Install tox"
+          /usr/bin/sudo apt-get update -yqq
+          /usr/bin/sudo apt-get install -yqq python3-pip
+          /usr/bin/sudo --preserve-env=http_proxy,https_proxy,no_proxy pip3 install tox
+          echo "# Install Juju"
+          /usr/bin/sudo snap install juju --classic --channel=latest/stable
+          echo "# Install tools"
+          /usr/bin/sudo snap install jq
+          /usr/bin/sudo snap install charm --classic --channel=latest/stable
+          /usr/bin/sudo snap install charmcraft --classic --channel=latest/stable
+          /usr/bin/sudo snap install juju-bundle --classic --channel=latest/stable
+          echo "# Install microk8s"
+          /usr/bin/sudo snap install microk8s --classic
+          echo "# Initialize microk8s"
+          /usr/bin/bash -c "sudo usermod -a -G microk8s $USER"
+          /usr/bin/sg microk8s -c "microk8s status --wait-ready"
+          /usr/bin/sg microk8s -c "microk8s enable storage rbac dns:185.125.188.1"
+          /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/coredns"
+          /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/hostpath-provisioner"
+          echo "# Bootstrap controller"
+          sleep 180  # Microk8s needs time to initialize properly
+          /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
       # TODO: Add certifier and certifier-related charms
       - name: Run integration tests
-        run: |
-          set -eux
-          #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
-          charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
-          for charm in ${charms}; do
-            tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
-          done
-
+      run: |
+        set -eux
+        #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
+        charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
+        for charm in ${charms}; do
+          tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
+        done
       - name: Clean up
         if: always()
         run: |

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -109,7 +109,7 @@ jobs:
           #charms="./orchestrator-bundle/orc8r-bootstrapper-operator ./orchestrator-bundle/orc8r-nginx-operator"
           charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
           for charm in ${charms}; do
-            tox -c ./orchestrator-bundle/magma-${charm}-operator -e integration
+            tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
           done
 
       # - name: Integration tests for eventd

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -109,7 +109,8 @@ jobs:
         run: |
           set -eux
           #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
-          charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
+          #charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
+          charms="lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
           for charm in ${charms}; do
             tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
           done

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -112,11 +112,11 @@ jobs:
           #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
           #charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
           charms=" certifier orchestrator bootstrapper nginx"
-          for charm in ${charms}; do
-            tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
-          done
-          tox -c ../orchestrator-bundle/nms-nginx-proxy-operator -e integration
-          tox -c ../orchestrator-bundle/nms-magmalte-operator -e integration
+          #for charm in ${charms}; do
+          #  tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
+          #done
+          tox -c ./orchestrator-bundle/nms-nginx-proxy-operator -e integration
+          tox -c ./orchestrator-bundle/nms-magmalte-operator -e integration
 
       - name: Clean up
         if: always()

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -111,7 +111,7 @@ jobs:
       #       tox -c "${charm}" -e integration
       #     done
 
-      - name: Run integration tests for eventd
+      - name: Integration tests for eventd
         run: |
           set -eux
           tox -c ./orchestrator-bundle/orc8r-eventd-operator -e integration

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -1,114 +1,118 @@
 name: main-branch
 
 on:
-  pull_request:
+  push:
     branches:
-      - main
+      - fix-integration-tests
 
 jobs:
-  orchestrator-lint-report:
-    name: Lint report
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install tox
-        run: pip install tox
-      - name: Run tests using tox
-        run: |
-          set -eux
-          charms="$(find ./orchestrator-bundle/ -name tox.ini)"
-          for charm in ${charms}; do
-            tox -c "${charm}" -e lint
-          done
+  #   orchestrator-lint-report:
+  #     name: Lint report
+  #     runs-on: ubuntu-latest
+  #     steps:
+  #       - uses: actions/checkout@v2
+  #       - name: Install tox
+  #         run: pip install tox
+  #       - name: Run tests using tox
+  #         run: |
+  #           set -eux
+  #           charms="$(find ./orchestrator-bundle/ -name tox.ini)"
+  #           for charm in ${charms}; do
+  #             tox -c "${charm}" -e lint
+  #           done
 
-  orchestrator-static-analysis:
-    name: Static analysis
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install tox
-        run: pip install tox
-      - name: Run tests using tox
-        run: |
-          set -eux
-          charms="$(find ./orchestrator-bundle/ -name tox.ini)"
-          for charm in ${charms}; do
-            tox -c "${charm}" -e static
-          done
+  #   orchestrator-static-analysis:
+  #     name: Static analysis
+  #     runs-on: ubuntu-latest
+  #     steps:
+  #       - uses: actions/checkout@v2
+  #       - name: Install tox
+  #         run: pip install tox
+  #       - name: Run tests using tox
+  #         run: |
+  #           set -eux
+  #           charms="$(find ./orchestrator-bundle/ -name tox.ini)"
+  #           for charm in ${charms}; do
+  #             tox -c "${charm}" -e static
+  #           done
 
-  orchestrator-unit-tests-with-coverage:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install tox
-        run: pip install tox
-      - name: Run tests using tox
-        run: |
-          set -eux
-          charms="$(find ./orchestrator-bundle/ -name tox.ini)"
-          for charm in ${charms}; do
-            tox -c "${charm}" -e unit
-          done
+  #   orchestrator-unit-tests-with-coverage:
+  #     name: Unit tests
+  #     runs-on: ubuntu-latest
+  #     steps:
+  #       - uses: actions/checkout@v2
+  #       - name: Install tox
+  #         run: pip install tox
+  #       - name: Run tests using tox
+  #         run: |
+  #           set -eux
+  #           charms="$(find ./orchestrator-bundle/ -name tox.ini)"
+  #           for charm in ${charms}; do
+  #             tox -c "${charm}" -e unit
+  #           done
 
   orchestrator-integration-test:
     name: Integration tests
-    runs-on: standalone
+    runs-on: integration-testing
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup operator environment
+
+      - name: Say hello
         run: |
-          echo "# Install core snap"
-          /usr/bin/sudo snap install core
-          echo "# Install LXD"
-          /usr/bin/sudo apt-get remove -qy lxd lxd-client || true
-          /usr/bin/sudo snap install lxd
-          echo "# Initialize LXD"
-          /usr/bin/sudo lxd waitready
-          /usr/bin/sudo lxd init --auto
-          /usr/bin/sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
-          /snap/bin/lxc network set lxdbr0 ipv6.address none
-          /usr/bin/sudo usermod -a -G lxd $USER
-          echo "# Configure LXD"
-          /usr/bin/sudo lxc --project charmcraft project create local:charmcraft || true
-          /usr/bin/sudo lxc --project charmcraft profile device add default root disk path=/ pool=default type=disk || true
-          /usr/bin/sudo lxc --project charmcraft profile device add default eth0 nic name=eth0 network=lxdbr0 || true
-          /usr/bin/sudo lxc --project charmcraft profile set default environment.http_proxy http://squid.internal:3128/
-          /usr/bin/sudo lxc --project charmcraft profile set default environment.https_proxy http://squid.internal:3128/
-          /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTP_PROXY http://squid.internal:3128/
-          /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTPS_PROXY http://squid.internal:3128/
-          echo "# Install tox"
-          /usr/bin/sudo apt-get update -yqq
-          /usr/bin/sudo apt-get install -yqq python3-pip
-          /usr/bin/sudo --preserve-env=http_proxy,https_proxy,no_proxy pip3 install tox
-          echo "# Install Juju"
-          /usr/bin/sudo snap install juju --classic --channel=latest/stable
-          echo "# Install tools"
-          /usr/bin/sudo snap install jq
-          /usr/bin/sudo snap install charm --classic --channel=latest/stable
-          /usr/bin/sudo snap install charmcraft --classic --channel=latest/stable
-          /usr/bin/sudo snap install juju-bundle --classic --channel=latest/stable
-          echo "# Install microk8s"
-          /usr/bin/sudo snap install microk8s --classic
-          echo "# Initialize microk8s"
-          /usr/bin/bash -c "sudo usermod -a -G microk8s $USER"
-          /usr/bin/sg microk8s -c "microk8s status --wait-ready"
-          /usr/bin/sg microk8s -c "microk8s enable storage rbac dns:185.125.188.1"
-          /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/coredns"
-          /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/hostpath-provisioner"
-          echo "# Bootstrap controller"
-          sleep 180  # Microk8s needs time to initialize properly
-          /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests-${GITHUB_RUN_ID} --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
-      - name: Run integration tests
-        run: |
-          set -eux
-          #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
-          charms="./orchestrator-bundle/orc8r-bootstrapper-operator ./orchestrator-bundle/orc8r-nginx-operator"
-          for charm in ${charms}; do
-            tox -c "${charm}" -e integration
-          done
-      - name: Clean up
-        if: always()
-        run: |
-          yes | juju kill-controller integration-tests-${GITHUB_RUN_ID}
+          echo "Hello I'm the runner from prodstack"
+      # - name: Setup operator environment
+      #   run: |
+      #     echo "# Install core snap"
+      #     /usr/bin/sudo snap install core
+      #     echo "# Install LXD"
+      #     /usr/bin/sudo apt-get remove -qy lxd lxd-client || true
+      #     /usr/bin/sudo snap install lxd
+      #     echo "# Initialize LXD"
+      #     /usr/bin/sudo lxd waitready
+      #     /usr/bin/sudo lxd init --auto
+      #     /usr/bin/sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
+      #     /snap/bin/lxc network set lxdbr0 ipv6.address none
+      #     /usr/bin/sudo usermod -a -G lxd $USER
+      #     echo "# Configure LXD"
+      #     /usr/bin/sudo lxc --project charmcraft project create local:charmcraft || true
+      #     /usr/bin/sudo lxc --project charmcraft profile device add default root disk path=/ pool=default type=disk || true
+      #     /usr/bin/sudo lxc --project charmcraft profile device add default eth0 nic name=eth0 network=lxdbr0 || true
+      #     /usr/bin/sudo lxc --project charmcraft profile set default environment.http_proxy http://squid.internal:3128/
+      #     /usr/bin/sudo lxc --project charmcraft profile set default environment.https_proxy http://squid.internal:3128/
+      #     /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTP_PROXY http://squid.internal:3128/
+      #     /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTPS_PROXY http://squid.internal:3128/
+      #     echo "# Install tox"
+      #     /usr/bin/sudo apt-get update -yqq
+      #     /usr/bin/sudo apt-get install -yqq python3-pip
+      #     /usr/bin/sudo --preserve-env=http_proxy,https_proxy,no_proxy pip3 install tox
+      #     echo "# Install Juju"
+      #     /usr/bin/sudo snap install juju --classic --channel=latest/stable
+      #     echo "# Install tools"
+      #     /usr/bin/sudo snap install jq
+      #     /usr/bin/sudo snap install charm --classic --channel=latest/stable
+      #     /usr/bin/sudo snap install charmcraft --classic --channel=latest/stable
+      #     /usr/bin/sudo snap install juju-bundle --classic --channel=latest/stable
+      #     echo "# Install microk8s"
+      #     /usr/bin/sudo snap install microk8s --classic
+      #     echo "# Initialize microk8s"
+      #     /usr/bin/bash -c "sudo usermod -a -G microk8s $USER"
+      #     /usr/bin/sg microk8s -c "microk8s status --wait-ready"
+      #     /usr/bin/sg microk8s -c "microk8s enable storage rbac dns:185.125.188.1"
+      #     /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/coredns"
+      #     /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/hostpath-provisioner"
+      #     echo "# Bootstrap controller"
+      #     sleep 180  # Microk8s needs time to initialize properly
+      #     /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests-${GITHUB_RUN_ID} --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
+      # - name: Run integration tests
+      #   run: |
+      #     set -eux
+      #     #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
+      #     charms="./orchestrator-bundle/orc8r-bootstrapper-operator ./orchestrator-bundle/orc8r-nginx-operator"
+      #     for charm in ${charms}; do
+      #       tox -c "${charm}" -e integration
+      #     done
+      # - name: Clean up
+      #   if: always()
+      #   run: |
+      #     yes | juju kill-controller integration-tests-${GITHUB_RUN_ID}

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -108,6 +108,7 @@ jobs:
           #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
           #charms="./orchestrator-bundle/orc8r-bootstrapper-operator ./orchestrator-bundle/orc8r-nginx-operator"
           charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
+
           for charm in ${charms}; do
             tox -c "./orchestrator-bundle/magma-${charm}-operator" -e integration
           done

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -102,7 +102,8 @@ jobs:
           sleep 180  # Microk8s needs time to initialize properly
           /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
           # Install dependencies
-          /usr/bin/sudo sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
+          /usr/bin/sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
+          /usr/bin/sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libffi-dev=3.3-4 libssh2-1=1.8.0-2.1build1 libssl-dev=1.1.1f-1ubuntu2.13 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1
 
       # TODO: Add certifier and certifier-related charms
       - name: Run integration tests.

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -1,55 +1,55 @@
 name: main-branch
 
 on:
-  push:
+  pull_request:
     branches:
-      - fix-integration-tests
+      - main
 
 jobs:
-  # orchestrator-lint-report:
-  #   name: Lint report
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install tox
-  #       run: pip install tox
-  #     - name: Run tests using tox
-  #       run: |
-  #         set -eux
-  #         charms="$(find ./orchestrator-bundle/ -name tox.ini)"
-  #         for charm in ${charms}; do
-  #           tox -c "${charm}" -e lint
-  #         done
+  orchestrator-lint-report:
+    name: Lint report
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install tox
+        run: pip install tox
+      - name: Run tests using tox
+        run: |
+          set -eux
+          charms="$(find ./orchestrator-bundle/ -name tox.ini)"
+          for charm in ${charms}; do
+            tox -c "${charm}" -e lint
+          done
 
-  # orchestrator-static-analysis:
-  #   name: Static analysis
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install tox
-  #       run: pip install tox
-  #     - name: Run tests using tox
-  #       run: |
-  #         set -eux
-  #         charms="$(find ./orchestrator-bundle/ -name tox.ini)"
-  #         for charm in ${charms}; do
-  #           tox -c "${charm}" -e static
-  #         done
+  orchestrator-static-analysis:
+    name: Static analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install tox
+        run: pip install tox
+      - name: Run tests using tox
+        run: |
+          set -eux
+          charms="$(find ./orchestrator-bundle/ -name tox.ini)"
+          for charm in ${charms}; do
+            tox -c "${charm}" -e static
+          done
 
-  # orchestrator-unit-tests-with-coverage:
-  #   name: Unit tests
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install tox
-  #       run: pip install tox
-  #     - name: Run tests using tox
-  #       run: |
-  #         set -eux
-  #         charms="$(find ./orchestrator-bundle/ -name tox.ini)"
-  #         for charm in ${charms}; do
-  #           tox -c "${charm}" -e unit
-  #         done
+  orchestrator-unit-tests-with-coverage:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install tox
+        run: pip install tox
+      - name: Run tests using tox
+        run: |
+          set -eux
+          charms="$(find ./orchestrator-bundle/ -name tox.ini)"
+          for charm in ${charms}; do
+            tox -c "${charm}" -e unit
+          done
 
   orchestrator-integration-test:
     name: Integration tests

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -112,7 +112,7 @@ jobs:
             tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
           done
 
-      # - name: Integration tests for eventd
+      # - name: Integration tests for one charm
       #   run: |
       #     set -eux
       #     tox -c ./orchestrator-bundle/orc8r-eventd-operator -e integration

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -104,7 +104,7 @@ jobs:
           # Install dependencies
           /usr/bin/sudo sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
 
-      # TODO: Add certifier and certifier-related charms.
+      # TODO: Add certifier and certifier-related charms
       - name: Run integration tests
         run: |
           set -eux

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -105,13 +105,12 @@ jobs:
           /usr/bin/sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
           /usr/bin/sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libffi-dev=3.3-4 libssh2-1=1.8.0-2.1build1 libssl-dev=1.1.1f-1ubuntu2.13 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1
 
-      # TODO: Add certifier and certifier-related charms.
       - name: Run integration tests.
         run: |
           set -eux
           charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
           for charm in ${charms}; do
-            tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
+            tox -c "${charm}" -e integration
           done
 
       - name: Clean up

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -53,7 +53,7 @@ jobs:
 
   orchestrator-integration-test:
     name: Integration tests
-    runs-on: integration-testing
+    runs-on: prodstack-github-runner
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -113,6 +113,7 @@ jobs:
           for charm in ${charms}; do
             tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
           done
+
       - name: Clean up
         if: always()
         run: |

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -110,10 +110,13 @@ jobs:
         run: |
           set -eux
           #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
-          charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
+          #charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
+          charms=" certifier orchestrator bootstrapper nginx"
           for charm in ${charms}; do
             tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
           done
+          tox -c ../orchestrator-bundle/nms-nginx-proxy-operator -e integration
+          tox -c ../orchestrator-bundle/nms-magmalte-operator -e integration
 
       - name: Clean up
         if: always()

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -110,7 +110,7 @@ jobs:
           charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
 
           for charm in ${charms}; do
-            tox -c "./orchestrator-bundle/magma-${charm}-operator" -e integration
+            tox -c ./orchestrator-bundle/magma-${charm}-operator -e integration
           done
 
       # - name: Integration tests for eventd

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -110,8 +110,7 @@ jobs:
           set -eux
           #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
           #charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
-          #charms="lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
-          charms="metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
+          charms="lte"
           for charm in ${charms}; do
             tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
           done

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -101,6 +101,7 @@ jobs:
       #     echo "# Bootstrap controller"
       #     sleep 180  # Microk8s needs time to initialize properly
       #     /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests-${GITHUB_RUN_ID} --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
+
       # - name: Run integration tests
       #   run: |
       #     set -eux
@@ -109,6 +110,7 @@ jobs:
       #     for charm in ${charms}; do
       #       tox -c "${charm}" -e integration
       #     done
+
       - name: Run integration tests for eventd
         run: |
           set -eux

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -101,6 +101,8 @@ jobs:
           echo "# Bootstrap controller"
           sleep 180  # Microk8s needs time to initialize properly
           /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
+          # Install dependencies
+          /usr/bin/sudo apt-get install -yqq python3-pip
 
       # TODO: Add certifier and certifier-related charms
       - name: Run integration tests

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -1,4 +1,4 @@
-name: orc8r
+name: main-branch
 
 on:
   pull_request:
@@ -51,20 +51,64 @@ jobs:
             tox -c "${charm}" -e unit
           done
 
-#  orchestrator-integration-test:
-#    name: Integration tests
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v2
-#      - name: Setup operator environment
-#        uses: charmed-kubernetes/actions-operator@main
-#        with:
-#          provider: microk8s
-#      - name: Run integration tests
-#        run: |
-#          set -eux
-#          charms="$(find ./orchestrator-bundle/ -name tox.ini)"
-#          for charm in ${charms}; do
-#            tox -c "${charm}" -e integration
-#          done
+  orchestrator-integration-test:
+    name: Integration tests
+    runs-on: standalone
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup operator environment
+        run: |
+          echo "# Install core snap"
+          /usr/bin/sudo snap install core
+          echo "# Install LXD"
+          /usr/bin/sudo apt-get remove -qy lxd lxd-client || true
+          /usr/bin/sudo snap install lxd
+          echo "# Initialize LXD"
+          /usr/bin/sudo lxd waitready
+          /usr/bin/sudo lxd init --auto
+          /usr/bin/sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
+          /snap/bin/lxc network set lxdbr0 ipv6.address none
+          /usr/bin/sudo usermod -a -G lxd $USER
+          echo "# Configure LXD"
+          /usr/bin/sudo lxc --project charmcraft project create local:charmcraft || true
+          /usr/bin/sudo lxc --project charmcraft profile device add default root disk path=/ pool=default type=disk || true
+          /usr/bin/sudo lxc --project charmcraft profile device add default eth0 nic name=eth0 network=lxdbr0 || true
+          /usr/bin/sudo lxc --project charmcraft profile set default environment.http_proxy http://squid.internal:3128/
+          /usr/bin/sudo lxc --project charmcraft profile set default environment.https_proxy http://squid.internal:3128/
+          /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTP_PROXY http://squid.internal:3128/
+          /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTPS_PROXY http://squid.internal:3128/
+          echo "# Install tox"
+          /usr/bin/sudo apt-get update -yqq
+          /usr/bin/sudo apt-get install -yqq python3-pip
+          /usr/bin/sudo --preserve-env=http_proxy,https_proxy,no_proxy pip3 install tox
+          echo "# Install Juju"
+          /usr/bin/sudo snap install juju --classic --channel=latest/stable
+          echo "# Install tools"
+          /usr/bin/sudo snap install jq
+          /usr/bin/sudo snap install charm --classic --channel=latest/stable
+          /usr/bin/sudo snap install charmcraft --classic --channel=latest/stable
+          /usr/bin/sudo snap install juju-bundle --classic --channel=latest/stable
+          echo "# Install microk8s"
+          /usr/bin/sudo snap install microk8s --classic
+          echo "# Initialize microk8s"
+          /usr/bin/bash -c "sudo usermod -a -G microk8s $USER"
+          /usr/bin/sg microk8s -c "microk8s status --wait-ready"
+          /usr/bin/sg microk8s -c "microk8s enable storage rbac dns:185.125.188.1"
+          /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/coredns"
+          /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/hostpath-provisioner"
+          echo "# Bootstrap controller"
+          sleep 180  # Microk8s needs time to initialize properly
+          /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests-${GITHUB_RUN_ID} --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
+      - name: Run integration tests
+        run: |
+          set -eux
+          #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
+          charms="./orchestrator-bundle/orc8r-bootstrapper-operator ./orchestrator-bundle/orc8r-nginx-operator"
+          for charm in ${charms}; do
+            tox -c "${charm}" -e integration
+          done
+      - name: Clean up
+        if: always()
+        run: |
+          yes | juju kill-controller integration-tests-${GITHUB_RUN_ID}

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -110,7 +110,8 @@ jobs:
           set -eux
           #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
           #charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
-          charms="lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
+          #charms="lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
+          charms="metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
           for charm in ${charms}; do
             tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
           done

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -58,49 +58,49 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      # - name: Setup operator environment
-      #   run: |
-      #     echo "# Install core snap"
-      #     /usr/bin/sudo snap install core
-      #     echo "# Install LXD"
-      #     /usr/bin/sudo apt-get remove -qy lxd lxd-client || true
-      #     /usr/bin/sudo snap install lxd
-      #     echo "# Initialize LXD"
-      #     /usr/bin/sudo lxd waitready
-      #     /usr/bin/sudo lxd init --auto
-      #     /usr/bin/sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
-      #     /snap/bin/lxc network set lxdbr0 ipv6.address none
-      #     /usr/bin/sudo usermod -a -G lxd $USER
-      #     echo "# Configure LXD"
-      #     /usr/bin/sudo lxc --project charmcraft project create local:charmcraft || true
-      #     /usr/bin/sudo lxc --project charmcraft profile device add default root disk path=/ pool=default type=disk || true
-      #     /usr/bin/sudo lxc --project charmcraft profile device add default eth0 nic name=eth0 network=lxdbr0 || true
-      #     /usr/bin/sudo lxc --project charmcraft profile set default environment.http_proxy http://squid.internal:3128/
-      #     /usr/bin/sudo lxc --project charmcraft profile set default environment.https_proxy http://squid.internal:3128/
-      #     /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTP_PROXY http://squid.internal:3128/
-      #     /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTPS_PROXY http://squid.internal:3128/
-      #     echo "# Install tox"
-      #     /usr/bin/sudo apt-get update -yqq
-      #     /usr/bin/sudo apt-get install -yqq python3-pip
-      #     /usr/bin/sudo --preserve-env=http_proxy,https_proxy,no_proxy pip3 install tox
-      #     echo "# Install Juju"
-      #     /usr/bin/sudo snap install juju --classic --channel=latest/stable
-      #     echo "# Install tools"
-      #     /usr/bin/sudo snap install jq
-      #     /usr/bin/sudo snap install charm --classic --channel=latest/stable
-      #     /usr/bin/sudo snap install charmcraft --classic --channel=latest/stable
-      #     /usr/bin/sudo snap install juju-bundle --classic --channel=latest/stable
-      #     echo "# Install microk8s"
-      #     /usr/bin/sudo snap install microk8s --classic
-      #     echo "# Initialize microk8s"
-      #     /usr/bin/bash -c "sudo usermod -a -G microk8s $USER"
-      #     /usr/bin/sg microk8s -c "microk8s status --wait-ready"
-      #     /usr/bin/sg microk8s -c "microk8s enable storage rbac dns:185.125.188.1"
-      #     /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/coredns"
-      #     /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/hostpath-provisioner"
-      #     echo "# Bootstrap controller"
-      #     sleep 180  # Microk8s needs time to initialize properly
-      #     /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests-${GITHUB_RUN_ID} --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
+      - name: Setup operator environment
+        run: |
+          echo "# Install core snap"
+          /usr/bin/sudo snap install core
+          echo "# Install LXD"
+          /usr/bin/sudo apt-get remove -qy lxd lxd-client || true
+          /usr/bin/sudo snap install lxd
+          echo "# Initialize LXD"
+          /usr/bin/sudo lxd waitready
+          /usr/bin/sudo lxd init --auto
+          /usr/bin/sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
+          /snap/bin/lxc network set lxdbr0 ipv6.address none
+          /usr/bin/sudo usermod -a -G lxd $USER
+          echo "# Configure LXD"
+          /usr/bin/sudo lxc --project charmcraft project create local:charmcraft || true
+          /usr/bin/sudo lxc --project charmcraft profile device add default root disk path=/ pool=default type=disk || true
+          /usr/bin/sudo lxc --project charmcraft profile device add default eth0 nic name=eth0 network=lxdbr0 || true
+          /usr/bin/sudo lxc --project charmcraft profile set default environment.http_proxy http://squid.internal:3128/
+          /usr/bin/sudo lxc --project charmcraft profile set default environment.https_proxy http://squid.internal:3128/
+          /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTP_PROXY http://squid.internal:3128/
+          /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTPS_PROXY http://squid.internal:3128/
+          echo "# Install tox"
+          /usr/bin/sudo apt-get update -yqq
+          /usr/bin/sudo apt-get install -yqq python3-pip
+          /usr/bin/sudo --preserve-env=http_proxy,https_proxy,no_proxy pip3 install tox
+          echo "# Install Juju"
+          /usr/bin/sudo snap install juju --classic --channel=latest/stable
+          echo "# Install tools"
+          /usr/bin/sudo snap install jq
+          /usr/bin/sudo snap install charm --classic --channel=latest/stable
+          /usr/bin/sudo snap install charmcraft --classic --channel=latest/stable
+          /usr/bin/sudo snap install juju-bundle --classic --channel=latest/stable
+          echo "# Install microk8s"
+          /usr/bin/sudo snap install microk8s --classic
+          echo "# Initialize microk8s"
+          /usr/bin/bash -c "sudo usermod -a -G microk8s $USER"
+          /usr/bin/sg microk8s -c "microk8s status --wait-ready"
+          /usr/bin/sg microk8s -c "microk8s enable storage rbac dns:185.125.188.1"
+          /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/coredns"
+          /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/hostpath-provisioner"
+          echo "# Bootstrap controller"
+          sleep 180  # Microk8s needs time to initialize properly
+          /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
 
       # - name: Run integration tests
       #   run: |
@@ -116,7 +116,7 @@ jobs:
           set -eux
           tox -c ./orchestrator-bundle/orc8r-eventd-operator -e integration
 
-      # - name: Clean up
-      #   if: always()
-      #   run: |
-      #     yes | juju kill-controller integration-tests-${GITHUB_RUN_ID}
+      - name: Clean up
+        if: always()
+        run: |
+          yes | juju kill-controller integration-tests

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -101,17 +101,22 @@ jobs:
           echo "# Bootstrap controller"
           sleep 180  # Microk8s needs time to initialize properly
           /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
-          # Install dependencies
-          /usr/bin/sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
-          /usr/bin/sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libffi-dev=3.3-4 libssh2-1=1.8.0-2.1build1 libssl-dev=1.1.1f-1ubuntu2.13 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1
+
+      # - name: Run integration tests.
+      #   run: |
+      #     set -eux
+      #     charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
+      #     for charm in ${charms}; do
+      #       tox -c "${charm}" -e integration
+      #     done
 
       - name: Run integration tests.
         run: |
           set -eux
-          charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
-          for charm in ${charms}; do
-            tox -c "${charm}" -e integration
-          done
+          ./update_libs.sh
+          ./build.sh
+          ./deploy.sh
+          tox -c "./orchestrator-bundle/orc8r-bundle/tox.ini -e" integration
 
       - name: Clean up
         if: always()

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -104,7 +104,7 @@ jobs:
           # Install dependencies
           /usr/bin/sudo sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
 
-      # TODO: Add certifier and certifier-related charms
+      # TODO: Add certifier and certifier-related charms.
       - name: Run integration tests
         run: |
           set -eux

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -6,116 +6,111 @@ on:
       - fix-integration-tests
 
 jobs:
-  #   orchestrator-lint-report:
-  #     name: Lint report
-  #     runs-on: ubuntu-latest
-  #     steps:
-  #       - uses: actions/checkout@v2
-  #       - name: Install tox
-  #         run: pip install tox
-  #       - name: Run tests using tox
-  #         run: |
-  #           set -eux
-  #           charms="$(find ./orchestrator-bundle/ -name tox.ini)"
-  #           for charm in ${charms}; do
-  #             tox -c "${charm}" -e lint
-  #           done
+    # orchestrator-lint-report:
+    #   name: Lint report
+    #   runs-on: ubuntu-latest
+    #   steps:
+    #     - uses: actions/checkout@v2
+    #     - name: Install tox
+    #       run: pip install tox
+    #     - name: Run tests using tox
+    #       run: |
+    #         set -eux
+    #         charms="$(find ./orchestrator-bundle/ -name tox.ini)"
+    #         for charm in ${charms}; do
+    #           tox -c "${charm}" -e lint
+    #         done
 
-  #   orchestrator-static-analysis:
-  #     name: Static analysis
-  #     runs-on: ubuntu-latest
-  #     steps:
-  #       - uses: actions/checkout@v2
-  #       - name: Install tox
-  #         run: pip install tox
-  #       - name: Run tests using tox
-  #         run: |
-  #           set -eux
-  #           charms="$(find ./orchestrator-bundle/ -name tox.ini)"
-  #           for charm in ${charms}; do
-  #             tox -c "${charm}" -e static
-  #           done
+    # orchestrator-static-analysis:
+    #   name: Static analysis
+    #   runs-on: ubuntu-latest
+    #   steps:
+    #     - uses: actions/checkout@v2
+    #     - name: Install tox
+    #       run: pip install tox
+    #     - name: Run tests using tox
+    #       run: |
+    #         set -eux
+    #         charms="$(find ./orchestrator-bundle/ -name tox.ini)"
+    #         for charm in ${charms}; do
+    #           tox -c "${charm}" -e static
+    #         done
 
-  #   orchestrator-unit-tests-with-coverage:
-  #     name: Unit tests
-  #     runs-on: ubuntu-latest
-  #     steps:
-  #       - uses: actions/checkout@v2
-  #       - name: Install tox
-  #         run: pip install tox
-  #       - name: Run tests using tox
-  #         run: |
-  #           set -eux
-  #           charms="$(find ./orchestrator-bundle/ -name tox.ini)"
-  #           for charm in ${charms}; do
-  #             tox -c "${charm}" -e unit
-  #           done
+    # orchestrator-unit-tests-with-coverage:
+    #   name: Unit tests
+    #   runs-on: ubuntu-latest
+    #   steps:
+    #     - uses: actions/checkout@v2
+    #     - name: Install tox
+    #       run: pip install tox
+    #     - name: Run tests using tox
+    #       run: |
+    #         set -eux
+    #         charms="$(find ./orchestrator-bundle/ -name tox.ini)"
+    #         for charm in ${charms}; do
+    #           tox -c "${charm}" -e unit
+    #         done
 
-  orchestrator-integration-test:
-    name: Integration tests
-    runs-on: integration-testing
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+    orchestrator-integration-test:
+      name: Integration tests
+      runs-on: integration-testing
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+          
+        - name: Setup operator environment
+          run: |
+            echo "# Install core snap"
+            /usr/bin/sudo snap install core
+            echo "# Install LXD"
+            /usr/bin/sudo apt-get remove -qy lxd lxd-client || true
+            /usr/bin/sudo snap install lxd
+            echo "# Initialize LXD"
+            /usr/bin/sudo lxd waitready
+            /usr/bin/sudo lxd init --auto
+            /usr/bin/sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
+            /snap/bin/lxc network set lxdbr0 ipv6.address none
+            /usr/bin/sudo usermod -a -G lxd $USER
+            echo "# Configure LXD"
+            /usr/bin/sudo lxc --project charmcraft project create local:charmcraft || true
+            /usr/bin/sudo lxc --project charmcraft profile device add default root disk path=/ pool=default type=disk || true
+            /usr/bin/sudo lxc --project charmcraft profile device add default eth0 nic name=eth0 network=lxdbr0 || true
+            /usr/bin/sudo lxc --project charmcraft profile set default environment.http_proxy http://squid.internal:3128/
+            /usr/bin/sudo lxc --project charmcraft profile set default environment.https_proxy http://squid.internal:3128/
+            /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTP_PROXY http://squid.internal:3128/
+            /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTPS_PROXY http://squid.internal:3128/
+            echo "# Install tox"
+            /usr/bin/sudo apt-get update -yqq
+            /usr/bin/sudo apt-get install -yqq python3-pip
+            /usr/bin/sudo --preserve-env=http_proxy,https_proxy,no_proxy pip3 install tox
+            echo "# Install Juju"
+            /usr/bin/sudo snap install juju --classic --channel=latest/stable
+            echo "# Install tools"
+            /usr/bin/sudo snap install jq
+            /usr/bin/sudo snap install charm --classic --channel=latest/stable
+            /usr/bin/sudo snap install charmcraft --classic --channel=latest/stable
+            /usr/bin/sudo snap install juju-bundle --classic --channel=latest/stable
+            echo "# Install microk8s"
+            /usr/bin/sudo snap install microk8s --classic
+            echo "# Initialize microk8s"
+            /usr/bin/bash -c "sudo usermod -a -G microk8s $USER"
+            /usr/bin/sg microk8s -c "microk8s status --wait-ready"
+            /usr/bin/sg microk8s -c "microk8s enable storage rbac dns:185.125.188.1"
+            /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/coredns"
+            /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/hostpath-provisioner"
+            echo "# Bootstrap controller"
+            sleep 180  # Microk8s needs time to initialize properly
+            /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
 
-      - name: Setup operator environment
-        run: |
-          echo "# Install core snap"
-          /usr/bin/sudo snap install core
-          echo "# Install LXD"
-          /usr/bin/sudo apt-get remove -qy lxd lxd-client || true
-          /usr/bin/sudo snap install lxd
-          echo "# Initialize LXD"
-          /usr/bin/sudo lxd waitready
-          /usr/bin/sudo lxd init --auto
-          /usr/bin/sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
-          /snap/bin/lxc network set lxdbr0 ipv6.address none
-          /usr/bin/sudo usermod -a -G lxd $USER
-          echo "# Configure LXD"
-          /usr/bin/sudo lxc --project charmcraft project create local:charmcraft || true
-          /usr/bin/sudo lxc --project charmcraft profile device add default root disk path=/ pool=default type=disk || true
-          /usr/bin/sudo lxc --project charmcraft profile device add default eth0 nic name=eth0 network=lxdbr0 || true
-          /usr/bin/sudo lxc --project charmcraft profile set default environment.http_proxy http://squid.internal:3128/
-          /usr/bin/sudo lxc --project charmcraft profile set default environment.https_proxy http://squid.internal:3128/
-          /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTP_PROXY http://squid.internal:3128/
-          /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTPS_PROXY http://squid.internal:3128/
-          echo "# Install tox"
-          /usr/bin/sudo apt-get update -yqq
-          /usr/bin/sudo apt-get install -yqq python3-pip
-          /usr/bin/sudo --preserve-env=http_proxy,https_proxy,no_proxy pip3 install tox
-          echo "# Install Juju"
-          /usr/bin/sudo snap install juju --classic --channel=latest/stable
-          echo "# Install tools"
-          /usr/bin/sudo snap install jq
-          /usr/bin/sudo snap install charm --classic --channel=latest/stable
-          /usr/bin/sudo snap install charmcraft --classic --channel=latest/stable
-          /usr/bin/sudo snap install juju-bundle --classic --channel=latest/stable
-          echo "# Install microk8s"
-          /usr/bin/sudo snap install microk8s --classic
-          echo "# Initialize microk8s"
-          /usr/bin/bash -c "sudo usermod -a -G microk8s $USER"
-          /usr/bin/sg microk8s -c "microk8s status --wait-ready"
-          /usr/bin/sg microk8s -c "microk8s enable storage rbac dns:185.125.188.1"
-          /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/coredns"
-          /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/hostpath-provisioner"
-          echo "# Bootstrap controller"
-          sleep 180  # Microk8s needs time to initialize properly
-          /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
-
+      # TODO: Add certifier and certifier-related charms
       - name: Run integration tests
         run: |
           set -eux
           #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
-          #charms="./orchestrator-bundle/orc8r-bootstrapper-operator ./orchestrator-bundle/orc8r-nginx-operator"
           charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
           for charm in ${charms}; do
             tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
           done
-
-      # - name: Integration tests for one charm
-      #   run: |
-      #     set -eux
-      #     tox -c ./orchestrator-bundle/orc8r-eventd-operator -e integration
 
       - name: Clean up
         if: always()

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -58,9 +58,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Say hello
-        run: |
-          echo "Hello I'm the runner from prodstack"
       # - name: Setup operator environment
       #   run: |
       #     echo "# Install core snap"
@@ -112,6 +109,11 @@ jobs:
       #     for charm in ${charms}; do
       #       tox -c "${charm}" -e integration
       #     done
+      - name: Run integration tests for eventd
+        run: |
+          set -eux
+          tox -c ./orchestrator-bundle/orc8r-eventd-operator -e integration
+
       # - name: Clean up
       #   if: always()
       #   run: |

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -102,19 +102,20 @@ jobs:
           sleep 180  # Microk8s needs time to initialize properly
           /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
 
-      # - name: Run integration tests
-      #   run: |
-      #     set -eux
-      #     #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
-      #     charms="./orchestrator-bundle/orc8r-bootstrapper-operator ./orchestrator-bundle/orc8r-nginx-operator"
-      #     for charm in ${charms}; do
-      #       tox -c "${charm}" -e integration
-      #     done
-
-      - name: Integration tests for eventd
+      - name: Run integration tests
         run: |
           set -eux
-          tox -c ./orchestrator-bundle/orc8r-eventd-operator -e integration
+          #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
+          #charms="./orchestrator-bundle/orc8r-bootstrapper-operator ./orchestrator-bundle/orc8r-nginx-operator"
+          charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
+          for charm in ${charms}; do
+            tox -c "./orchestrator-bundle/magma-${charm}-operator" -e integration
+          done
+
+      # - name: Integration tests for eventd
+      #   run: |
+      #     set -eux
+      #     tox -c ./orchestrator-bundle/orc8r-eventd-operator -e integration
 
       - name: Clean up
         if: always()

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -109,14 +109,10 @@ jobs:
       - name: Run integration tests.
         run: |
           set -eux
-          #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
-          #charms="accessd analytics configurator ctraced device directoryd dispatcher eventd ha lte metricsd obsidian smsd state streamer subscriberdb subscriberdb-cache tenants"
-          charms=" certifier orchestrator bootstrapper nginx"
-          #for charm in ${charms}; do
-          #  tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
-          #done
-          tox -c ./orchestrator-bundle/nms-nginx-proxy-operator -e integration
-          tox -c ./orchestrator-bundle/nms-magmalte-operator -e integration
+          charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
+          for charm in ${charms}; do
+            tox -c ./orchestrator-bundle/orc8r-${charm}-operator -e integration
+          done
 
       - name: Clean up
         if: always()

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -105,7 +105,7 @@ jobs:
           /usr/bin/sudo sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
 
       # TODO: Add certifier and certifier-related charms
-      - name: Run integration tests
+      - name: Run integration tests.
         run: |
           set -eux
           #charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -102,7 +102,7 @@ jobs:
           sleep 180  # Microk8s needs time to initialize properly
           /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
           # Install dependencies
-          /usr/bin/sudo apt-get install -yqq python3-pip
+          /usr/bin/sudo sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
 
       # TODO: Add certifier and certifier-related charms
       - name: Run integration tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.idea
+.vscode/

--- a/orchestrator-bundle/build.sh
+++ b/orchestrator-bundle/build.sh
@@ -8,6 +8,7 @@ function build() {
     charmcraft pack $DESTRUCTIVE_MODE
     mv "magma-${charm}_ubuntu-20.04-amd64.charm" "${charm}.charm"
     eval $MOVE_TO_DIR
+    popd
 }
 
 charms="

--- a/orchestrator-bundle/build.sh
+++ b/orchestrator-bundle/build.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eo pipefail
 
 function build() {
   charm="$1"
     pushd "${charm}-operator/"
     charmcraft pack $DESTRUCTIVE_MODE
     mv "magma-${charm}_ubuntu-20.04-amd64.charm" "${charm}.charm"
-    $MOVE_CHAMS_TO_DIR
-    popd
+    eval $MOVE_TO_DIR
 }
 
 charms="

--- a/orchestrator-bundle/build.sh
+++ b/orchestrator-bundle/build.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 function build() {
   charm="$1"
     pushd "${charm}-operator/"
-    charmcraft pack
+    charmcraft pack $DESTRUCTIVE_MODE
     mv "magma-${charm}_ubuntu-20.04-amd64.charm" "${charm}.charm"
+    $MOVE_CHAMS_TO_DIR
     popd
 }
 

--- a/orchestrator-bundle/nms-magmalte-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/nms-magmalte-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -35,10 +34,10 @@ class TestNmsMagmaLTE:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )
-        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="orc8r-certifier:certifier"
         )
@@ -64,7 +63,9 @@ class TestNmsMagmaLTE:
             config={"domain": "example.com"},
             trust=True,
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(
+            apps=[CERTIFIER_APPLICATION_NAME], status="blocked", timeout=1000
+        )
         await ops_test.model.add_relation(
             relation1=CERTIFIER_APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/nms-magmalte-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/nms-magmalte-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401

--- a/orchestrator-bundle/nms-magmalte-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/nms-magmalte-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -37,6 +38,7 @@ class TestNmsMagmaLTE:
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="orc8r-certifier:certifier"
         )
@@ -62,6 +64,7 @@ class TestNmsMagmaLTE:
             config={"domain": "example.com"},
             trust=True,
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=CERTIFIER_APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/nms-magmalte-operator/tox.ini
+++ b/orchestrator-bundle/nms-magmalte-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/nms-magmalte-operator/tox.ini
+++ b/orchestrator-bundle/nms-magmalte-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/nms-magmalte-operator/tox.ini
+++ b/orchestrator-bundle/nms-magmalte-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/nms-magmalte-operator/tox.ini
+++ b/orchestrator-bundle/nms-magmalte-operator/tox.ini
@@ -85,3 +85,5 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libffi-dev=3.3-4 libssh2-1=1.8.0-2.1build1 libssl-dev=1.1.1f-1ubuntu2.13 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1

--- a/orchestrator-bundle/nms-magmalte-operator/tox.ini
+++ b/orchestrator-bundle/nms-magmalte-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/nms-nginx-proxy-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/nms-nginx-proxy-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -39,11 +38,10 @@ class TestNmsNginxProxy:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="orc8r-certifier:certifier"
         )
-        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="nms-magmalte:magmalte"
         )
@@ -69,7 +67,9 @@ class TestNmsNginxProxy:
             config={"domain": "example.com"},
             trust=True,
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(
+            apps=[CERTIFIER_APPLICATION_NAME], status="blocked", timeout=1000
+        )
         await ops_test.model.add_relation(
             relation1=CERTIFIER_APPLICATION_NAME, relation2="postgresql-k8s:db"
         )
@@ -88,11 +88,12 @@ class TestNmsNginxProxy:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=NMS_MAGMALTE_APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(
+            apps=[NMS_MAGMALTE_APPLICATION_NAME], status="blocked", timeout=1000
+        )
         await ops_test.model.add_relation(
             relation1=NMS_MAGMALTE_APPLICATION_NAME, relation2="postgresql-k8s:db"
         )
-        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=NMS_MAGMALTE_APPLICATION_NAME, relation2="orc8r-certifier:certifier"
         )

--- a/orchestrator-bundle/nms-nginx-proxy-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/nms-nginx-proxy-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401

--- a/orchestrator-bundle/nms-nginx-proxy-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/nms-nginx-proxy-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -38,9 +39,11 @@ class TestNmsNginxProxy:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="orc8r-certifier:certifier"
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="nms-magmalte:magmalte"
         )
@@ -66,6 +69,7 @@ class TestNmsNginxProxy:
             config={"domain": "example.com"},
             trust=True,
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=CERTIFIER_APPLICATION_NAME, relation2="postgresql-k8s:db"
         )
@@ -84,9 +88,11 @@ class TestNmsNginxProxy:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=NMS_MAGMALTE_APPLICATION_NAME, trust=True
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=NMS_MAGMALTE_APPLICATION_NAME, relation2="postgresql-k8s:db"
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=NMS_MAGMALTE_APPLICATION_NAME, relation2="orc8r-certifier:certifier"
         )

--- a/orchestrator-bundle/nms-nginx-proxy-operator/tox.ini
+++ b/orchestrator-bundle/nms-nginx-proxy-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/nms-nginx-proxy-operator/tox.ini
+++ b/orchestrator-bundle/nms-nginx-proxy-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/nms-nginx-proxy-operator/tox.ini
+++ b/orchestrator-bundle/nms-nginx-proxy-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/nms-nginx-proxy-operator/tox.ini
+++ b/orchestrator-bundle/nms-nginx-proxy-operator/tox.ini
@@ -85,3 +85,5 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libffi-dev=3.3-4 libssh2-1=1.8.0-2.1build1 libssl-dev=1.1.1f-1ubuntu2.13 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1

--- a/orchestrator-bundle/nms-nginx-proxy-operator/tox.ini
+++ b/orchestrator-bundle/nms-nginx-proxy-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-accessd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-accessd-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -28,6 +29,7 @@ async def test_build_and_deploy(ops_test, setup):
     await ops_test.model.deploy(
         charm, resources=resources, application_name=APPLICATION_NAME, trust=True
     )
+    time.sleep(10)
     await ops_test.model.add_relation(
         relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
     )

--- a/orchestrator-bundle/orc8r-accessd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-accessd-operator/tests/integration/test_integration.py
@@ -15,23 +15,20 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APPLICATION_NAME = "orc8r-accessd"
 CHARM_NAME = "magma-orc8r-accessd"
 
-
-class TestOrc8rAccessd:
-    @pytest.fixture(scope="module")
-    async def setup(self, ops_test):
-        await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
-        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
-
-    @pytest.mark.abort_on_fail
-    async def test_build_and_deploy(self, ops_test, setup):
-        charm = await ops_test.build_charm(".")
-        resources = {
-            f"{CHARM_NAME}-image": METADATA["resources"][f"{CHARM_NAME}-image"]["upstream-source"],
-        }
-        await ops_test.model.deploy(
-            charm, resources=resources, application_name=APPLICATION_NAME, trust=True
-        )
-        await ops_test.model.add_relation(
-            relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
-        )
-        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+@pytest.fixture(scope="module")
+async def setup(ops_test):
+    await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
+    await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test, setup):
+    charm = await ops_test.build_charm(".")
+    resources = {
+        f"{CHARM_NAME}-image": METADATA["resources"][f"{CHARM_NAME}-image"]["upstream-source"],
+    }
+    await ops_test.model.deploy(
+        charm, resources=resources, application_name=APPLICATION_NAME, trust=True
+    )
+    await ops_test.model.add_relation(
+        relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
+    )
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)

--- a/orchestrator-bundle/orc8r-accessd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-accessd-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -16,21 +16,24 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APPLICATION_NAME = "orc8r-accessd"
 CHARM_NAME = "magma-orc8r-accessd"
 
-@pytest.fixture(scope="module")
-async def setup(ops_test):
-    await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
-    await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
-@pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test, setup):
-    charm = await ops_test.build_charm(".")
-    resources = {
-        f"{CHARM_NAME}-image": METADATA["resources"][f"{CHARM_NAME}-image"]["upstream-source"],
-    }
-    await ops_test.model.deploy(
-        charm, resources=resources, application_name=APPLICATION_NAME, trust=True
-    )
-    time.sleep(10)
-    await ops_test.model.add_relation(
-        relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
-    )
-    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+
+class TestOrc8rAccessd:
+    @pytest.fixture(scope="module")
+    async def setup(self, ops_test):
+        await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
+        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
+
+    @pytest.mark.abort_on_fail
+    async def test_build_and_deploy(self, ops_test, setup):
+        charm = await ops_test.build_charm(".")
+        resources = {
+            f"{CHARM_NAME}-image": METADATA["resources"][f"{CHARM_NAME}-image"]["upstream-source"],
+        }
+        await ops_test.model.deploy(
+            charm, resources=resources, application_name=APPLICATION_NAME, trust=True
+        )
+        time.sleep(10)
+        await ops_test.model.add_relation(
+            relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
+        )
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)

--- a/orchestrator-bundle/orc8r-accessd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-accessd-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -32,7 +31,7 @@ class TestOrc8rAccessd:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-accessd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-accessd-operator/tox.ini
@@ -78,7 +78,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-accessd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-accessd-operator/tox.ini
@@ -81,4 +81,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-accessd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-accessd-operator/tox.ini
@@ -78,7 +78,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-accessd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-accessd-operator/tox.ini
@@ -16,6 +16,9 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-accessd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-accessd-operator/tox.ini
@@ -78,4 +78,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-analytics-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-analytics-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-analytics-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-analytics-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-analytics-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-analytics-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-analytics-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-analytics-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/tests/integration/test_integration.py
@@ -63,7 +63,9 @@ class TestOrc8rBootstrapper:
             config={"domain": "example.com"},
             trust=True,
         )
-        await ops_test.model.wait_for_idle(apps=[CERTIFIER_APPLICATION_NAME], status="blocked", timeout=1000)
+        await ops_test.model.wait_for_idle(
+            apps=[CERTIFIER_APPLICATION_NAME], status="blocked", timeout=1000
+        )
         await ops_test.model.add_relation(
             relation1=CERTIFIER_APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -34,9 +35,11 @@ class TestOrc8rBootstrapper:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="orc8r-certifier:certifier"
         )
@@ -62,6 +65,7 @@ class TestOrc8rBootstrapper:
             config={"domain": "example.com"},
             trust=True,
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=CERTIFIER_APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -35,11 +34,10 @@ class TestOrc8rBootstrapper:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )
-        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="orc8r-certifier:certifier"
         )
@@ -65,7 +63,7 @@ class TestOrc8rBootstrapper:
             config={"domain": "example.com"},
             trust=True,
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(apps=[CERTIFIER_APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=CERTIFIER_APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/tox.ini
@@ -78,7 +78,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/tox.ini
@@ -81,6 +81,6 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
     sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libffi-dev=3.3-4 libssh2-1=1.8.0-2.1build1 libssl-dev=1.1.1f-1ubuntu2.13 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/tox.ini
@@ -78,7 +78,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/tox.ini
@@ -16,6 +16,9 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/tox.ini
@@ -82,3 +82,5 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libffi-dev=3.3-4 libssh2-1=1.8.0-2.1build1 libssl-dev=1.1.1f-1ubuntu2.13 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/tox.ini
@@ -78,4 +78,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-bundle/tests/test_integration_bundle.py
+++ b/orchestrator-bundle/orc8r-bundle/tests/test_integration_bundle.py
@@ -1,0 +1,43 @@
+import logging
+
+import pytest
+from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
+
+logger = logging.getLogger(__name__)
+
+POSTGRES="postgresql-k8s"
+ORC8R_CHARMS = ["nms-magmalte",
+"nms-nginx-proxy",
+"orc8r-accessd",
+"orc8r-analytics",
+"orc8r-bootstrapper",
+"orc8r-certifier",
+"orc8r-configurator",
+"orc8r-ctraced",
+"orc8r-device",
+"orc8r-directoryd",
+"orc8r-dispatcher",
+"orc8r-eventd",
+"orc8r-ha",
+"orc8r-lte",
+"orc8r-metricsd",
+"orc8r-nginx",
+"orc8r-obsidian",
+"orc8r-orchestrator",
+"orc8r-policydb",
+"orc8r-service-registry",
+"orc8r-smsd",
+"orc8r-state",
+"orc8r-streamer",
+"orc8r-subscriberdb",
+"orc8r-subscriberdb-cache",
+"orc8r-tenants"]
+
+
+class TestBundle:
+    
+    @pytest.mark.abort_on_fail
+    async def test_bundle(self, ops_test, setup):
+        await ops_test.model.wait_for_idle(apps[POSTGRES], status="active", timeout=1000)
+        for charm in ORC8R_CHARMS:
+            await ops_test.model.wait_for_idle(apps=[charm], status="active", timeout=1000)

--- a/orchestrator-bundle/orc8r-bundle/tox.ini
+++ b/orchestrator-bundle/orc8r-bundle/tox.ini
@@ -3,18 +3,14 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, static, unit
+envlist = static
 
 [vars]
-src_path = {toxinidir}/src/
-unit_test_path = {toxinidir}/tests/unit/
-integration_test_path = {toxinidir}/tests/integration/
+unit_test_path = {toxinidir}/tests/
+integration_test_path = {toxinidir}/tests/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
-deps = 
-    pytest
-    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
@@ -36,51 +32,12 @@ commands =
     isort {[vars]all_path}
     black {[vars]all_path}
 
-[testenv:lint]
-description = Check code against coding style standards
-deps =
-    black
-    flake8
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
-commands =
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
-    black --check --diff {[vars]all_path}
-
-[testenv:static]
-description = Run static analysis checks
-deps =
-    -r{toxinidir}/requirements.txt
-    mypy
-    types-PyYAML
-    pytest
-    pytest-operator
-    juju
-    types-setuptools
-    types-toml
-commands =
-    mypy {[vars]all_path} {posargs}
-
-[testenv:unit]
-description = Run unit tests
-deps =
-    pytest
-    coverage[toml]
-    -r{toxinidir}/requirements.txt
-commands =
-    coverage run --source={[vars]src_path} -m pytest --ignore {[vars]integration_test_path} -v --tb native -s {posargs}
-    coverage report
-
 [testenv:integration]
 description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
+    pytest-operator
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =

--- a/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -35,6 +36,7 @@ class TestOrc8rCertifier:
             config={"domain": "example.com"},
             trust=True,
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401

--- a/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -36,7 +35,7 @@ class TestOrc8rCertifier:
             config={"domain": "example.com"},
             trust=True,
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-certifier-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-certifier-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-certifier-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-certifier-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-certifier-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-certifier-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-certifier-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-certifier-operator/tox.ini
@@ -85,3 +85,5 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libffi-dev=3.3-4 libssh2-1=1.8.0-2.1build1 libssl-dev=1.1.1f-1ubuntu2.13 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1

--- a/orchestrator-bundle/orc8r-certifier-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-certifier-operator/tox.ini
@@ -84,6 +84,6 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
     sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libffi-dev=3.3-4 libssh2-1=1.8.0-2.1build1 libssl-dev=1.1.1f-1ubuntu2.13 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-certifier-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-certifier-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-configurator-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-configurator-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -31,6 +32,7 @@ class TestOrc8rConfigurator:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-configurator-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-configurator-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401

--- a/orchestrator-bundle/orc8r-configurator-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-configurator-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -32,7 +31,7 @@ class TestOrc8rConfigurator:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-configurator-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-configurator-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-configurator-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-configurator-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-configurator-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-configurator-operator/tox.ini
@@ -84,4 +84,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-configurator-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-configurator-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-configurator-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-configurator-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-ctraced-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-ctraced-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -32,7 +31,7 @@ class TestOrc8rCtraced:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-ctraced-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-ctraced-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401

--- a/orchestrator-bundle/orc8r-ctraced-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-ctraced-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -31,6 +32,7 @@ class TestOrc8rCtraced:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-ctraced-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-ctraced-operator/tox.ini
@@ -78,7 +78,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-ctraced-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-ctraced-operator/tox.ini
@@ -81,4 +81,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-ctraced-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-ctraced-operator/tox.ini
@@ -78,7 +78,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-ctraced-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-ctraced-operator/tox.ini
@@ -16,6 +16,9 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-ctraced-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-ctraced-operator/tox.ini
@@ -78,4 +78,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-device-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-device-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401

--- a/orchestrator-bundle/orc8r-device-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-device-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -31,6 +32,7 @@ class TestOrc8rDevice:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-device-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-device-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -32,7 +31,7 @@ class TestOrc8rDevice:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-device-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-device-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-device-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-device-operator/tox.ini
@@ -84,4 +84,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-device-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-device-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-device-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-device-operator/tox.ini
@@ -12,14 +12,20 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
-  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
-  PYTHONBREAKPOINT=ipdb.set_trace
+    PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
+    PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
-  PYTHONPATH
-  HOME
-  CHARM_BUILD_DIR
-  MODEL_SETTINGS
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
+    PYTHONPATH
+    HOME
+    CHARM_BUILD_DIR
+    MODEL_SETTINGS
 
 [testenv:fmt]
 description = Apply coding style standards to code

--- a/orchestrator-bundle/orc8r-device-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-device-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-directoryd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-directoryd-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401

--- a/orchestrator-bundle/orc8r-directoryd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-directoryd-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -32,7 +31,7 @@ class TestOrc8rDirectoryd:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-directoryd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-directoryd-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -31,6 +32,7 @@ class TestOrc8rDirectoryd:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-directoryd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-directoryd-operator/tox.ini
@@ -78,7 +78,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-directoryd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-directoryd-operator/tox.ini
@@ -78,7 +78,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-directoryd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-directoryd-operator/tox.ini
@@ -78,4 +78,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-directoryd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-directoryd-operator/tox.ini
@@ -13,13 +13,16 @@ all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
 setenv =
-  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
-  PYTHONBREAKPOINT=ipdb.set_trace
+    PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
+    PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
-  PYTHONPATH
-  HOME
-  CHARM_BUILD_DIR
-  MODEL_SETTINGS
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
+    PYTHONPATH
+    HOME
+    CHARM_BUILD_DIR
+    MODEL_SETTINGS
 
 [testenv:fmt]
 description = Apply coding style standards to code

--- a/orchestrator-bundle/orc8r-directoryd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-directoryd-operator/tox.ini
@@ -81,4 +81,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4s
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-dispatcher-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-dispatcher-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-dispatcher-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-dispatcher-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-dispatcher-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-dispatcher-operator/tox.ini
@@ -84,4 +84,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-dispatcher-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-dispatcher-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-dispatcher-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-dispatcher-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-eventd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-eventd-operator/src/charm.py
@@ -72,7 +72,7 @@ class MagmaOrc8rEventdCharm(CharmBase):
 
     def _get_elasticsearch_config(self) -> tuple:
         elasticsearch_url = self.model.config.get("elasticsearch-url")
-        elasticsearch_url_split = elasticsearch_url.split(":")
+        elasticsearch_url_split = elasticsearch_url.split(":") # type: ignore [union-attr] 
         return elasticsearch_url_split[0], elasticsearch_url_split[1]
 
     @property

--- a/orchestrator-bundle/orc8r-eventd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-eventd-operator/src/charm.py
@@ -72,7 +72,7 @@ class MagmaOrc8rEventdCharm(CharmBase):
 
     def _get_elasticsearch_config(self) -> tuple:
         elasticsearch_url = self.model.config.get("elasticsearch-url")
-        elasticsearch_url_split = elasticsearch_url.split(":") # type: ignore [union-attr] 
+        elasticsearch_url_split = elasticsearch_url.split(":")  # type: ignore [union-attr]
         return elasticsearch_url_split[0], elasticsearch_url_split[1]
 
     @property

--- a/orchestrator-bundle/orc8r-eventd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-eventd-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-eventd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-eventd-operator/tox.ini
@@ -12,6 +12,9 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace

--- a/orchestrator-bundle/orc8r-eventd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-eventd-operator/tox.ini
@@ -15,10 +15,16 @@ all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 deps = 
     pytest
     pytest-operator
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR
@@ -81,4 +87,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-eventd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-eventd-operator/tox.ini
@@ -84,4 +84,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-eventd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-eventd-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-eventd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-eventd-operator/tox.ini
@@ -15,9 +15,6 @@ all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 deps = 
     pytest
     pytest-operator
-deps = 
-    pytest
-    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace

--- a/orchestrator-bundle/orc8r-ha-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-ha-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-ha-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-ha-operator/tox.ini
@@ -84,4 +84,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-ha-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-ha-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-ha-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-ha-operator/tox.ini
@@ -12,14 +12,20 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
-  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
-  PYTHONBREAKPOINT=ipdb.set_trace
+    PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
+    PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
-  PYTHONPATH
-  HOME
-  CHARM_BUILD_DIR
-  MODEL_SETTINGS
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
+    PYTHONPATH
+    HOME
+    CHARM_BUILD_DIR
+    MODEL_SETTINGS
 
 [testenv:fmt]
 description = Apply coding style standards to code

--- a/orchestrator-bundle/orc8r-ha-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-ha-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-libs/tox.ini
+++ b/orchestrator-bundle/orc8r-libs/tox.ini
@@ -14,17 +14,17 @@ all_path = {[vars]src_path} {[vars]tst_path} {[vars]lib_path}
 [testenv]
 basepython = python3
 setenv =
-  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
-  PYTHONBREAKPOINT=ipdb.set_trace
+    PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
+    PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
-  PYTHONPATH
-  HOME
-  PATH
-  CHARM_BUILD_DIR
-  MODEL_SETTINGS
-  HTTP_PROXY
-  HTTPS_PROXY
-  NO_PROXY
+    PYTHONPATH
+    HOME
+    PATH
+    CHARM_BUILD_DIR
+    MODEL_SETTINGS
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
 
 [testenv:fmt]
 description = Apply coding style standards to code

--- a/orchestrator-bundle/orc8r-lte-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-lte-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401

--- a/orchestrator-bundle/orc8r-lte-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-lte-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -32,7 +31,7 @@ class TestOrc8rLte:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
-        time.sleep(20)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-lte-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-lte-operator/tests/integration/test_integration.py
@@ -32,7 +32,7 @@ class TestOrc8rLte:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        time.sleep(20)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-lte-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-lte-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -31,6 +32,7 @@ class TestOrc8rLte:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-lte-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-lte-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-lte-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-lte-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-lte-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-lte-operator/tox.ini
@@ -84,4 +84,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-lte-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-lte-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-lte-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-lte-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-metricsd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-metricsd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-metricsd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tox.ini
@@ -84,4 +84,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-metricsd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-metricsd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-nginx-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-nginx-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -45,15 +44,13 @@ class TestOrc8rNginx:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="orc8r-certifier:certifier"
         )
-        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="orc8r-bootstrapper:bootstrapper"
         )
-        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="orc8r-obsidian:obsidian"
         )
@@ -79,7 +76,9 @@ class TestOrc8rNginx:
             config={"domain": "example.com"},
             trust=True,
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(
+            apps=[CERTIFIER_APPLICATION_NAME], status="blocked", timeout=1000
+        )
         await ops_test.model.add_relation(
             relation1=CERTIFIER_APPLICATION_NAME, relation2="postgresql-k8s:db"
         )
@@ -98,11 +97,12 @@ class TestOrc8rNginx:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=BOOTSTRAPPER_APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(
+            apps=[BOOTSTRAPPER_APPLICATION_NAME], status="blocked", timeout=1000
+        )
         await ops_test.model.add_relation(
             relation1=BOOTSTRAPPER_APPLICATION_NAME, relation2="postgresql-k8s:db"
         )
-        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=BOOTSTRAPPER_APPLICATION_NAME, relation2="orc8r-certifier:certifier"
         )

--- a/orchestrator-bundle/orc8r-nginx-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-nginx-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401

--- a/orchestrator-bundle/orc8r-nginx-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-nginx-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -44,12 +45,15 @@ class TestOrc8rNginx:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="orc8r-certifier:certifier"
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="orc8r-bootstrapper:bootstrapper"
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="orc8r-obsidian:obsidian"
         )
@@ -75,6 +79,7 @@ class TestOrc8rNginx:
             config={"domain": "example.com"},
             trust=True,
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=CERTIFIER_APPLICATION_NAME, relation2="postgresql-k8s:db"
         )
@@ -93,9 +98,11 @@ class TestOrc8rNginx:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=BOOTSTRAPPER_APPLICATION_NAME, trust=True
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=BOOTSTRAPPER_APPLICATION_NAME, relation2="postgresql-k8s:db"
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=BOOTSTRAPPER_APPLICATION_NAME, relation2="orc8r-certifier:certifier"
         )

--- a/orchestrator-bundle/orc8r-nginx-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-nginx-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-nginx-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-nginx-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-nginx-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-nginx-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-nginx-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-nginx-operator/tox.ini
@@ -85,3 +85,5 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libffi-dev=3.3-4 libssh2-1=1.8.0-2.1build1 libssl-dev=1.1.1f-1ubuntu2.13 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1

--- a/orchestrator-bundle/orc8r-nginx-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-nginx-operator/tox.ini
@@ -84,6 +84,6 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
     sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libffi-dev=3.3-4 libssh2-1=1.8.0-2.1build1 libssl-dev=1.1.1f-1ubuntu2.13 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-nginx-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-nginx-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-obsidian-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-obsidian-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-obsidian-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-obsidian-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-obsidian-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-obsidian-operator/tox.ini
@@ -84,4 +84,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-obsidian-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-obsidian-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-obsidian-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-obsidian-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
@@ -300,7 +300,7 @@ class MagmaOrc8rOrchestratorCharm(CharmBase):
 
     def _get_elasticsearch_config(self) -> tuple:
         elasticsearch_url = self.model.config.get("elasticsearch-url")
-        elasticsearch_url_split = elasticsearch_url.split(":")
+        elasticsearch_url_split = elasticsearch_url.split(":")  # type: ignore [union-attr]
         return elasticsearch_url_split[0], elasticsearch_url_split[1]
 
     @property

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tests/integration/test_integration.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
-
 import logging
 from pathlib import Path
 
@@ -10,19 +9,62 @@ import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
 
 logger = logging.getLogger(__name__)
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+CERTIFIER_METADATA = yaml.safe_load(Path("../orc8r-certifier-operator/metadata.yaml").read_text())
 APPLICATION_NAME = "orc8r-orchestrator"
 CHARM_NAME = "magma-orc8r-orchestrator"
+CERTIFIER_APPLICATION_NAME = "orc8r-certifier"
+CERTIFIER_CHARM_NAME = "magma-orc8r-certifier"
 
 
-@pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest):
-    charm = await ops_test.build_charm(".")
-    resources = {
-        f"{CHARM_NAME}-image": METADATA["resources"][f"{CHARM_NAME}-image"]["upstream-source"],
-    }
-    await ops_test.model.deploy(
-        charm, resources=resources, application_name=APPLICATION_NAME, trust=True
-    )
-    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+class TestOrchestrator:
+    @pytest.fixture(scope="module")
+    async def setup(self, ops_test):
+        await self._deploy_postgresql(ops_test)
+        await self._deploy_orc8r_certifier(ops_test)
+
+    @pytest.mark.abort_on_fail
+    async def test_build_and_deploy(self, ops_test, setup):
+        charm = await ops_test.build_charm(".")
+        resources = {
+            f"{CHARM_NAME}-image": METADATA["resources"][f"{CHARM_NAME}-image"]["upstream-source"],
+        }
+        await ops_test.model.deploy(
+            charm, resources=resources, application_name=APPLICATION_NAME, trust=True
+        )
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
+        await ops_test.model.add_relation(
+            relation1=APPLICATION_NAME, relation2="orc8r-certifier:certifier"
+        )
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+
+    @staticmethod
+    async def _deploy_postgresql(ops_test):
+        await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
+        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
+
+    @staticmethod
+    async def _deploy_orc8r_certifier(ops_test):
+        charm = await ops_test.build_charm("../orc8r-certifier-operator/")
+        resources = {
+            f"{CERTIFIER_CHARM_NAME}-image": CERTIFIER_METADATA["resources"][
+                f"{CERTIFIER_CHARM_NAME}-image"
+            ]["upstream-source"],
+        }
+        await ops_test.model.deploy(
+            charm,
+            resources=resources,
+            application_name=CERTIFIER_APPLICATION_NAME,
+            config={"domain": "example.com"},
+            trust=True,
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[CERTIFIER_APPLICATION_NAME], status="blocked", timeout=1000
+        )
+        await ops_test.model.add_relation(
+            relation1=CERTIFIER_APPLICATION_NAME, relation2="postgresql-k8s:db"
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[CERTIFIER_APPLICATION_NAME], status="active", timeout=1000
+        )

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tox.ini
@@ -85,3 +85,5 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libffi-dev=3.3-4 libssh2-1=1.8.0-2.1build1 libssl-dev=1.1.1f-1ubuntu2.13 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tox.ini
@@ -84,6 +84,6 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
     sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install cargo=0.58.0-0ubuntu1~20.04.1 libffi-dev=3.3-4 libssh2-1=1.8.0-2.1build1 libssl-dev=1.1.1f-1ubuntu2.13 libstd-rust-1.57=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 libstd-rust-dev=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1 rustc=1.57.0+dfsg1+llvm-0ubuntu1~20.04.1
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-policydb-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-policydb-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401

--- a/orchestrator-bundle/orc8r-policydb-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-policydb-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -32,7 +31,7 @@ class TestOrc8rPolicyDB:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-policydb-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-policydb-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -31,6 +32,7 @@ class TestOrc8rPolicyDB:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-policydb-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-policydb-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-policydb-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-policydb-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-policydb-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-policydb-operator/tox.ini
@@ -84,4 +84,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-policydb-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-policydb-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-policydb-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-policydb-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-service-registry-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-service-registry-operator/tox.ini
@@ -78,7 +78,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-service-registry-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-service-registry-operator/tox.ini
@@ -81,4 +81,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-service-registry-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-service-registry-operator/tox.ini
@@ -78,7 +78,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-service-registry-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-service-registry-operator/tox.ini
@@ -16,6 +16,9 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-service-registry-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-service-registry-operator/tox.ini
@@ -78,4 +78,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-smsd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-smsd-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -32,7 +31,7 @@ class TestOrc8rSmsd:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-smsd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-smsd-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401

--- a/orchestrator-bundle/orc8r-smsd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-smsd-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -31,6 +32,7 @@ class TestOrc8rSmsd:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-smsd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-smsd-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-smsd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-smsd-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-smsd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-smsd-operator/tox.ini
@@ -84,4 +84,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-smsd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-smsd-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-smsd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-smsd-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-state-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-state-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -32,7 +31,7 @@ class TestOrc8rState:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-state-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-state-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401

--- a/orchestrator-bundle/orc8r-state-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-state-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -31,6 +32,7 @@ class TestOrc8rState:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-state-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-state-operator/tox.ini
@@ -78,7 +78,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-state-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-state-operator/tox.ini
@@ -81,4 +81,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-state-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-state-operator/tox.ini
@@ -78,7 +78,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-state-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-state-operator/tox.ini
@@ -16,6 +16,9 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-state-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-state-operator/tox.ini
@@ -78,4 +78,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-streamer-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-streamer-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-streamer-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-streamer-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-streamer-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-streamer-operator/tox.ini
@@ -84,4 +84,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-streamer-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-streamer-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-streamer-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-streamer-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -31,6 +32,7 @@ class TestOrc8rSubscriberDBCache:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -32,7 +31,7 @@ class TestOrc8rSubscriberDBCache:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tox.ini
@@ -84,4 +84,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -32,7 +31,7 @@ class TestOrc8rSubscriberDB:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -31,6 +32,7 @@ class TestOrc8rSubscriberDB:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/tox.ini
@@ -84,4 +84,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-tenants-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-tenants-operator/tests/integration/test_integration.py
@@ -3,9 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 from pathlib import Path
 
-import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401

--- a/orchestrator-bundle/orc8r-tenants-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-tenants-operator/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 from pathlib import Path
 
 import pytest
@@ -32,7 +31,7 @@ class TestOrc8rTenants:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
-        time.sleep(10)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-tenants-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-tenants-operator/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import logging
 from pathlib import Path
 
+import time
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
@@ -31,6 +32,7 @@ class TestOrc8rTenants:
         await ops_test.model.deploy(
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
+        time.sleep(10)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
         )

--- a/orchestrator-bundle/orc8r-tenants-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-tenants-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-tenants-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-tenants-operator/tox.ini
@@ -12,10 +12,16 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+deps = 
+    pytest
+    pytest-operator
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
     PYTHONPATH
     HOME
     CHARM_BUILD_DIR

--- a/orchestrator-bundle/orc8r-tenants-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-tenants-operator/tox.ini
@@ -84,4 +84,5 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3-venv=3.8.2-0ubuntu2 python3.8-venv=3.8.10-0ubuntu1~20.04.4
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-tenants-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-tenants-operator/tox.ini
@@ -84,4 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode

--- a/orchestrator-bundle/orc8r-tenants-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-tenants-operator/tox.ini
@@ -81,7 +81,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git@issue/connection_closure
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode


### PR DESCRIPTION
- Adds proxy-related environment variables to `tox.ini` file for every charm.
- Adds dependencies installation in `Setup operator environment` step.
- Now charms are packed using destructive mode.
- Sets `runs-on: prodstack-github-runner` to attach the integration tests on the corresponding VM in prodstack.
- Adds `ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)` just before adding relations. This prevents issues trying to relate before the charm is even deployed.
- Sets `asyncio-mode` to `auto`, to remove warnings in every integration test run. As suggested in this [issue](https://github.com/charmed-kubernetes/pytest-operator/issues/50).
- Adds missing relations in `orc8r-orchestrator` integration test.

NOTES: 
- I created another [issue](https://github.com/charmed-kubernetes/pytest-operator/issues/75) to remove the warning that was flooding the integration tests logs.
- I also created a simple [how-to-guide](https://drive.google.com/file/d/1WxpcG9HxLlj0fnmNMlzgotH-BTzed7jg/view?usp=sharing) to spin up a new Github runner in prodstack.

[Successful run](https://github.com/canonical/charmed-magma/actions/runs/2307205315)