### PR TITLE
Bundle integration tests

### DIFF
--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -120,7 +120,7 @@ jobs:
           set -eux
           ./orchestrator-bundle/build.sh
 
-      - name: Deploy bundle and wait for idle
+      - name: Run bundle integration tests
         run: |
           tox -c "./orchestrator-bundle/orc8r-bundle/tox.ini" -e integration
 

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -120,14 +120,9 @@ jobs:
           set -eux
           ./orchestrator-bundle/build.sh
 
-      # - name: Run integration tests
-      #   run: |
-      #     set -eux
-
-      #     charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator | grep -wv orc8r-orchestrator)"
-      #     for charm in ${charms}; do
-      #       tox -c "${charm}" -e integration
-      #     done
+      - name: Deploy and wait for idle
+        run: |
+          tox -c "./orchestrator-bundle/orc8r-bundle/tox.ini" -e integration
 
       - name: Clean up
         if: always()

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run tests using tox
         run: |
           set -eux
-          charms="$(find ./orchestrator-bundle/ -name tox.ini -not -path "./orchestrator-bundle/orc8r-bundle/*")"
+          charms="$(find ./orchestrator-bundle/ -name tox.ini)"
           for charm in ${charms}; do
             tox -c "${charm}" -e static
           done
@@ -46,7 +46,7 @@ jobs:
       - name: Run tests using tox
         run: |
           set -eux
-          charms="$(find ./orchestrator-bundle/ -name tox.ini)"
+          charms="$(find ./orchestrator-bundle/ -name tox.ini  -not -path "./orchestrator-bundle/orc8r-bundle/*")"
           for charm in ${charms}; do
             tox -c "${charm}" -e unit
           done

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run tests using tox
         run: |
           set -eux
-          charms="$(find ./orchestrator-bundle/ -name tox.ini)"
+          charms="$(find ./orchestrator-bundle/ -name tox.ini -not -path "./orchestrator-bundle/orc8r-bundle/*")"
           for charm in ${charms}; do
             tox -c "${charm}" -e static
           done
@@ -120,7 +120,7 @@ jobs:
           set -eux
           ./orchestrator-bundle/build.sh
 
-      - name: Deploy and wait for idle
+      - name: Deploy bundle and wait for idle
         run: |
           tox -c "./orchestrator-bundle/orc8r-bundle/tox.ini" -e integration
 

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -109,20 +109,25 @@ jobs:
 
           echo "# Bootstrap controller"
           sleep 180  # Microk8s needs time to initialize properly
-          /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests --model-default test-mode=true --model-default automatically-retry-hooks=false --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
+          /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests --model-default test-mode=true --model-default automatically-retry-hooks=true --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
 
           # Install dependencies
           /usr/bin/sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv=3.8.10-0ubuntu1~20.04.4
           /usr/bin/sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install libffi-dev libssh2-1 libssl-dev libssl-dev libstd-rust-1.57 cargo libstd-rust-dev rustc
 
-      - name: Run integration tests
+      - name: Build charms
         run: |
           set -eux
+          ./orchestrator-bundle/build.sh
 
-          charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator)"
-          for charm in ${charms}; do
-            tox -c "${charm}" -e integration
-          done
+      # - name: Run integration tests
+      #   run: |
+      #     set -eux
+
+      #     charms="$(find ./orchestrator-bundle/ -name tox.ini | grep operator | grep -wv orc8r-orchestrator)"
+      #     for charm in ${charms}; do
+      #       tox -c "${charm}" -e integration
+      #     done
 
       - name: Clean up
         if: always()

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -111,10 +111,6 @@ jobs:
           sleep 180  # Microk8s needs time to initialize properly
           /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests --model-default test-mode=true --model-default automatically-retry-hooks=true --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
 
-          # Install dependencies
-          /usr/bin/sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv=3.8.10-0ubuntu1~20.04.4
-          /usr/bin/sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install libffi-dev libssh2-1 libssl-dev libssl-dev libstd-rust-1.57 cargo libstd-rust-dev rustc
-
       - name: Build charms
         run: |
           set -eux

--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -124,6 +124,13 @@ jobs:
         run: |
           tox -c "./orchestrator-bundle/orc8r-bundle/tox.ini" -e integration
 
+      - name: Archive charmcraft logs
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: charmcraft-logs
+          path: /home/ubuntu/snap/charmcraft/common/cache/charmcraft/log/*.log
+
       - name: Clean up
         if: always()
         run: |

--- a/orchestrator-bundle/build.sh
+++ b/orchestrator-bundle/build.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 function build() {
   charm="$1"
     pushd "${charm}-operator/"
-    charmcraft pack
+    sudo charmcraft pack --destructive-mode
     mv "magma-${charm}_ubuntu-20.04-amd64.charm" "${charm}.charm"
     popd
 }

--- a/orchestrator-bundle/build.sh
+++ b/orchestrator-bundle/build.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 function build() {
   charm="$1"
     pushd "orchestrator-bundle/${charm}-operator/"
-    sudo charmcraft pack --destructive-mode
+    charmcraft pack
     mv -f "magma-${charm}_ubuntu-20.04-amd64.charm" "${charm}.charm"
     popd
 }

--- a/orchestrator-bundle/build.sh
+++ b/orchestrator-bundle/build.sh
@@ -6,7 +6,7 @@ function build() {
   charm="$1"
     pushd "${charm}-operator/"
     sudo charmcraft pack --destructive-mode
-    mv "magma-${charm}_ubuntu-20.04-amd64.charm" "${charm}.charm"
+    mv -f "magma-${charm}_ubuntu-20.04-amd64.charm" "${charm}.charm"
     popd
 }
 

--- a/orchestrator-bundle/build.sh
+++ b/orchestrator-bundle/build.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 function build() {
   charm="$1"
-    pushd "${charm}-operator/"
+    pushd "orchestrator-bundle/${charm}-operator/"
     sudo charmcraft pack --destructive-mode
     mv -f "magma-${charm}_ubuntu-20.04-amd64.charm" "${charm}.charm"
     popd

--- a/orchestrator-bundle/orc8r-bundle/pyproject.toml
+++ b/orchestrator-bundle/orc8r-bundle/pyproject.toml
@@ -1,0 +1,46 @@
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+
+[tool.black]
+line-length = 99
+target-version = ["py38"]
+
+[tool.isort]
+profile = "black"
+
+[tool.flake8]
+max-line-length = 99
+max-doc-length = 99
+max-complexity = 10
+exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
+select = ["E", "W", "F", "C", "N"]
+copyright-check = "True"
+copyright-author = "Canonical Ltd."
+copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+
+[tool.mypy]
+pretty = true
+python_version = 3.8
+mypy_path = "$MYPY_CONFIG_FILE_DIR/src:$MYPY_CONFIG_FILE_DIR/lib:$MYPY_CONFIG_FILE_DIR/tests/unit"
+follow_imports = "normal"
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_unused_configs = true
+show_traceback = true
+show_error_codes = true
+namespace_packages = true
+explicit_package_bases = true
+check_untyped_defs = true
+allow_redefinition = true
+
+# Ignore libraries that do not have type hint nor stubs
+[[tool.mypy.overrides]]
+module = ["ops.*", "kubernetes.*", "flatten_json.*", "git.*"]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+log_cli_level = "INFO"

--- a/orchestrator-bundle/orc8r-bundle/pyproject.toml
+++ b/orchestrator-bundle/orc8r-bundle/pyproject.toml
@@ -1,9 +1,3 @@
-[tool.coverage.run]
-branch = true
-
-[tool.coverage.report]
-show_missing = true
-
 [tool.black]
 line-length = 99
 target-version = ["py38"]

--- a/orchestrator-bundle/orc8r-bundle/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-bundle/tests/integration/test_integration.py
@@ -28,4 +28,8 @@ class TestOrc8rBundle:
         logger.info(stdout)
 
     async def test_wait_for_idle(self, ops_test: OpsTest, deploy_bundle):
-        await ops_test.model.wait_for_idle(status="active", timeout=20000)
+        try:
+            await ops_test.model.wait_for_idle(status="active", timeout=1000)
+        except Exception as e:
+            logger.error(e)
+            pass

--- a/orchestrator-bundle/orc8r-bundle/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-bundle/tests/integration/test_integration.py
@@ -8,34 +8,26 @@ from pathlib import Path
 import pytest
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
 
-from juju.controller import Controller
+from helpers import (cli_deploy_bundle)
 
 
 logger = logging.getLogger(__name__)
 
 
 class TestOrc8rBundle:
-    async def cli_deploy_bundle(ops_test: OpsTest, name: str, channel: str = "edge"):
-        run_args = [
-            "juju",
-            "deploy",
-            "./bundle-local.yaml",
-            "--trust",
-            "-m",
-            ops_test.model_full_name,
-        ]
-
-        retcode, stdout, stderr = await ops_test.run(*run_args)
-        logger.info("Deploying bundle")
-        logger.info(stdout)
-
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail
     async def deploy_bundle(self, ops_test: OpsTest):
+        run_args = [
+            "juju",
+            "deploy",
+            "/home/ubuntu/charmed-magma/orchestrator-bundle/bundle-local.yaml",
+            "--trust",
+        ]
+
         logger.info("Deploying bundle")
-        await cli_deploy_bundle(ops_test, "magma-orc8r")
-        logger.info("Bundle deployed!")
-        
-    
+        retcode, stdout, stderr = await ops_test.run(*run_args)
+        logger.info(stdout)
+
     async def test_wait_for_idle(self, ops_test: OpsTest, deploy_bundle):
         await ops_test.model.wait_for_idle(status="active", timeout=1500)

--- a/orchestrator-bundle/orc8r-bundle/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-bundle/tests/integration/test_integration.py
@@ -8,14 +8,34 @@ from pathlib import Path
 import pytest
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
 
+from juju.controller import Controller
+
+
 logger = logging.getLogger(__name__)
 
 
 class TestOrc8rBundle:
+    async def cli_deploy_bundle(ops_test: OpsTest, name: str, channel: str = "edge"):
+        run_args = [
+            "juju",
+            "deploy",
+            "./bundle-local.yaml",
+            "--trust",
+            "-m",
+            ops_test.model_full_name,
+        ]
+
+        retcode, stdout, stderr = await ops_test.run(*run_args)
+        logger.info("Deploying bundle")
+        logger.info(stdout)
+
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail
-    async def deploy_bundle(self, ops_test):
-        pass
+    async def deploy_bundle(self, ops_test: OpsTest):
+        logger.info("Deploying bundle")
+        await cli_deploy_bundle(ops_test, "magma-orc8r")
+        logger.info("Bundle deployed!")
+        
     
-    async def test_relate_and_wait_for_idle(self, ops_test, deploy_bundle):
-        await ops_test.model.wait_for_idle(status="active", timeout=1000)
+    async def test_wait_for_idle(self, ops_test: OpsTest, deploy_bundle):
+        await ops_test.model.wait_for_idle(status="active", timeout=1500)

--- a/orchestrator-bundle/orc8r-bundle/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-bundle/tests/integration/test_integration.py
@@ -3,11 +3,9 @@
 # See LICENSE file for licensing details.
 
 import logging
-from pathlib import Path
 
 import pytest
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
-
 
 logger = logging.getLogger(__name__)
 

--- a/orchestrator-bundle/orc8r-bundle/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-bundle/tests/integration/test_integration.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from pathlib import Path
+
+import pytest
+from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
+
+logger = logging.getLogger(__name__)
+
+
+class TestOrc8rBundle:
+    @pytest.fixture(scope="module")
+    @pytest.mark.abort_on_fail
+    async def deploy_bundle(self, ops_test):
+        pass
+    
+    async def test_relate_and_wait_for_idle(self, ops_test, deploy_bundle):
+        await ops_test.model.wait_for_idle(status="active", timeout=1000)

--- a/orchestrator-bundle/orc8r-bundle/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-bundle/tests/integration/test_integration.py
@@ -8,8 +8,6 @@ from pathlib import Path
 import pytest
 from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
 
-from helpers import (cli_deploy_bundle)
-
 
 logger = logging.getLogger(__name__)
 
@@ -30,4 +28,4 @@ class TestOrc8rBundle:
         logger.info(stdout)
 
     async def test_wait_for_idle(self, ops_test: OpsTest, deploy_bundle):
-        await ops_test.model.wait_for_idle(status="active", timeout=1500)
+        await ops_test.model.wait_for_idle(status="active", timeout=20000)

--- a/orchestrator-bundle/orc8r-bundle/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-bundle/tests/integration/test_integration.py
@@ -30,4 +30,3 @@ class TestOrc8rBundle:
             await ops_test.model.wait_for_idle(status="active", timeout=1000)
         except Exception as e:
             logger.error(e)
-            pass

--- a/orchestrator-bundle/orc8r-bundle/tox.ini
+++ b/orchestrator-bundle/orc8r-bundle/tox.ini
@@ -3,12 +3,11 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, static
+envlist = lint, static, integration
 
 [vars]
-unit_test_path = {toxinidir}/tests/unit/
 integration_test_path = {toxinidir}/tests/integration/
-all_path = {[vars]integration_test_path}
+all_path = {[vars]integration_test_path} {[vars]integration_test_path}
 
 [testenv]
 deps = 
@@ -64,16 +63,6 @@ deps =
 commands =
     mypy {[vars]all_path} {posargs}
 
-[testenv:unit]
-description = Run unit tests
-deps =
-    pytest
-    coverage[toml]
-    -r{toxinidir}/requirements.txt
-commands =
-    coverage run --source -m pytest --ignore {[vars]integration_test_path} -v --tb native -s {posargs}
-    coverage report
-
 [testenv:integration]
 description = Run integration tests
 deps =
@@ -81,5 +70,5 @@ deps =
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
 commands =
-    ; sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv=3.8.10-0ubuntu1~20.04.4
-    pytest --asyncio-mode=auto -v --tb native --log-cli-level=INFO -s {posargs} --destructive-mode
+    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv=3.8.10-0ubuntu1~20.04.4
+    pytest --asyncio-mode=auto -v --tb native --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-bundle/tox.ini
+++ b/orchestrator-bundle/orc8r-bundle/tox.ini
@@ -7,7 +7,7 @@ envlist = lint, static, integration
 
 [vars]
 integration_test_path = {toxinidir}/tests/integration/
-all_path = {[vars]integration_test_path} {[vars]integration_test_path}
+all_path = {[vars]integration_test_path}
 
 [testenv]
 deps = 

--- a/orchestrator-bundle/orc8r-bundle/tox.ini
+++ b/orchestrator-bundle/orc8r-bundle/tox.ini
@@ -1,0 +1,85 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist=True
+skip_missing_interpreters = True
+envlist = lint, static
+
+[vars]
+unit_test_path = {toxinidir}/tests/unit/
+integration_test_path = {toxinidir}/tests/integration/
+all_path = {[vars]integration_test_path}
+
+[testenv]
+deps = 
+    pytest
+    pytest-operator
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}/lib
+    PYTHONBREAKPOINT=ipdb.set_trace
+passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    NO_PROXY
+    PYTHONPATH
+    HOME
+    CHARM_BUILD_DIR
+    MODEL_SETTINGS
+
+[testenv:fmt]
+description = Apply coding style standards to code
+deps =
+    black
+    isort
+commands =
+    isort {[vars]all_path}
+    black {[vars]all_path}
+
+[testenv:lint]
+description = Check code against coding style standards
+deps =
+    black
+    flake8
+    flake8-docstrings
+    flake8-copyright
+    flake8-builtins
+    pyproject-flake8
+    pep8-naming
+    isort
+commands =
+    pflake8 {[vars]all_path}
+    isort --check-only --diff {[vars]all_path}
+    black --check --diff {[vars]all_path}
+
+[testenv:static]
+description = Run static analysis checks
+deps =
+    mypy
+    types-PyYAML
+    pytest
+    pytest-operator
+    juju
+    types-setuptools
+    types-toml
+commands =
+    mypy {[vars]all_path} {posargs}
+
+[testenv:unit]
+description = Run unit tests
+deps =
+    pytest
+    coverage[toml]
+    -r{toxinidir}/requirements.txt
+commands =
+    coverage run --source -m pytest --ignore {[vars]integration_test_path} -v --tb native -s {posargs}
+    coverage report
+
+[testenv:integration]
+description = Run integration tests
+deps =
+    git+https://github.com/juju/python-libjuju.git
+    pytest
+    git+https://github.com/charmed-kubernetes/pytest-operator.git
+commands =
+    ; sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv=3.8.10-0ubuntu1~20.04.4
+    pytest --asyncio-mode=auto -v --tb native --log-cli-level=INFO -s {posargs} --destructive-mode


### PR DESCRIPTION
- Adds integration tests for `orc8r-bundle`
- Modifies `orchestrator.main.yaml` workflow file for running integration tests for the whole bundle instead of individual integration tests for each charm.
- Toggles `--model-default automatically-retry-hooks` to `True` while bootstrapping the controller for solving the issue of events being lost while bundle deployment.
- For running `bundle` integration tests go under `charmed-magma/orchestrator-bundle/orc8r-bundle` and run 
```bash
tox -e integration
```