### PR TITLE
Chore: Uplift magmacore version

### DIFF
--- a/orchestrator-bundle/bundle-local-federated.yaml
+++ b/orchestrator-bundle/bundle-local-federated.yaml
@@ -10,7 +10,7 @@ applications:
     scale: 1
     trust: true
     resources:
-      magma-nms-magmalte-image: docker.artifactory.magmacore.org/magmalte:1.6.0
+      magma-nms-magmalte-image: docker-ci.artifactory.magmacore.org/magmalte:13029
   nms-nginx-proxy:
     charm: ./nms-nginx-proxy-operator/nms-nginx-proxy.charm
     scale: 1
@@ -22,55 +22,55 @@ applications:
     scale: 1
     trust: true
     resources:
-      magma-orc8r-accessd-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-accessd-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-analytics:
     charm: ./orc8r-analytics-operator/orc8r-analytics.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-analytics-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-analytics-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-base-acct:
     charm: ./orc8r-base-acct-operator/magma-orc8r-base-acct.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-base-acct-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-base-acct-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-bootstrapper:
     charm: ./orc8r-bootstrapper-operator/orc8r-bootstrapper.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-bootstrapper-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-bootstrapper-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-configurator:
     charm: ./orc8r-configurator-operator/orc8r-configurator.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-configurator-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-configurator-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-ctraced:
     charm: ./orc8r-ctraced-operator/orc8r-ctraced.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-ctraced-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-ctraced-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-device:
     charm: ./orc8r-device-operator/orc8r-device.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-device-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-device-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-directoryd:
     charm: ./orc8r-directoryd-operator/orc8r-directoryd.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-directoryd-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-directoryd-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-dispatcher:
     charm: ./orc8r-dispatcher-operator/orc8r-dispatcher.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-dispatcher-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-dispatcher-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-eventd:
     charm: ./orc8r-eventd-operator/orc8r-eventd.charm
     scale: 1
@@ -78,31 +78,31 @@ applications:
     options:
       elasticsearch-url: "orc8r-elasticsearch:1234"
     resources:
-      magma-orc8r-eventd-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-eventd-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-feg:
     charm: ./orc8r-feg-operator/magma-orc8r-feg.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-feg-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-feg-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-feg-relay:
     charm: ./orc8r-feg-relay-operator/magma-orc8r-feg-relay.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-feg-relay-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-feg-relay-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-ha:
     charm: ./orc8r-ha-operator/orc8r-ha.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-ha-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-ha-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-health:
     charm: ./orc8r-health-operator/magma-orc8r-health
     scale: 1
     trust: true
     resources:
-      magma-orc8r-health-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-health-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-certifier:
     charm: ./orc8r-certifier-operator/orc8r-certifier.charm
     scale: 1
@@ -110,31 +110,31 @@ applications:
     options:
       domain: example.com
     resources:
-      magma-orc8r-certifier-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-certifier-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-lte:
     charm: ./orc8r-lte-operator/orc8r-lte.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-lte-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-lte-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-metricsd:
     charm: ./orc8r-metricsd-operator/orc8r-metricsd.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-metricsd-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-metricsd-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-nginx:
     charm: ./orc8r-nginx-operator/orc8r-nginx.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-nginx-image: docker.artifactory.magmacore.org/nginx:1.6.0
+      magma-orc8r-nginx-image: docker-ci.artifactory.magmacore.org/nginx:13029
   orc8r-obsidian:
     charm: ./orc8r-obsidian-operator/orc8r-obsidian.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-obsidian-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-obsidian-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-orchestrator:
     charm: ./orc8r-orchestrator-operator/orc8r-orchestrator.charm
     scale: 1
@@ -142,55 +142,55 @@ applications:
     options:
       elasticsearch-url: "orc8r-elasticsearch:1234"
     resources:
-      magma-orc8r-orchestrator-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-orchestrator-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-policydb:
     charm: ./orc8r-policydb-operator/orc8r-policydb.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-policydb-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-policydb-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-service-registry:
     charm: ./orc8r-service-registry-operator/orc8r-service-registry.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-service-registry-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-service-registry-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-smsd:
     charm: ./orc8r-smsd-operator/orc8r-smsd.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-smsd-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-smsd-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-state:
     charm: ./orc8r-state-operator/orc8r-state.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-state-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-state-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-streamer:
     charm: ./orc8r-streamer-operator/orc8r-streamer.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-streamer-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-streamer-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-subscriberdb:
     charm: ./orc8r-subscriberdb-operator/orc8r-subscriberdb.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-subscriberdb-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-subscriberdb-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-subscriberdb-cache:
     charm: ./orc8r-subscriberdb-cache-operator/orc8r-subscriberdb-cache.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-subscriberdb-cache-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-subscriberdb-cache-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-tenants:
     charm: ./orc8r-tenants-operator/orc8r-tenants.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-tenants-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-tenants-image: docker-ci.artifactory.magmacore.org/controller:13029
   postgresql-k8s:
     charm: postgresql-k8s
     series: kubernetes

--- a/orchestrator-bundle/bundle-local.yaml
+++ b/orchestrator-bundle/bundle-local.yaml
@@ -10,7 +10,7 @@ applications:
     scale: 1
     trust: true
     resources:
-      magma-nms-magmalte-image: docker.artifactory.magmacore.org/magmalte:1.6.0
+      magma-nms-magmalte-image: docker-ci.artifactory.magmacore.org/magmalte:13029
   nms-nginx-proxy:
     charm: ./nms-nginx-proxy-operator/nms-nginx-proxy.charm
     scale: 1
@@ -22,49 +22,49 @@ applications:
     scale: 1
     trust: true
     resources:
-      magma-orc8r-accessd-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-accessd-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-analytics:
     charm: ./orc8r-analytics-operator/orc8r-analytics.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-analytics-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-analytics-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-bootstrapper:
     charm: ./orc8r-bootstrapper-operator/orc8r-bootstrapper.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-bootstrapper-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-bootstrapper-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-configurator:
     charm: ./orc8r-configurator-operator/orc8r-configurator.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-configurator-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-configurator-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-ctraced:
     charm: ./orc8r-ctraced-operator/orc8r-ctraced.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-ctraced-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-ctraced-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-device:
     charm: ./orc8r-device-operator/orc8r-device.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-device-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-device-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-directoryd:
     charm: ./orc8r-directoryd-operator/orc8r-directoryd.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-directoryd-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-directoryd-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-dispatcher:
     charm: ./orc8r-dispatcher-operator/orc8r-dispatcher.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-dispatcher-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-dispatcher-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-eventd:
     charm: ./orc8r-eventd-operator/orc8r-eventd.charm
     scale: 1
@@ -72,13 +72,13 @@ applications:
     options:
       elasticsearch-url: "orc8r-elasticsearch:1234"
     resources:
-      magma-orc8r-eventd-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-eventd-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-ha:
     charm: ./orc8r-ha-operator/orc8r-ha.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-ha-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-ha-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-certifier:
     charm: ./orc8r-certifier-operator/orc8r-certifier.charm
     scale: 1
@@ -86,31 +86,31 @@ applications:
     options:
       domain: example.com
     resources:
-      magma-orc8r-certifier-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-certifier-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-lte:
     charm: ./orc8r-lte-operator/orc8r-lte.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-lte-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-lte-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-metricsd:
     charm: ./orc8r-metricsd-operator/orc8r-metricsd.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-metricsd-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-metricsd-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-nginx:
     charm: ./orc8r-nginx-operator/orc8r-nginx.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-nginx-image: docker.artifactory.magmacore.org/nginx:1.6.0
