### PR TITLE
Chore: change the name of the get_admin_credentials juju

### DIFF
--- a/orchestrator-bundle/documentation/how-to-guides/deploy_on_aws_charmed_kubernetes.md
+++ b/orchestrator-bundle/documentation/how-to-guides/deploy_on_aws_charmed_kubernetes.md
@@ -112,7 +112,7 @@ script.
 Get the master organization's username and password:
 
 ```bash
-juju run-action nms-magmalte/0 get-admin-credentials --wait
+juju run-action nms-magmalte/0 get-master-admin-credentials --wait
 ```
 
 Confirm successful deployment by visiting `https://master.nms.<your domain>` and logging in

--- a/orchestrator-bundle/documentation/how-to-guides/deploy_on_aws_eks.md
+++ b/orchestrator-bundle/documentation/how-to-guides/deploy_on_aws_eks.md
@@ -89,7 +89,7 @@ script.
 Get the master organization's username and password:
 
 ```bash
-juju run-action nms-magmalte/0 get-admin-credentials --wait
+juju run-action nms-magmalte/0 get-master-admin-credentials --wait
 ```
 
 Confirm successful deployment by visiting `https://master.nms.<your domain>` and logging in

--- a/orchestrator-bundle/documentation/how-to-guides/deploy_on_azure_aks.md
+++ b/orchestrator-bundle/documentation/how-to-guides/deploy_on_azure_aks.md
@@ -87,7 +87,7 @@ Create these A records in your managed domain:
 Get the master organization's username and password:
 
 ```bash
-juju run-action nms-magmalte/0 get-admin-credentials --wait
+juju run-action nms-magmalte/0 get-master-admin-credentials --wait
 ```
 
 Confirm successful deployment by visiting `https://master.nms.<your domain>` and logging in

--- a/orchestrator-bundle/documentation/how-to-guides/deploy_on_gcp_gke.md
+++ b/orchestrator-bundle/documentation/how-to-guides/deploy_on_gcp_gke.md
@@ -86,7 +86,7 @@ Create these A records in your managed domain:
 Get the master organization's username and password:
 
 ```bash
-juju run-action nms-magmalte/0 get-admin-credentials --wait
+juju run-action nms-magmalte/0 get-master-admin-credentials --wait
 ```
 
 Confirm successful deployment by visiting `https://master.nms.<your domain>` and logging in

--- a/orchestrator-bundle/documentation/how-to-guides/deploy_on_microk8s.md
+++ b/orchestrator-bundle/documentation/how-to-guides/deploy_on_microk8s.md
@@ -98,7 +98,7 @@ IP's of the specified Kubernetes services.
 Get the master organization's username and password:
 
 ```bash
-juju run-action nms-magmalte/0 get-admin-credentials --wait
+juju run-action nms-magmalte/0 get-master-admin-credentials --wait
 ```
 
 Confirm successful deployment by visiting `https://master.nms.<your domain>` and logging in

--- a/orchestrator-bundle/nms-magmalte-operator/README.md
+++ b/orchestrator-bundle/nms-magmalte-operator/README.md
@@ -45,7 +45,7 @@ juju relate nms-magmalte postgresql-k8s:db
 ### Get the master organization's username and password
 
 ```bash
-juju run-action nms-magmalte/0 get-admin-credentials --wait
+juju run-action nms-magmalte/0 get-master-admin-credentials --wait
 ```
 
 ## Relations

--- a/orchestrator-bundle/nms-magmalte-operator/actions.yaml
+++ b/orchestrator-bundle/nms-magmalte-operator/actions.yaml
@@ -1,7 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-get-admin-credentials:
+get-master-admin-credentials:
   description: Returns the admin username and password for the master organization in NMS.
 
 create-nms-admin-user:

