### PR TITLE
Fixing versions of libs

### DIFF
--- a/orchestrator-bundle/orc8r-libs/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
+++ b/orchestrator-bundle/orc8r-libs/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
@@ -76,7 +76,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 9
 
 
 logger = logging.getLogger(__name__)

--- a/orchestrator-bundle/orc8r-libs/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orchestrator-bundle/orc8r-libs/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -71,7 +71,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 8
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes orc8r_libs versioning, which got misaligned because our pipeline hasn't been publishing changes.