+      magma-orc8r-nginx-image: docker-ci.artifactory.magmacore.org/nginx:13029
   orc8r-obsidian:
     charm: ./orc8r-obsidian-operator/orc8r-obsidian.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-obsidian-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-obsidian-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-orchestrator:
     charm: ./orc8r-orchestrator-operator/orc8r-orchestrator.charm
     scale: 1
@@ -118,55 +118,55 @@ applications:
     options:
       elasticsearch-url: "orc8r-elasticsearch:1234"
     resources:
-      magma-orc8r-orchestrator-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-orchestrator-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-policydb:
     charm: ./orc8r-policydb-operator/orc8r-policydb.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-policydb-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-policydb-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-service-registry:
     charm: ./orc8r-service-registry-operator/orc8r-service-registry.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-service-registry-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-service-registry-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-smsd:
     charm: ./orc8r-smsd-operator/orc8r-smsd.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-smsd-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-smsd-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-state:
     charm: ./orc8r-state-operator/orc8r-state.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-state-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-state-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-streamer:
     charm: ./orc8r-streamer-operator/orc8r-streamer.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-streamer-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-streamer-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-subscriberdb:
     charm: ./orc8r-subscriberdb-operator/orc8r-subscriberdb.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-subscriberdb-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-subscriberdb-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-subscriberdb-cache:
     charm: ./orc8r-subscriberdb-cache-operator/orc8r-subscriberdb-cache.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-subscriberdb-cache-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-subscriberdb-cache-image: docker-ci.artifactory.magmacore.org/controller:13029
   orc8r-tenants:
     charm: ./orc8r-tenants-operator/orc8r-tenants.charm
     scale: 1
     trust: true
     resources:
-      magma-orc8r-tenants-image: docker.artifactory.magmacore.org/controller:1.6.0
+      magma-orc8r-tenants-image: docker-ci.artifactory.magmacore.org/controller:13029
   postgresql-k8s:
     charm: postgresql-k8s
     series: kubernetes

--- a/orchestrator-bundle/bundle-local.yaml
+++ b/orchestrator-bundle/bundle-local.yaml
@@ -210,8 +210,12 @@ relations:
   - postgresql-k8s:db
 - - orc8r-bootstrapper:magma-orc8r-certifier
   - orc8r-certifier:magma-orc8r-certifier
+- - orc8r-bootstrapper:db
+  - postgresql-k8s:db
 - - orc8r-certifier:db
   - postgresql-k8s:db
+- - orc8r-certifier:magma-orc8r-obsidian
+  - orc8r-obsidian:magma-orc8r-obsidian
 - - orc8r-configurator:db
   - postgresql-k8s:db
 - - orc8r-ctraced:db
@@ -234,6 +238,8 @@ relations:
   - orc8r-certifier:magma-orc8r-certifier
 - - orc8r-orchestrator:metrics-endpoint
   - orc8r-prometheus-cache:metrics-endpoint
+- - orc8r-orchestrator:magma-orc8r-accessd
+  - orc8r-accessd:magma-orc8r-accessd
 - - orc8r-policydb:db
   - postgresql-k8s:db
 - - orc8r-prometheus:alertmanager

--- a/orchestrator-bundle/deploy.sh
+++ b/orchestrator-bundle/deploy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-juju deploy ./bundle-local.yaml --trust
+juju deploy ./bundle-local.yaml --trust --overlay overlay.yaml

--- a/orchestrator-bundle/nms-magmalte-operator/README.md
+++ b/orchestrator-bundle/nms-magmalte-operator/README.md
@@ -58,4 +58,4 @@ Currently supported relations are:
 - [postgresql-k8s](https://charmhub.io/postgresql-k8s) - SQL store for magmalte service.
 
 ## OCI Images
-Default: docker.artifactory.magmacore.org/magmalte:1.6.0
+Default: docker-ci.artifactory.magmacore.org/magmalte:13029

--- a/orchestrator-bundle/nms-magmalte-operator/metadata.yaml
+++ b/orchestrator-bundle/nms-magmalte-operator/metadata.yaml
@@ -18,8 +18,8 @@ containers:
 resources:
   magma-nms-magmalte-image:
     type: oci-image
-    description: OCI image for magma-nms-magmalte (docker.artifactory.magmacore.org/magmalte:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/magmalte:1.6.0
+    description: OCI image for magma-nms-magmalte (docker-ci.artifactory.magmacore.org/magmalte:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/magmalte:13029
 
 provides:
   magma-nms-magmalte:

--- a/orchestrator-bundle/nms-magmalte-operator/src/charm.py
+++ b/orchestrator-bundle/nms-magmalte-operator/src/charm.py
@@ -278,7 +278,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
             ],
             timeout=30,
             environment=self._environment_variables,
-            working_dir="/usr/src/packages/magmalte",
+            working_dir="/usr/src/",
         )
         try:
             process.wait_output()

--- a/orchestrator-bundle/nms-magmalte-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/nms-magmalte-operator/tests/unit/test_charm.py
@@ -32,7 +32,6 @@ class TestCharm(unittest.TestCase):
         "port=1234 "
         "user=test_db_user"
     )
