### PR TITLE
orc8r-orchestrator integration tests

### DIFF
--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           set -eux
 
-          charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator | grep -wv orc8r-orchestrator)"
+          charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
           for charm in ${charms}; do
             tox -c "${charm}" -e integration
           done

--- a/.github/workflows/orchestrator.orchestrator.yml
+++ b/.github/workflows/orchestrator.orchestrator.yml
@@ -36,15 +36,15 @@ jobs:
       - name: Run tests using tox
         run: cd orchestrator-bundle/orc8r-orchestrator-operator && tox -e unit
 
-  # orc8r-orchestrator-integration-test:
-  #   name: Integration tests (orc8r-orchestrator)
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #     - name: Setup operator environment
-  #       uses: charmed-kubernetes/actions-operator@main
-  #       with:
-  #         provider: microk8s
-  #     - name: Run integration tests
-  #       run: cd orchestrator-bundle/orc8r-orchestrator-operator && tox -e integration
+  orc8r-orchestrator-integration-test:
+    name: Integration tests (orc8r-orchestrator)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: microk8s
+      - name: Run integration tests
+        run: cd orchestrator-bundle/orc8r-orchestrator-operator && tox -e integration

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tests/integration/test_integration.py
@@ -67,13 +67,12 @@ class TestOrchestrator:
             charm, resources=resources, application_name=APPLICATION_NAME, trust=True
         )
 
-        await ops_test.model.add_relation(
-            relation1=APPLICATION_NAME, relation2="orc8r-certifier:magma-orc8r-certifier"
-        )
-
     @pytest.mark.abort_on_fail
     async def test_wait_for_blocked_status(self, ops_test, setup, build_and_deploy):
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
 
-    async def test_wait_for_idle(self, ops_test, setup, build_and_deploy):
+    async def test_relate_and_wait_for_idle(self, ops_test, setup, build_and_deploy):
+        await ops_test.model.add_relation(
+            relation1=APPLICATION_NAME, relation2="orc8r-certifier:magma-orc8r-certifier"
+        )
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tests/integration/test_integration.py
@@ -24,12 +24,22 @@ class TestOrchestrator:
     @pytest.mark.abort_on_fail
     async def setup(self, ops_test):
         await self._deploy_postgresql(ops_test)
+        await self._deploy_prometheus_cache(ops_test)
         await self._deploy_orc8r_certifier(ops_test)
 
     @staticmethod
     async def _deploy_postgresql(ops_test):
         await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
         await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
+
+    @staticmethod
+    async def _deploy_prometheus_cache(ops_test):
+        await ops_test.model.deploy(
+            "prometheus-edge-hub",
+            application_name="orc8r-prometheus-cache",
+            channel="edge",
+            trust=True,
+        )
 
     @staticmethod
     async def _deploy_orc8r_certifier(ops_test):
@@ -74,5 +84,8 @@ class TestOrchestrator:
     async def test_relate_and_wait_for_idle(self, ops_test, setup, build_and_deploy):
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="orc8r-certifier:magma-orc8r-certifier"
+        )
+        await ops_test.model.add_relation(
+            relation1=APPLICATION_NAME, relation2="orc8r-prometheus-cache:metrics-endpoint"
         )
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)


### PR DESCRIPTION
Fixes `orc8r-orchestrator`  integration tests adding a new relation with `orc8r-prometheus-cache:metrics-endpoint`.
