### PR TITLE
Fix: Removes duplicated logs upload

### DIFF
--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -127,12 +127,6 @@ jobs:
           name: charmcraft-logs
           path: /home/ubuntu/snap/charmcraft/common/cache/charmcraft/log/*.log
 
-      - name: Archive charmcraft logs
-        uses: actions/upload-artifact@v3
-        with:
-          name: charmcraft-logs
-          path: /home/runner/snap/charmcraft/common/cache/charmcraft/log/*.log
-
       - name: Clean up
         if: always()
         run: |


### PR DESCRIPTION
There are two steps for uploading charmcraft logs, these PR just removes the one unused.