### PR TITLE
Chore: Uses lxd instead of destructive mode to pack the charms during integration tests

### DIFF
--- a/orchestrator-bundle/orc8r-accessd-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-accessd-operator/charmcraft.yaml
@@ -8,7 +8,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    build-packages:
-      - git
     charm-binary-python-packages:
       - psycopg2-binary

--- a/orchestrator-bundle/orc8r-accessd-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-accessd-operator/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/orc8r-accessd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-accessd-operator/tox.ini
@@ -84,5 +84,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-analytics-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-analytics-operator/charmcraft.yaml
@@ -6,7 +6,3 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
-parts:
-  charm:
-    build-packages:
-      - git

--- a/orchestrator-bundle/orc8r-analytics-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-analytics-operator/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 lightkube
 lightkube-models

--- a/orchestrator-bundle/orc8r-analytics-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-analytics-operator/tox.ini
@@ -86,5 +86,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-base-acct-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-base-acct-operator/charmcraft.yaml
@@ -6,8 +6,3 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
-
-parts:
-  charm:
-    build-packages:
-      - git

--- a/orchestrator-bundle/orc8r-base-acct-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-base-acct-operator/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 lightkube >= 0.8.1
 lightkube-models >= 1.22.0.4

--- a/orchestrator-bundle/orc8r-base-acct-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-base-acct-operator/tox.ini
@@ -86,5 +86,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/charmcraft.yaml
@@ -6,8 +6,3 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
-
-parts:
-  charm:
-    build-packages:
-      - git

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 lightkube
 lightkube-models

--- a/orchestrator-bundle/orc8r-bundle/tox.ini
+++ b/orchestrator-bundle/orc8r-bundle/tox.ini
@@ -72,5 +72,4 @@ deps =
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
     pytest --asyncio-mode=auto -v --tb native --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-configurator-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-configurator-operator/charmcraft.yaml
@@ -8,7 +8,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    build-packages:
-      - git
     charm-binary-python-packages:
       - psycopg2-binary

--- a/orchestrator-bundle/orc8r-configurator-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-configurator-operator/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/orc8r-configurator-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-configurator-operator/tox.ini
@@ -86,5 +86,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-ctraced-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-ctraced-operator/charmcraft.yaml
@@ -8,7 +8,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    build-packages:
-      - git
     charm-binary-python-packages:
       - psycopg2-binary

--- a/orchestrator-bundle/orc8r-ctraced-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-ctraced-operator/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/orc8r-ctraced-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-ctraced-operator/tox.ini
@@ -83,5 +83,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-device-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-device-operator/charmcraft.yaml
@@ -8,7 +8,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    build-packages:
-      - git
     charm-binary-python-packages:
       - psycopg2-binary

--- a/orchestrator-bundle/orc8r-device-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-device-operator/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/orc8r-device-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-device-operator/tox.ini
@@ -86,5 +86,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-directoryd-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-directoryd-operator/charmcraft.yaml
@@ -8,7 +8,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    build-packages:
-      - git
     charm-binary-python-packages:
       - psycopg2-binary

--- a/orchestrator-bundle/orc8r-directoryd-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-directoryd-operator/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/orc8r-directoryd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-directoryd-operator/tox.ini
@@ -83,5 +83,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-dispatcher-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-dispatcher-operator/charmcraft.yaml
@@ -6,7 +6,3 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
-parts:
-  charm:
-    build-packages:
-      - git

--- a/orchestrator-bundle/orc8r-dispatcher-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-dispatcher-operator/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 lightkube
 lightkube-models

--- a/orchestrator-bundle/orc8r-dispatcher-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-dispatcher-operator/tox.ini
@@ -86,5 +86,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-eventd-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-eventd-operator/charmcraft.yaml
@@ -6,8 +6,3 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
-
-parts:
-  charm:
-    build-packages:
-      - git

--- a/orchestrator-bundle/orc8r-eventd-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-eventd-operator/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 lightkube
 lightkube-models

--- a/orchestrator-bundle/orc8r-eventd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-eventd-operator/tox.ini
@@ -86,5 +86,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-feg-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-feg-operator/charmcraft.yaml
@@ -6,8 +6,3 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
-
-parts:
-  charm:
-    build-packages:
-      - git

--- a/orchestrator-bundle/orc8r-feg-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-feg-operator/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 lightkube >= 0.8.1
 lightkube-models >= 1.22.0.4

--- a/orchestrator-bundle/orc8r-feg-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-feg-operator/tox.ini
@@ -86,5 +86,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-feg-relay-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-feg-relay-operator/charmcraft.yaml
@@ -6,8 +6,3 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
-
-parts:
-  charm:
-    build-packages:
-      - git

--- a/orchestrator-bundle/orc8r-feg-relay-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-feg-relay-operator/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 lightkube >= 0.8.1
 lightkube-models >= 1.22.0.4

--- a/orchestrator-bundle/orc8r-feg-relay-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-feg-relay-operator/tox.ini
@@ -86,5 +86,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-ha-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-ha-operator/charmcraft.yaml
@@ -6,7 +6,3 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
-parts:
-  charm:
-    build-packages:
-      - git

--- a/orchestrator-bundle/orc8r-ha-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-ha-operator/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 lightkube
 lightkube-models

--- a/orchestrator-bundle/orc8r-ha-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-ha-operator/tox.ini
@@ -86,5 +86,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-health-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-health-operator/charmcraft.yaml
@@ -9,7 +9,5 @@ bases:
 
 parts:
   charm:
-    build-packages:
-      - git
     charm-binary-python-packages:
       - psycopg2-binary