-    TEST_DOMAIN_NAME = "test.domain.com"
 
     @patch(
         "charm.KubernetesServicePatch", lambda charm, ports, service_name, additional_labels: None

--- a/orchestrator-bundle/orc8r-accessd-operator/README.md
+++ b/orchestrator-bundle/orc8r-accessd-operator/README.md
@@ -23,4 +23,4 @@ The current setup has only been tested with relation to the `postgresql-k8s` cha
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-accessd-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-accessd-operator/metadata.yaml
@@ -16,7 +16,7 @@ resources:
   magma-orc8r-accessd-image:
     type: oci-image
     description: OCI image for magma-orc8r-accessd
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-accessd:

--- a/orchestrator-bundle/orc8r-accessd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-accessd-operator/src/charm.py
@@ -14,7 +14,7 @@ class MagmaOrc8rAccessdCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9091)],
+            ports=[("grpc", 9180, 9091), ("grpc-internal", 9190, 9191)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
         startup_command = (

--- a/orchestrator-bundle/orc8r-analytics-operator/README.md
+++ b/orchestrator-bundle/orc8r-analytics-operator/README.md
@@ -14,4 +14,4 @@ juju deploy magma-orc8r-analytics orc8r-analytics
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-analytics-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-analytics-operator/metadata.yaml
@@ -19,8 +19,8 @@ containers:
 resources:
   magma-orc8r-analytics-image:
     type: oci-image
-    description: OCI image for magma-orc8r-analytics (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-analytics (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-analytics:

--- a/orchestrator-bundle/orc8r-base-acct-operator/README.md
+++ b/orchestrator-bundle/orc8r-base-acct-operator/README.md
@@ -13,4 +13,4 @@ juju deploy magma-orc8r-base-acct  orc8r-base-acct --trust
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-base-acct-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-base-acct-operator/metadata.yaml
@@ -15,8 +15,8 @@ containers:
 resources:
   magma-orc8r-base-acct-image:
     type: oci-image
-    description: OCI image for magma-orc8r-base-acct (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-base-acct (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-base-acct:

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/README.md
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/README.md
@@ -14,4 +14,4 @@ juju relate orc8r-bootstrapper orc8r-certifier
 **IMPORTANT**: For now, deploying this charm must be done with an alias as shown above.
 
 ## OCI Images
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/metadata.yaml
@@ -16,8 +16,8 @@ containers:
 resources:
   magma-orc8r-bootstrapper-image:
     type: oci-image
-    description: OCI image for magma-orc8r-bootstrapper (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-bootstrapper (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-bootstrapper:

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/metadata.yaml
@@ -24,6 +24,9 @@ provides:
     interface: magma-orc8r-bootstrapper
 
 requires:
+  db:
+    interface: pgsql
+    limit: 1
   magma-orc8r-certifier:
     interface: magma-orc8r-certifier
     limit: 1

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/canonical/operator/#egg=ops
+ops-lib-pgsql
 lightkube
 lightkube-models

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/src/charm.py
@@ -31,6 +31,7 @@ from pgconnstr import ConnectionString  # type: ignore[import]
 logger = logging.getLogger(__name__)
 pgsql = ops.lib.use("pgsql", 1, "postgresql-charmers@lists.launchpad.net")
 
+
 class MagmaOrc8rBootstrapperCharm(CharmBase):
 
     DB_NAME = "magma_dev"
@@ -267,7 +268,7 @@ class MagmaOrc8rBootstrapperCharm(CharmBase):
         """Returns DB connection string provided by the DB relation."""
         try:
             db_relation = self.model.get_relation("db")
-            return ConnectionString(db_relation.data[db_relation.app]["master"])
+            return ConnectionString(db_relation.data[db_relation.app]["master"])  # type: ignore[union-attr, index]  # noqa: E501
         except (AttributeError, KeyError):
             return
 
@@ -280,8 +281,8 @@ class MagmaOrc8rBootstrapperCharm(CharmBase):
         """Returns domain name provided by the orc8r-certifier relation."""
         try:
             certifier_relation = self.model.get_relation("certifier")
-            units = certifier_relation.units
-            return certifier_relation.data[next(iter(units))]["domain"]
+            units = certifier_relation.units  # type: ignore[union-attr]
+            return certifier_relation.data[next(iter(units))]["domain"]  # type: ignore[union-attr]
         except (KeyError, StopIteration):
             return None
 

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/src/charm.py
@@ -42,6 +42,10 @@ class MagmaOrc8rBootstrapperCharm(CharmBase):
         self._container = self.unit.get_container(self._container_name)
         self._db = pgsql.PostgreSQLClient(self, "db")
         self.framework.observe(
+            self._db.on.database_relation_joined,
+            self._on_database_relation_joined,
+        )
+        self.framework.observe(
             self.on.magma_orc8r_bootstrapper_pebble_ready,
             self._on_magma_orc8r_bootstrapper_pebble_ready,
         )

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/tests/unit/test_charm.py
@@ -5,7 +5,8 @@ import unittest
 from unittest.mock import Mock, PropertyMock, patch
 
 from ops import testing
-from ops.model import BlockedStatus
+from ops.model import ActiveStatus, BlockedStatus
+from pgconnstr import ConnectionString  # type: ignore[import]
 
 from charm import MagmaOrc8rBootstrapperCharm
 
@@ -13,12 +14,41 @@ testing.SIMULATE_CAN_CONNECT = True
 
 
 class TestCharm(unittest.TestCase):
+
+    TEST_DB_NAME = MagmaOrc8rBootstrapperCharm.DB_NAME
+    TEST_DB_PORT = "1234"
+    TEST_DB_CONNECTION_STRING = ConnectionString(
+        "dbname=test_db_name "
+        "fallback_application_name=whatever "
+        "host=123.456.789.101 "
+        "password=test-password"
+        "port=1234"
+        "user=test_user"
+    )
+
     @patch("charm.KubernetesServicePatch", lambda charm, ports, additional_labels: None)
     def setUp(self):
         self.harness = testing.Harness(MagmaOrc8rBootstrapperCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
         self.maxDiff = None
+
+    @staticmethod
+    def _fake_db_event(
+        postgres_db_name: str,
+        postgres_username: str,
+        postgres_password: str,
+        postgres_host: str,
+        postgres_port: str,
+    ):
+        db_event = Mock()
+        db_event.master = Mock()
+        db_event.master.dbname = postgres_db_name
+        db_event.master.user = postgres_username
+        db_event.master.password = postgres_password
+        db_event.master.host = postgres_host
+        db_event.master.port = postgres_port
+        return db_event
 
     def test_given_charm_when_pebble_ready_event_emitted_and_no_relations_established_then_charm_goes_to_blocked_state(  # noqa: E501
         self,
@@ -30,6 +60,8 @@ class TestCharm(unittest.TestCase):
             BlockedStatus("Waiting for magma-orc8r-certifier relation to be created"),
         )
 
+    @patch("charm.MagmaOrc8rBootstrapperCharm._domain_name", new_callable=PropertyMock)
+    @patch("charm.MagmaOrc8rBootstrapperCharm._get_db_connection_string", new_callable=PropertyMock)
     @patch("charm.MagmaOrc8rBootstrapperCharm._namespace", new_callable=PropertyMock)
     @patch(
         "charm.MagmaOrc8rBootstrapperCharm._orc8r_certs_mounted", PropertyMock(return_value=True)
@@ -43,10 +75,12 @@ class TestCharm(unittest.TestCase):
         PropertyMock(return_value=True),
     )
     def test_given_ready_when_get_plan_then_plan_is_filled_with_magma_orc8r_bootstrapper_service_content(  # noqa: E501
-        self, patch_namespace
+        self, patch_namespace, get_db_connection_string, _domain_name
     ):
+        _domain_name.return_value = "test.domain"
         namespace = "whatever"
         patch_namespace.return_value = namespace
+        get_db_connection_string.return_value = self.TEST_DB_CONNECTION_STRING
         expected_plan = {
             "services": {
                 "magma-orc8r-bootstrapper": {
@@ -59,8 +93,18 @@ class TestCharm(unittest.TestCase):
                     "-logtostderr=true "
                     "-v=0",
                     "environment": {
+                        "ORC8R_DOMAIN_NAME": "test.domain",
+                        "SERVICE_HOSTNAME": "magma-orc8r-bootstrapper",
                         "SERVICE_REGISTRY_MODE": "k8s",
                         "SERVICE_REGISTRY_NAMESPACE": namespace,
+                        "DATABASE_SOURCE": f"dbname={self.TEST_DB_NAME} "
+                        f"user={self.TEST_DB_CONNECTION_STRING.user} "
+                        f"password={self.TEST_DB_CONNECTION_STRING.password} "
+                        f"host={self.TEST_DB_CONNECTION_STRING.host} "
+                        f"port={self.TEST_DB_CONNECTION_STRING.port} "
+                        f"sslmode=disable",
+                        "SQL_DRIVER": "postgres",
+                        "SQL_DIALECT": "psql",
                     },
                 },
             },
@@ -95,6 +139,44 @@ class TestCharm(unittest.TestCase):
         self.harness.update_relation_data(relation_id, "orc8r-certifier/0", {"active": "True"})
 
         mock_on_certifier_relation_changed.assert_not_called()
+
+    @patch("ops.model.Unit.is_leader")
+    def test_given_pod_is_leader_when_database_relation_joined_event_then_database_is_set_correctly(  # noqa: E501
+        self, is_leader
+    ):
+        is_leader.return_value = True
+        postgres_db_name = self.TEST_DB_NAME
+        postgres_host = "test_host"
+        postgres_password = "password123"
+        postgres_username = "test_user"
+        postgres_port = self.TEST_DB_PORT
+        db_event = self._fake_db_event(
+            postgres_db_name,
+            postgres_username,
+            postgres_password,
+            postgres_host,
+            postgres_port,
+        )
+        self.harness.charm._on_database_relation_joined(db_event)
+
+        self.assertEqual(db_event.database, self.TEST_DB_NAME)
+
+    @patch("charm.MagmaOrc8rBootstrapperCharm._orc8r_certs_mounted")
+    def test_given_charm_when_pebble_ready_event_emitted_and_certifier_relation_is_established_and_certs_mounted_but_db_relation_is_missing_then_charm_goes_to_blocked_state(  # noqa: E501
+        self, mock_orc8r_certs_mounted
+    ):
+        event = Mock()
+        relation_id = self.harness.add_relation("certifier", "orc8r-certifier")
+        self.harness.add_relation_unit(relation_id, "orc8r-certifier/0")
+
+        mock_orc8r_certs_mounted.return_value = True
+
+        self.harness.charm.on.magma_orc8r_bootstrapper_pebble_ready.emit(event)
+
+        self.assertEqual(
+            self.harness.charm.unit.status,
+            BlockedStatus("Waiting for database relation to be established"),
+        )
 
     @patch("charm.MagmaOrc8rBootstrapperCharm._namespace", PropertyMock(return_value="qwerty"))
     @patch(
@@ -146,3 +228,34 @@ class TestCharm(unittest.TestCase):
             self.harness.get_relation_data(relation_id, "magma-orc8r-bootstrapper/0"),
             {"active": "False"},
         )
+
+    @patch("charm.MagmaOrc8rBootstrapperCharm._orc8r_certs_mounted")
+    @patch("charm.MagmaOrc8rBootstrapperCharm._get_db_connection_string", new_callable=PropertyMock)
+    @patch("charm.MagmaOrc8rBootstrapperCharm._configure_pebble")
+    def test_given_charm_when_pebble_ready_event_emitted_and_relations_are_established_and_certs_mounted_configure_pebble_is_called(  # noqa: E501
+        self, mock_configure_pebble, get_db_connection_string, mock_orc8r_certs_mounted,
+    ):
+        relation_id = self.harness.add_relation("certifier", "orc8r-certifier")
+        self.harness.add_relation_unit(relation_id, "orc8r-certifier/0")
+
+        mock_orc8r_certs_mounted.return_value=True
+        get_db_connection_string.return_value = self.TEST_DB_CONNECTION_STRING
+
+        event=Mock()
+        self.harness.charm.on.magma_orc8r_bootstrapper_pebble_ready.emit(event)
+
+        mock_configure_pebble.assert_called_once()
+
+    @patch("charm.MagmaOrc8rBootstrapperCharm._orc8r_certs_mounted")
+    @patch("charm.MagmaOrc8rBootstrapperCharm._get_db_connection_string", new_callable=PropertyMock)
+    def test_given_charm_when_pebble_ready_event_emitted_and_relations_are_established_and_certs_mounted_then_charm_goes_to_active_state(  # noqa: E501
+        self, get_db_connection_string, mock_orc8r_certs_mounted
+    ):
+        mock_orc8r_certs_mounted.return_value=True
+        relation_id = self.harness.add_relation("certifier", "orc8r-certifier")
+        self.harness.add_relation_unit(relation_id, "orc8r-certifier/0")
+        get_db_connection_string.return_value = self.TEST_DB_CONNECTION_STRING
+        self.harness.container_pebble_ready(container_name="magma-orc8r-bootstrapper")
+
+        self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
+

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/tests/unit/test_charm.py
@@ -61,7 +61,9 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.MagmaOrc8rBootstrapperCharm._domain_name", new_callable=PropertyMock)
-    @patch("charm.MagmaOrc8rBootstrapperCharm._get_db_connection_string", new_callable=PropertyMock)
+    @patch(
+        "charm.MagmaOrc8rBootstrapperCharm._get_db_connection_string", new_callable=PropertyMock
+    )
     @patch("charm.MagmaOrc8rBootstrapperCharm._namespace", new_callable=PropertyMock)
     @patch(
         "charm.MagmaOrc8rBootstrapperCharm._orc8r_certs_mounted", PropertyMock(return_value=True)
@@ -230,32 +232,38 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.MagmaOrc8rBootstrapperCharm._orc8r_certs_mounted")
-    @patch("charm.MagmaOrc8rBootstrapperCharm._get_db_connection_string", new_callable=PropertyMock)
+    @patch(
+        "charm.MagmaOrc8rBootstrapperCharm._get_db_connection_string", new_callable=PropertyMock
+    )
     @patch("charm.MagmaOrc8rBootstrapperCharm._configure_pebble")
     def test_given_charm_when_pebble_ready_event_emitted_and_relations_are_established_and_certs_mounted_configure_pebble_is_called(  # noqa: E501
-        self, mock_configure_pebble, get_db_connection_string, mock_orc8r_certs_mounted,
+        self,
+        mock_configure_pebble,
+        get_db_connection_string,
+        mock_orc8r_certs_mounted,
     ):
         relation_id = self.harness.add_relation("certifier", "orc8r-certifier")
         self.harness.add_relation_unit(relation_id, "orc8r-certifier/0")
 
-        mock_orc8r_certs_mounted.return_value=True
+        mock_orc8r_certs_mounted.return_value = True
         get_db_connection_string.return_value = self.TEST_DB_CONNECTION_STRING
 
-        event=Mock()
+        event = Mock()
         self.harness.charm.on.magma_orc8r_bootstrapper_pebble_ready.emit(event)
 
         mock_configure_pebble.assert_called_once()
 
     @patch("charm.MagmaOrc8rBootstrapperCharm._orc8r_certs_mounted")
-    @patch("charm.MagmaOrc8rBootstrapperCharm._get_db_connection_string", new_callable=PropertyMock)
+    @patch(
+        "charm.MagmaOrc8rBootstrapperCharm._get_db_connection_string", new_callable=PropertyMock
+    )
     def test_given_charm_when_pebble_ready_event_emitted_and_relations_are_established_and_certs_mounted_then_charm_goes_to_active_state(  # noqa: E501
         self, get_db_connection_string, mock_orc8r_certs_mounted
     ):
-        mock_orc8r_certs_mounted.return_value=True
+        mock_orc8r_certs_mounted.return_value = True
         relation_id = self.harness.add_relation("certifier", "orc8r-certifier")
         self.harness.add_relation_unit(relation_id, "orc8r-certifier/0")
         get_db_connection_string.return_value = self.TEST_DB_CONNECTION_STRING
         self.harness.container_pebble_ready(container_name="magma-orc8r-bootstrapper")
 
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
-

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/tests/unit/test_charm.py
@@ -144,7 +144,7 @@ class TestCharm(unittest.TestCase):
         mock_on_certifier_relation_changed.assert_not_called()
 
     def test_given_pod_is_leader_when_database_relation_joined_event_then_database_is_set_correctly(  # noqa: E501
-        self
+        self,
     ):
         postgres_db_name = self.TEST_DB_NAME
         postgres_host = "test_host"
@@ -169,8 +169,7 @@ class TestCharm(unittest.TestCase):
         event = Mock()
         relation_id = self.harness.add_relation("magma-orc8r-certifier", "orc8r-certifier")
         self.harness.add_relation_unit(relation_id, "orc8r-certifier/0")
-        self.harness.update_relation_data(
-            relation_id, "orc8r-certifier/0", {"active": "True"})
+        self.harness.update_relation_data(relation_id, "orc8r-certifier/0", {"active": "True"})
 
         mock_orc8r_certs_mounted.return_value = True
 
@@ -194,12 +193,12 @@ class TestCharm(unittest.TestCase):
         "charm.MagmaOrc8rBootstrapperCharm._orc8r_certs_mounted", PropertyMock(return_value=True)
     )
     @patch(
-        "charm.MagmaOrc8rBootstrapperCharm._db_relation_established", PropertyMock(
-            return_value=True)
+        "charm.MagmaOrc8rBootstrapperCharm._db_relation_established",
+        PropertyMock(return_value=True),
     )
     @patch(
-        "charm.MagmaOrc8rBootstrapperCharm._get_db_connection_string", PropertyMock(
-            return_value=TEST_DB_CONNECTION_STRING)
+        "charm.MagmaOrc8rBootstrapperCharm._get_db_connection_string",
+        PropertyMock(return_value=TEST_DB_CONNECTION_STRING),
     )
     def test_given_magma_orc8r_bootstrapper_service_running_when_magma_orc8r_bootstrapper_relation_joined_event_emitted_then_active_key_in_relation_data_is_set_to_true(  # noqa: E501
         self,
@@ -251,8 +250,7 @@ class TestCharm(unittest.TestCase):
     ):
         relation_id = self.harness.add_relation("magma-orc8r-certifier", "orc8r-certifier")
         self.harness.add_relation_unit(relation_id, "orc8r-certifier/0")
-        self.harness.update_relation_data(
-            relation_id, "orc8r-certifier/0", {"active": "True"})
+        self.harness.update_relation_data(relation_id, "orc8r-certifier/0", {"active": "True"})
 
         mock_orc8r_certs_mounted.return_value = True
         get_db_connection_string.return_value = self.TEST_DB_CONNECTION_STRING
@@ -272,8 +270,7 @@ class TestCharm(unittest.TestCase):
         mock_orc8r_certs_mounted.return_value = True
         relation_id = self.harness.add_relation("magma-orc8r-certifier", "orc8r-certifier")
         self.harness.add_relation_unit(relation_id, "orc8r-certifier/0")
-        self.harness.update_relation_data(
-            relation_id, "orc8r-certifier/0", {"active": "True"})
+        self.harness.update_relation_data(relation_id, "orc8r-certifier/0", {"active": "True"})
 
         get_db_connection_string.return_value = self.TEST_DB_CONNECTION_STRING
         self.harness.container_pebble_ready(container_name="magma-orc8r-bootstrapper")

--- a/orchestrator-bundle/orc8r-certifier-operator/README.md
+++ b/orchestrator-bundle/orc8r-certifier-operator/README.md
@@ -49,7 +49,7 @@ juju deploy ./magma-orc8r-certifier_ubuntu-20.04-amd64.charm orc8r-certifier \
  --config certifier-pem="$(cat /home/ubuntu/certs/certifier.pem)" \
  --config rootCA-key="$(cat /home/ubuntu/certs/rootCA.key)" \
  --config rootCA-pem="$(cat /home/ubuntu/certs/rootCA.pem)" \
- --resource magma-orc8r-certifier-image=docker.artifactory.magmacore.org/controller:1.6.0
+ --resource magma-orc8r-certifier-image=docker-ci.artifactory.magmacore.org/controller:13029
 ```
 
 #### With self-signed certificates
@@ -57,7 +57,7 @@ juju deploy ./magma-orc8r-certifier_ubuntu-20.04-amd64.charm orc8r-certifier \
 ```bash
 juju deploy ./magma-orc8r-certifier_ubuntu-20.04-amd64.charm orc8r-certifier \
   --config domain=example.com \
-  --resource magma-orc8r-certifier-image=docker.artifactory.magmacore.org/controller:1.6.0
+  --resource magma-orc8r-certifier-image=docker-ci.artifactory.magmacore.org/controller:13029
 ```
 
 By default, the passphrase to open the `admin_operator.pfx` file is `password123`. This can be 
@@ -85,4 +85,4 @@ The current setup has only been tested with relation to the `postgresql-k8s` cha
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-certifier-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-certifier-operator/metadata.yaml
@@ -19,8 +19,8 @@ containers:
 resources:
   magma-orc8r-certifier-image:
     type: oci-image
-    description: OCI image for magma-orc8r-certifier (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-certifier (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 storage:
   config:
@@ -36,3 +36,5 @@ requires:
   db:
     interface: pgsql
     limit: 1
+  magma-orc8r-obsidian:
+    interface: magma-orc8r-obsidian

--- a/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
@@ -86,12 +86,11 @@ class MagmaOrc8rCertifierCharm(CharmBase):
         self._orc8r_certs_data = {}
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9086), ("http", 8080, 10089),
-                    ("grpc-internal", 9190, 9186)],
+            ports=[("grpc", 9180, 9086), ("http", 8080, 10089), ("grpc-internal", 9190, 9186)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/analytics_collector": "true",
-                 "orc8r.io/obsidian_handlers": "true",
+                "orc8r.io/obsidian_handlers": "true",
             },
             additional_annotations={
                 "orc8r.io/obsidian_handlers_path_prefixes": "/magma/v1/user"  # noqa: E501

--- a/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
@@ -86,10 +86,15 @@ class MagmaOrc8rCertifierCharm(CharmBase):
         self._orc8r_certs_data = {}
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9086)],
+            ports=[("grpc", 9180, 9086), ("http", 8080, 10089),
+                    ("grpc-internal", 9190, 9186)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/analytics_collector": "true",
+                 "orc8r.io/obsidian_handlers": "true",
+            },
+            additional_annotations={
+                "orc8r.io/obsidian_handlers_path_prefixes": "/magma/v1/user"  # noqa: E501
             },
         )
 
@@ -416,6 +421,7 @@ class MagmaOrc8rCertifierCharm(CharmBase):
                         f"-cak={self.BASE_CERTS_PATH}/certifier.key "
                         f"-vpnc={self.BASE_CERTS_PATH}/vpn_ca.crt "
                         f"-vpnk={self.BASE_CERTS_PATH}/vpn_ca.key "
+                        "-run_echo_server=true "
                         "-logtostderr=true "
                         "-v=0",
                         "environment": {

--- a/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
@@ -11,8 +11,7 @@ from pytest_operator.plugin import OpsTest  # type: ignore[import]  # noqa: F401
 
 logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-OBSIDIAN_METADATA = yaml.safe_load(
-    Path("../orc8r-obsidian-operator/metadata.yaml").read_text())
+OBSIDIAN_METADATA = yaml.safe_load(Path("../orc8r-obsidian-operator/metadata.yaml").read_text())
 
 APPLICATION_NAME = "orc8r-certifier"
 CHARM_NAME = "magma-orc8r-certifier"

--- a/orchestrator-bundle/orc8r-certifier-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/tests/unit/test_charm.py
@@ -30,7 +30,7 @@ class TestCharm(unittest.TestCase):
         "user=test_db_user"
     )
 
-    @patch("charm.KubernetesServicePatch", lambda charm, ports, additional_labels: None)
+    @patch("charm.KubernetesServicePatch", lambda charm, ports,  additional_annotations, additional_labels: None)
     def setUp(self):
         self.harness = testing.Harness(MagmaOrc8rCertifierCharm)
         self.addCleanup(self.harness.cleanup)
@@ -109,6 +109,7 @@ class TestCharm(unittest.TestCase):
                     "-cak=/var/opt/magma/certs/certifier.key "
                     "-vpnc=/var/opt/magma/certs/vpn_ca.crt "
                     "-vpnk=/var/opt/magma/certs/vpn_ca.key "
+                    "-run_echo_server=true "
                     "-logtostderr=true "
                     "-v=0",
                     "environment": {

--- a/orchestrator-bundle/orc8r-certifier-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/tests/unit/test_charm.py
@@ -30,7 +30,10 @@ class TestCharm(unittest.TestCase):
         "user=test_db_user"
     )
 
-    @patch("charm.KubernetesServicePatch", lambda charm, ports,  additional_annotations, additional_labels: None)
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda charm, ports, additional_annotations, additional_labels: None,
+    )  # noqa: E501
     def setUp(self):
         self.harness = testing.Harness(MagmaOrc8rCertifierCharm)
         self.addCleanup(self.harness.cleanup)

--- a/orchestrator-bundle/orc8r-configurator-operator/README.md
+++ b/orchestrator-bundle/orc8r-configurator-operator/README.md
@@ -22,4 +22,4 @@ The current setup has only been tested with relation to the `postgresql-k8s` cha
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-configurator-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-configurator-operator/metadata.yaml
@@ -16,8 +16,8 @@ containers:
 resources:
   magma-orc8r-configurator-image:
     type: oci-image
-    description: OCI image for magma-orc8r-configurator (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-configurator (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-configurator:

--- a/orchestrator-bundle/orc8r-configurator-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-configurator-operator/src/charm.py
@@ -14,7 +14,7 @@ class MagmaOrc8rConfiguratorCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9108)],
+            ports=[("grpc", 9180, 9108), ("grpc-internal", 9190, 9208)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
         startup_command = (

--- a/orchestrator-bundle/orc8r-ctraced-operator/README.md
+++ b/orchestrator-bundle/orc8r-ctraced-operator/README.md
@@ -21,4 +21,4 @@ The current setup has only been tested with relation to the `postgresql-k8s` cha
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-ctraced-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-ctraced-operator/metadata.yaml
@@ -14,8 +14,8 @@ containers:
 resources:
   magma-orc8r-ctraced-image:
     type: oci-image
-    description: OCI image for magma-orc8r-ctraced (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-ctraced (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-ctraced:

--- a/orchestrator-bundle/orc8r-device-operator/README.md
+++ b/orchestrator-bundle/orc8r-device-operator/README.md
@@ -21,4 +21,4 @@ The current setup has only been tested with relation to the `postgresql-k8s` cha
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-device-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-device-operator/metadata.yaml
@@ -14,8 +14,8 @@ containers:
 resources:
   magma-orc8r-device-image:
     type: oci-image
-    description: OCI image for magma-orc8r-device (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-device (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-device:

--- a/orchestrator-bundle/orc8r-device-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-device-operator/src/charm.py
@@ -14,7 +14,7 @@ class MagmaOrc8rDeviceCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9106)],
+            ports=[("grpc", 9180, 9106), ("grpc-internal", 9190, 9306)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
         startup_command = (

--- a/orchestrator-bundle/orc8r-directoryd-operator/README.md
+++ b/orchestrator-bundle/orc8r-directoryd-operator/README.md
@@ -21,4 +21,4 @@ The current setup has only been tested with relation to the `postgresql-k8s` cha
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-directoryd-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-directoryd-operator/metadata.yaml
@@ -15,8 +15,8 @@ containers:
 resources:
   magma-orc8r-directoryd-image:
     type: oci-image
-    description: OCI image for magma-orc8r-directoryd (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-directoryd (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-directoryd:

--- a/orchestrator-bundle/orc8r-directoryd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-directoryd-operator/src/charm.py
@@ -14,7 +14,7 @@ class MagmaOrc8rDirectorydCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9100)],
+            ports=[("grpc", 9180, 9100), ("grpc-internal", 9190, 9102)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
         startup_command = (

--- a/orchestrator-bundle/orc8r-dispatcher-operator/README.md
+++ b/orchestrator-bundle/orc8r-dispatcher-operator/README.md
@@ -13,4 +13,4 @@ juju deploy magma-orc8r-dispatcher orc8r-dispatcher
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-dispatcher-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-dispatcher-operator/metadata.yaml
@@ -14,8 +14,8 @@ containers:
 resources:
   magma-orc8r-dispatcher-image:
     type: oci-image
-    description: OCI image for magma-orc8r-dispatcher (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-dispatcher (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-dispatcher:

--- a/orchestrator-bundle/orc8r-eventd-operator/README.md
+++ b/orchestrator-bundle/orc8r-eventd-operator/README.md
@@ -26,4 +26,4 @@ charmcraft pack
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-eventd-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-eventd-operator/metadata.yaml
@@ -23,8 +23,8 @@ containers:
 resources:
   magma-orc8r-eventd-image:
     type: oci-image
-    description: OCI image for magma-orc8r-eventd (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-eventd (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-eventd:

--- a/orchestrator-bundle/orc8r-eventd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-eventd-operator/src/charm.py
@@ -24,7 +24,8 @@ class MagmaOrc8rEventdCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9121), ("http", 8080, 10121)],
+            ports=[("grpc", 9180, 9121), ("http", 8080, 10121),
+                   ("grpc-internal", 9190, 9221)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/obsidian_handlers": "true",

--- a/orchestrator-bundle/orc8r-eventd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-eventd-operator/src/charm.py
@@ -24,8 +24,7 @@ class MagmaOrc8rEventdCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9121), ("http", 8080, 10121),
-                   ("grpc-internal", 9190, 9221)],
+            ports=[("grpc", 9180, 9121), ("http", 8080, 10121), ("grpc-internal", 9190, 9221)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/obsidian_handlers": "true",

--- a/orchestrator-bundle/orc8r-feg-operator/README.md
+++ b/orchestrator-bundle/orc8r-feg-operator/README.md
@@ -15,4 +15,4 @@ juju deploy magma-orc8r-feg  orc8r-feg --trust
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-feg-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-feg-operator/metadata.yaml
@@ -19,8 +19,8 @@ containers:
 resources:
   magma-orc8r-feg-image:
     type: oci-image
-    description: OCI image for magma-orc8r-feg (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-feg (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-feg:

--- a/orchestrator-bundle/orc8r-feg-relay-operator/README.md
+++ b/orchestrator-bundle/orc8r-feg-relay-operator/README.md
@@ -14,4 +14,4 @@ juju deploy magma-orc8r-feg-relay  orc8r-feg-relay --trust
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-feg-relay-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-feg-relay-operator/metadata.yaml
@@ -15,8 +15,8 @@ containers:
 resources:
   magma-orc8r-feg-relay-image:
     type: oci-image
-    description: OCI image for magma-orc8r-feg-relay (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-feg-relay (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 
 provides:

--- a/orchestrator-bundle/orc8r-ha-operator/README.md
+++ b/orchestrator-bundle/orc8r-ha-operator/README.md
@@ -13,4 +13,4 @@ juju deploy magma-orc8r-ha orc8r-ha
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-ha-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-ha-operator/metadata.yaml
@@ -16,8 +16,8 @@ containers:
 resources:
   magma-orc8r-ha-image:
     type: oci-image
-    description: OCI image for magma-orc8r-ha (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-ha (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-ha:

--- a/orchestrator-bundle/orc8r-health-operator/README.md
+++ b/orchestrator-bundle/orc8r-health-operator/README.md
@@ -13,4 +13,4 @@ juju deploy magma-orc8r-health  orc8r-health --trust
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-health-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-health-operator/metadata.yaml
@@ -15,8 +15,8 @@ containers:
 resources:
   magma-orc8r-health-image:
     type: oci-image
-    description: OCI image for magma-orc8r-health (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-health (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-health:

--- a/orchestrator-bundle/orc8r-libs/tests/test_orc8r_base_charm/metadata.yaml
+++ b/orchestrator-bundle/orc8r-libs/tests/test_orc8r_base_charm/metadata.yaml
@@ -16,8 +16,8 @@ containers:
 resources:
   magma-orc8r-dummy-image:
     type: oci-image
-    description: OCI image for magma-orc8r-dummy (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-dummy (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-dummy:

--- a/orchestrator-bundle/orc8r-libs/tests/test_orc8r_base_db_charm/metadata.yaml
+++ b/orchestrator-bundle/orc8r-libs/tests/test_orc8r_base_db_charm/metadata.yaml
@@ -15,8 +15,8 @@ containers:
 resources:
   magma-orc8r-dummy-image:
     type: oci-image
-    description: OCI image for magma-orc8r-dummy (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-dummy (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 requires:
   db:

--- a/orchestrator-bundle/orc8r-lte-operator/README.md
+++ b/orchestrator-bundle/orc8r-lte-operator/README.md
@@ -23,4 +23,4 @@ The current setup has only been tested with relation to the `postgresql-k8s` cha
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-lte-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-lte-operator/metadata.yaml
@@ -21,8 +21,8 @@ containers:
 resources:
   magma-orc8r-lte-image:
     type: oci-image
-    description: OCI image for magma-orc8r-lte (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-lte (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-lte:

--- a/orchestrator-bundle/orc8r-lte-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-lte-operator/src/charm.py
@@ -21,7 +21,8 @@ class MagmaOrc8rLteCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9113), ("http", 8080, 10113)],
+            ports=[("grpc", 9180, 9113), ("http", 8080, 10113),
+                   ("grpc-internal", 9190, 9213)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/analytics_collector": "true",

--- a/orchestrator-bundle/orc8r-lte-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-lte-operator/src/charm.py
@@ -21,8 +21,7 @@ class MagmaOrc8rLteCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9113), ("http", 8080, 10113),
-                   ("grpc-internal", 9190, 9213)],
+            ports=[("grpc", 9180, 9113), ("http", 8080, 10113), ("grpc-internal", 9190, 9213)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/analytics_collector": "true",

--- a/orchestrator-bundle/orc8r-metricsd-operator/README.md
+++ b/orchestrator-bundle/orc8r-metricsd-operator/README.md
@@ -13,4 +13,4 @@ juju deploy magma-orc8r-metricsd orc8r-metricsd
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-metricsd-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-metricsd-operator/metadata.yaml
@@ -17,8 +17,8 @@ containers:
 resources:
   magma-orc8r-metricsd-image:
     type: oci-image
-    description: OCI image for magma-orc8r-metricsd (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-metricsd (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-metricsd:

--- a/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
@@ -29,7 +29,8 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9084), ("http", 8080, 10084)],
+            ports=[("grpc", 9180, 9084), ("http", 8080, 10084),
+                    ("grpc-internal", 9190, 9184)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/obsidian_handlers": "true",

--- a/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
@@ -29,8 +29,7 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9084), ("http", 8080, 10084),
-                    ("grpc-internal", 9190, 9184)],
+            ports=[("grpc", 9180, 9084), ("http", 8080, 10084), ("grpc-internal", 9190, 9184)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/obsidian_handlers": "true",

--- a/orchestrator-bundle/orc8r-nginx-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-nginx-operator/metadata.yaml
@@ -15,8 +15,8 @@ containers:
 resources:
   magma-orc8r-nginx-image:
     type: oci-image
-    description: OCI image for magma-orc8r-nginx (docker.artifactory.magmacore.org/nginx:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/nginx:1.6.0
+    description: OCI image for magma-orc8r-nginx (docker-ci.artifactory.magmacore.org/nginx:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/nginx:13029
 
 requires:
   magma-orc8r-bootstrapper:

--- a/orchestrator-bundle/orc8r-nginx-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-nginx-operator/src/charm.py
@@ -122,6 +122,9 @@ class MagmaOrc8rNginxCharm(CharmBase):
                 "CONTROLLER_HOSTNAME": f"controller.{self._get_domain_name}",
                 "RESOLVER": "kube-dns.kube-system.svc.cluster.local valid=10s",
                 "SERVICE_REGISTRY_MODE": "k8s",
+                "SSL_CERTIFICATE": "/var/opt/magma/certs/controller.crt",
+                "SSL_CERTIFICATE_KEY": "/var/opt/magma/certs/controller.key",
+                "SSL_CLIENT_CERTIFICATE": "/var/opt/magma/certs/certifier.pem",
             },
         )
         stdout, _ = process.wait_output()

--- a/orchestrator-bundle/orc8r-nginx-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-nginx-operator/tests/unit/test_charm.py
@@ -307,6 +307,9 @@ class TestCharm(unittest.TestCase):
                 "CONTROLLER_HOSTNAME": "controller.True",
                 "RESOLVER": "kube-dns.kube-system.svc.cluster.local valid=10s",
                 "SERVICE_REGISTRY_MODE": "k8s",
+                "SSL_CERTIFICATE": "/var/opt/magma/certs/controller.crt",
+                "SSL_CERTIFICATE_KEY": "/var/opt/magma/certs/controller.key",
+                "SSL_CLIENT_CERTIFICATE": "/var/opt/magma/certs/certifier.pem",
             },
         )
 

--- a/orchestrator-bundle/orc8r-obsidian-operator/README.md
+++ b/orchestrator-bundle/orc8r-obsidian-operator/README.md
@@ -13,4 +13,4 @@ juju deploy magma-orc8r-obsidian orc8r-obsidian
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-obsidian-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-obsidian-operator/metadata.yaml
@@ -17,8 +17,8 @@ containers:
 resources:
   magma-orc8r-obsidian-image:
     type: oci-image
-    description: OCI image for magma-orc8r-nginx (docker.artifactory.magmacore.org/nginx:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-nginx (docker-ci.artifactory.magmacore.org/nginx:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-obsidian:

--- a/orchestrator-bundle/orc8r-orchestrator-operator/README.md
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/README.md
@@ -49,4 +49,4 @@ juju run-action orc8r-orchestrator/0 set-log-verbosity level=10 service=obsidian
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-orchestrator-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/metadata.yaml
@@ -20,8 +20,8 @@ containers:
 resources:
   magma-orc8r-orchestrator-image:
     type: oci-image
-    description: OCI image for magma-orc8r-orchestrator (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-orchestrator (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-orchestrator:
@@ -34,6 +34,8 @@ requires:
   metrics-endpoint:
     interface: prometheus_scrape
     limit: 1
+  magma-orc8r-accessd:
+    interface: magma-orc8r-accessd
 
 storage:
   config:

--- a/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
@@ -75,7 +75,8 @@ class MagmaOrc8rOrchestratorCharm(CharmBase):
         self.framework.observe(self.on.config_changed, self._on_elasticsearch_url_config_changed)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9112), ("http", 8080, 10112)],
+            ports=[("grpc", 9180, 9112), ("http", 8080, 10112),
+                   ("grpc-internal", 9190, 9212)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/analytics_collector": "true",

--- a/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
@@ -75,8 +75,7 @@ class MagmaOrc8rOrchestratorCharm(CharmBase):
         self.framework.observe(self.on.config_changed, self._on_elasticsearch_url_config_changed)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9112), ("http", 8080, 10112),
-                   ("grpc-internal", 9190, 9212)],
+            ports=[("grpc", 9180, 9112), ("http", 8080, 10112), ("grpc-internal", 9190, 9212)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/analytics_collector": "true",

--- a/orchestrator-bundle/orc8r-policydb-operator/README.md
+++ b/orchestrator-bundle/orc8r-policydb-operator/README.md
@@ -44,4 +44,4 @@ Currently supported relations are:
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-policydb-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-policydb-operator/metadata.yaml
@@ -15,8 +15,8 @@ containers:
 resources:
   magma-orc8r-policydb-image:
     type: oci-image
-    description: OCI image for magma-orc8r-policydb (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-policydb (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-policydb:

--- a/orchestrator-bundle/orc8r-policydb-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-policydb-operator/src/charm.py
@@ -14,7 +14,8 @@ class MagmaOrc8rPolicydbCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9085), ("http", 8080, 10085)],
+            ports=[("grpc", 9180, 9085), ("http", 8080, 10085),
+                    ("grpc-internal", 9190, 9185)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/obsidian_handlers": "true",

--- a/orchestrator-bundle/orc8r-policydb-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-policydb-operator/src/charm.py
@@ -14,8 +14,7 @@ class MagmaOrc8rPolicydbCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9085), ("http", 8080, 10085),
-                    ("grpc-internal", 9190, 9185)],
+            ports=[("grpc", 9180, 9085), ("http", 8080, 10085), ("grpc-internal", 9190, 9185)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/obsidian_handlers": "true",

--- a/orchestrator-bundle/orc8r-service-registry-operator/README.md
+++ b/orchestrator-bundle/orc8r-service-registry-operator/README.md
@@ -13,4 +13,4 @@ juju deploy magma-orc8r-service-registry orc8r-service-registry
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-service-registry-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-service-registry-operator/metadata.yaml
@@ -16,8 +16,8 @@ containers:
 resources:
   magma-orc8r-service-registry-image:
     type: oci-image
-    description: OCI image for magma-orc8r-service-registry (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-service-registry (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-service-registry:

--- a/orchestrator-bundle/orc8r-service-registry-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-service-registry-operator/src/charm.py
@@ -16,7 +16,7 @@ class MagmaOrc8rServiceRegistry(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180)],
+            ports=[("grpc", 9180), ("grpc-internal", 9190, 9190)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
         startup_command = (

--- a/orchestrator-bundle/orc8r-smsd-operator/README.md
+++ b/orchestrator-bundle/orc8r-smsd-operator/README.md
@@ -21,4 +21,4 @@ The current setup has only been tested with relation to the `postgresql-k8s` cha
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-smsd-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-smsd-operator/metadata.yaml
@@ -14,8 +14,8 @@ containers:
 resources:
   magma-orc8r-smsd-image:
     type: oci-image
-    description: OCI image for magma-orc8r-smsd (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-smsd (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-smsd:

--- a/orchestrator-bundle/orc8r-smsd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-smsd-operator/src/charm.py
@@ -14,8 +14,7 @@ class MagmaOrc8rSmsdCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9120), ("http", 8080, 10086),
-                   ("grpc-internal", 9190, 9220)],
+            ports=[("grpc", 9180, 9120), ("http", 8080, 10086), ("grpc-internal", 9190, 9220)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/obsidian_handlers": "true",

--- a/orchestrator-bundle/orc8r-smsd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-smsd-operator/src/charm.py
@@ -14,7 +14,8 @@ class MagmaOrc8rSmsdCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9120), ("http", 8080, 10086)],
+            ports=[("grpc", 9180, 9120), ("http", 8080, 10086),
+                   ("grpc-internal", 9190, 9220)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/obsidian_handlers": "true",

--- a/orchestrator-bundle/orc8r-state-operator/README.md
+++ b/orchestrator-bundle/orc8r-state-operator/README.md
@@ -21,4 +21,4 @@ The current setup has only been tested with relation to the `postgresql-k8s` cha
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-state-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-state-operator/metadata.yaml
@@ -14,8 +14,8 @@ containers:
 resources:
   magma-orc8r-state-image:
     type: oci-image
-    description: OCI image for magma-orc8r-state (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-state (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-state:

--- a/orchestrator-bundle/orc8r-state-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-state-operator/src/charm.py
@@ -14,7 +14,7 @@ class MagmaOrc8rStateCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9105)],
+            ports=[("grpc", 9180, 9105), ("grpc-internal", 9190, 9305)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
         startup_command = (

--- a/orchestrator-bundle/orc8r-streamer-operator/README.md
+++ b/orchestrator-bundle/orc8r-streamer-operator/README.md
@@ -14,4 +14,4 @@ juju deploy magma-orc8r-streamer orc8r-streamer
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-streamer-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-streamer-operator/metadata.yaml
@@ -17,8 +17,8 @@ containers:
 resources:
   magma-orc8r-streamer-image:
     type: oci-image
-    description: OCI image for magma-orc8r-streamer (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-streamer (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-streamer:

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/README.md
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/README.md
@@ -21,4 +21,4 @@ The current setup has only been tested with relation to the `postgresql-k8s` cha
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/metadata.yaml
@@ -14,8 +14,8 @@ containers:
 resources:
   magma-orc8r-subscriberdb-cache-image:
     type: oci-image
-    description: OCI image for magma-orc8r-subscriberdb-cache (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-subscriberdb-cache (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-subscriberdb-cache:

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/README.md
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/README.md
@@ -21,4 +21,4 @@ The current setup has only been tested with relation to the `postgresql-k8s` cha
 
 ## OCI Images
 
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/metadata.yaml
@@ -14,8 +14,8 @@ containers:
 resources:
   magma-orc8r-subscriberdb-image:
     type: oci-image
-    description: OCI image for magma-orc8r-subscriberdb (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-subscriberdb (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-subscriberdb:

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/src/charm.py
@@ -14,8 +14,7 @@ class MagmaOrc8rSubscriberdbCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9083), ("http", 8080, 10083),
-                   ("grpc-internal", 9190, 9183)],
+            ports=[("grpc", 9180, 9083), ("http", 8080, 10083), ("grpc-internal", 9190, 9183)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/obsidian_handlers": "true",

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/src/charm.py
@@ -14,7 +14,8 @@ class MagmaOrc8rSubscriberdbCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9083), ("http", 8080, 10083)],
+            ports=[("grpc", 9180, 9083), ("http", 8080, 10083),
+                   ("grpc-internal", 9190, 9183)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/obsidian_handlers": "true",

--- a/orchestrator-bundle/orc8r-tenants-operator/README.md
+++ b/orchestrator-bundle/orc8r-tenants-operator/README.md
@@ -17,4 +17,4 @@ juju relate orc8r-tenants postgresql-k8s:db
 The magma-orc8r-tenants service relies on a relation to `postgresql-k8s`. 
 
 ## OCI Images
-Default: docker.artifactory.magmacore.org/controller:1.6.0
+Default: docker-ci.artifactory.magmacore.org/controller:13029

--- a/orchestrator-bundle/orc8r-tenants-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-tenants-operator/metadata.yaml
@@ -14,8 +14,8 @@ containers:
 resources:
   magma-orc8r-tenants-image:
     type: oci-image
-    description: OCI image for magma-orc8r-tenants (docker.artifactory.magmacore.org/controller:1.6.0)
-    upstream-source: docker.artifactory.magmacore.org/controller:1.6.0
+    description: OCI image for magma-orc8r-tenants (docker-ci.artifactory.magmacore.org/controller:13029)
+    upstream-source: docker-ci.artifactory.magmacore.org/controller:13029
 
 provides:
   magma-orc8r-tenants:

--- a/orchestrator-bundle/orc8r-tenants-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-tenants-operator/src/charm.py
@@ -14,7 +14,8 @@ class MagmaOrc8rTenantsCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9110), ("http", 8080, 10110)],
+            ports=[("grpc", 9180, 9110), ("http", 8080, 10110),
+                   ("grpc-internal", 9190, 9210)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/obsidian_handlers": "true",

--- a/orchestrator-bundle/orc8r-tenants-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-tenants-operator/src/charm.py
@@ -14,8 +14,7 @@ class MagmaOrc8rTenantsCharm(CharmBase):
         super().__init__(*args)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
-            ports=[("grpc", 9180, 9110), ("http", 8080, 10110),
-                   ("grpc-internal", 9190, 9210)],
+            ports=[("grpc", 9180, 9110), ("http", 8080, 10110), ("grpc-internal", 9190, 9210)],
             additional_labels={
                 "app.kubernetes.io/part-of": "orc8r-app",
                 "orc8r.io/obsidian_handlers": "true",


### PR DESCRIPTION
Uplifts magmacore version to > 1.7, uses the images that are generated by CI from the master branch and fetches them from the ci-docker registry.
Makes changes to charms to be in sync with changes made in magma.

- Upgrades magmacore images
- Adds the grpc-internal ports to charms that use them
- Adds relations (bootstrapper - pgsql, orchestrator - accessd)
- Adds new environment variables to orc8r-nginx
- Adds and fixes unit tests
- Fixes integration tests with the new relations