### PR TITLE
Chore: Forces flake8 to stay at 4.0.1 

### DIFF
--- a/orchestrator-bundle/nms-magmalte-operator/tox.ini
+++ b/orchestrator-bundle/nms-magmalte-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/nms-nginx-proxy-operator/tox.ini
+++ b/orchestrator-bundle/nms-nginx-proxy-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-accessd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-accessd-operator/tox.ini
@@ -37,7 +37,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-analytics-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-analytics-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-base-acct-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-base-acct-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/tox.ini
@@ -37,7 +37,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-bundle/tox.ini
+++ b/orchestrator-bundle/orc8r-bundle/tox.ini
@@ -38,7 +38,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-certifier-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-certifier-operator/tox.ini
@@ -41,7 +41,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-configurator-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-configurator-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-ctraced-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-ctraced-operator/tox.ini
@@ -37,7 +37,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-device-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-device-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-directoryd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-directoryd-operator/tox.ini
@@ -37,7 +37,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-dispatcher-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-dispatcher-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-eventd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-eventd-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-feg-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-feg-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-feg-relay-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-feg-relay-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-ha-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-ha-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-health-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-health-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-libs/tox.ini
+++ b/orchestrator-bundle/orc8r-libs/tox.ini
@@ -39,7 +39,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-lte-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-lte-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-metricsd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-nginx-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-nginx-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-obsidian-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-obsidian-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-policydb-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-policydb-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-service-registry-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-service-registry-operator/tox.ini
@@ -37,7 +37,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-smsd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-smsd-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-state-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-state-operator/tox.ini
@@ -37,7 +37,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-streamer-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-streamer-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/orchestrator-bundle/orc8r-tenants-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-tenants-operator/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 == 4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
Forces flake8 to stay at 4.0.1 to avoid the `AttributeError: module 'flake8.options.config' has no attribute 'ConfigFileFinder'` error.