--- a/orchestrator-bundle/orc8r-health-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-health-operator/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube >= 0.8.1

--- a/orchestrator-bundle/orc8r-health-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-health-operator/tox.ini
@@ -86,5 +86,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-libs/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-libs/charmcraft.yaml
@@ -8,7 +8,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    build-packages:
-      - git
     charm-binary-python-packages:
       - psycopg2-binary

--- a/orchestrator-bundle/orc8r-libs/requirements.txt
+++ b/orchestrator-bundle/orc8r-libs/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/orc8r-lte-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-lte-operator/charmcraft.yaml
@@ -8,7 +8,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    build-packages:
-      - git
     charm-binary-python-packages:
       - psycopg2-binary

--- a/orchestrator-bundle/orc8r-lte-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-lte-operator/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/orc8r-lte-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-lte-operator/tox.ini
@@ -86,5 +86,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-metricsd-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-metricsd-operator/charmcraft.yaml
@@ -6,7 +6,3 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
-parts:
-  charm:
-    build-packages:
-      - git

--- a/orchestrator-bundle/orc8r-metricsd-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-metricsd-operator/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 lightkube
 lightkube-models

--- a/orchestrator-bundle/orc8r-nginx-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-nginx-operator/charmcraft.yaml
@@ -6,8 +6,3 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
-
-parts:
-  charm:
-    build-packages:
-      - git

--- a/orchestrator-bundle/orc8r-nginx-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-nginx-operator/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 lightkube
 lightkube-models

--- a/orchestrator-bundle/orc8r-nginx-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-nginx-operator/src/charm.py
@@ -414,7 +414,7 @@ class MagmaOrc8rNginxCharm(CharmBase):
             process.wait_output()
         except ExecError as e:
             logger.error("Exited with code %d. Stderr:", e.exit_code)
-            for line in e.stderr.splitlines():  # type: ignore[union-attr]
+            for line in e.stderr.splitlines():
                 logger.error("    %s", line)
             raise e
         logger.info("Successfully generated nginx config file")

--- a/orchestrator-bundle/orc8r-obsidian-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-obsidian-operator/charmcraft.yaml
@@ -6,7 +6,3 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
-parts:
-  charm:
-    build-packages:
-      - git

--- a/orchestrator-bundle/orc8r-obsidian-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-obsidian-operator/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 lightkube
 lightkube-models

--- a/orchestrator-bundle/orc8r-obsidian-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-obsidian-operator/tox.ini
@@ -86,5 +86,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-policydb-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-policydb-operator/charmcraft.yaml
@@ -9,7 +9,5 @@ bases:
 
 parts:
   charm:
-    build-packages:
-      - git
     charm-binary-python-packages:
       - psycopg2-binary

--- a/orchestrator-bundle/orc8r-policydb-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-policydb-operator/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/orc8r-policydb-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-policydb-operator/tox.ini
@@ -86,5 +86,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-service-registry-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-service-registry-operator/charmcraft.yaml
@@ -6,7 +6,3 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
-parts:
-  charm:
-    build-packages:
-      - git

--- a/orchestrator-bundle/orc8r-service-registry-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-service-registry-operator/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 lightkube
 lightkube-models

--- a/orchestrator-bundle/orc8r-service-registry-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-service-registry-operator/tox.ini
@@ -83,5 +83,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-smsd-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-smsd-operator/charmcraft.yaml
@@ -8,7 +8,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    build-packages:
-      - git
     charm-binary-python-packages:
       - psycopg2-binary

--- a/orchestrator-bundle/orc8r-smsd-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-smsd-operator/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/orc8r-smsd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-smsd-operator/tox.ini
@@ -86,5 +86,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-state-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-state-operator/charmcraft.yaml
@@ -8,7 +8,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    build-packages:
-      - git
     charm-binary-python-packages:
       - psycopg2-binary

--- a/orchestrator-bundle/orc8r-state-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-state-operator/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/orc8r-state-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-state-operator/tox.ini
@@ -83,5 +83,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-streamer-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-streamer-operator/charmcraft.yaml
@@ -6,7 +6,3 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
-parts:
-  charm:
-    build-packages:
-      - git

--- a/orchestrator-bundle/orc8r-streamer-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-streamer-operator/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 lightkube
 lightkube-models

--- a/orchestrator-bundle/orc8r-streamer-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-streamer-operator/tox.ini
@@ -86,5 +86,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/charmcraft.yaml
@@ -8,7 +8,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    build-packages:
-      - git
     charm-binary-python-packages:
       - psycopg2-binary

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tox.ini
@@ -87,4 +87,4 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/charmcraft.yaml
@@ -8,7 +8,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    build-packages:
-      - git
     charm-binary-python-packages:
       - psycopg2-binary

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/tox.ini
@@ -87,4 +87,4 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}

--- a/orchestrator-bundle/orc8r-tenants-operator/charmcraft.yaml
+++ b/orchestrator-bundle/orc8r-tenants-operator/charmcraft.yaml
@@ -8,7 +8,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    build-packages:
-      - git
     charm-binary-python-packages:
       - psycopg2-binary

--- a/orchestrator-bundle/orc8r-tenants-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-tenants-operator/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/orc8r-tenants-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-tenants-operator/tox.ini
@@ -86,5 +86,4 @@ deps =
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
-    sudo apt-get --no-install-recommends -y -oDpkg::Use-Pty=0 --allow-downgrades install python3.8-venv
-    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs} --destructive-mode
+    pytest --asyncio-mode=auto -v --tb native --ignore {[vars]unit_test_path} --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
- Uses lxd instead of destructive mode to pack the charms during integration tests
- Uses the pypi version of `ops` instead of the github one.