--- a/orchestrator-bundle/nms-magmalte-operator/src/charm.py
+++ b/orchestrator-bundle/nms-magmalte-operator/src/charm.py
@@ -287,8 +287,8 @@ class MagmaNmsMagmalteCharm(CharmBase):
         """Returns domain name provided by the orc8r-certifier relation."""
         try:
             certifier_relation = self.model.get_relation("magma-orc8r-certifier")
-            units = certifier_relation.units
-            return certifier_relation.data[next(iter(units))]["domain"]
+            units = certifier_relation.units  # type: ignore[union-attr]
+            return certifier_relation.data[next(iter(units))]["domain"]  # type: ignore[union-attr]  # noqa: E501
         except (KeyError, StopIteration):
             return None
 
@@ -297,7 +297,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
         """Returns DB connection string provided by the DB relation."""
         try:
             db_relation = self.model.get_relation("db")
-            return ConnectionString(db_relation.data[db_relation.app]["master"])
+            return ConnectionString(db_relation.data[db_relation.app]["master"])  # type: ignore[union-attr, index]  # noqa: E501
         except (AttributeError, KeyError):
             return None
 

--- a/orchestrator-bundle/nms-magmalte-operator/src/charm.py
+++ b/orchestrator-bundle/nms-magmalte-operator/src/charm.py
@@ -54,7 +54,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
             self._on_magma_orc8r_certifier_relation_changed,
         )
         self.framework.observe(
-            self.on.get_admin_credentials_action, self._on_get_admin_credentials
+            self.on.get_master_admin_credentials_action, self._on_get_master_admin_credentials
         )
         self.framework.observe(
             self.on.create_nms_admin_user_action, self._create_nms_admin_user_action
@@ -189,7 +189,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
             organization=event.params["organization"],
         )
 
-    def _on_get_admin_credentials(self, event: ActionEvent) -> None:
+    def _on_get_master_admin_credentials(self, event: ActionEvent) -> None:
         if not self._relations_ready:
             event.fail("Relations aren't yet set up. Please try again in a few minutes")
             return
@@ -203,7 +203,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
 
     def _create_nms_admin_user(self, email: str, password: str, organization: str):
         """
-        Creates Admin user for the master organization in NMS.
+        Creates Admin user for the given organization in NMS.
         """
         logger.info("Creating admin user for NMS")
         process = self._container.exec(
@@ -287,8 +287,8 @@ class MagmaNmsMagmalteCharm(CharmBase):
         """Returns domain name provided by the orc8r-certifier relation."""
         try:
             certifier_relation = self.model.get_relation("magma-orc8r-certifier")
-            units = certifier_relation.units  # type: ignore[union-attr]
-            return certifier_relation.data[next(iter(units))]["domain"]  # type: ignore[union-attr]
+            units = certifier_relation.units
+            return certifier_relation.data[next(iter(units))]["domain"]
         except (KeyError, StopIteration):
             return None
 
@@ -297,7 +297,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
         """Returns DB connection string provided by the DB relation."""
         try:
             db_relation = self.model.get_relation("db")
-            return ConnectionString(db_relation.data[db_relation.app]["master"])  # type: ignore[index, union-attr]  # noqa: E501
+            return ConnectionString(db_relation.data[db_relation.app]["master"])
         except (AttributeError, KeyError):
             return None
 

--- a/orchestrator-bundle/orc8r-bundle/README.md
+++ b/orchestrator-bundle/orc8r-bundle/README.md
@@ -84,7 +84,7 @@ Create these A records in your managed domain:
 Get the master organization's username and password:
 
 ```bash
-juju run-action nms-magmalte/0 get-admin-credentials --wait
+juju run-action nms-magmalte/0 get-master-admin-credentials --wait
 ```
 
 Confirm successful deployment by visiting `https://master.nms.<your domain>` and logging in


### PR DESCRIPTION
change the name of the get_admin_credentials juju to get_master_admin_credentials
The action returns the credentials of the admin user only for the master organization, change the name to reflect that.