### PR TITLE
Enable scaling for orc8r-certifier

### DIFF
--- a/orchestrator-bundle/orc8r-certifier-operator/lib/charms/tls_certificates_interface/v0/tls_certificates.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/lib/charms/tls_certificates_interface/v0/tls_certificates.py
@@ -97,7 +97,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 23
+LIBPATCH = 24
 
 REQUIRER_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -323,10 +323,10 @@ class TLSCertificatesProvides(Object):
         """
         relation_data = _load_relation_data(event.relation.data[event.unit])
         if not relation_data:
-            logger.info("No relation data - Deferring")
+            logger.info("No relation data")
             return
         if not self._relation_data_is_valid(relation_data):
-            logger.warning("Relation data did not pass JSON Schema validation - Deferring")
+            logger.warning("Relation data did not pass JSON Schema validation")
             return
         for server_cert_request in relation_data.get("cert_requests", {}):
             self.on.certificate_request.emit(
@@ -458,13 +458,14 @@ class TLSCertificatesRequires(Object):
         Returns:
             None
         """
-        if self.model.unit.is_leader():
-            relation_data = _load_relation_data(event.relation.data[event.unit])
-            if not self._relation_data_is_valid(relation_data):
-                logger.warning("Relation data did not pass JSON Schema validation - Deferring")
-                event.defer()
-                return
+        relation_data = _load_relation_data(event.relation.data[event.unit])
+        if not relation_data:
+            logger.info("No relation data")
+            return
+        if not self._relation_data_is_valid(relation_data):
+            logger.warning("Relation data did not pass JSON Schema validation")
+            return
 
-            certificates = self._parse_certificates_from_relation_data(relation_data)
-            for certificate in certificates:
-                self.on.certificate_available.emit(certificate_data=certificate)
+        certificates = self._parse_certificates_from_relation_data(relation_data)
+        for certificate in certificates:
+            self.on.certificate_available.emit(certificate_data=certificate)

--- a/orchestrator-bundle/orc8r-certifier-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-certifier-operator/metadata.yaml
@@ -33,6 +33,10 @@ storage:
     description: Certs storage
     minimum-size: 1M
 
+peers:
+  replicas:
+    interface: orc8r-certifier-replica
+
 requires:
   db:
     interface: pgsql

--- a/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
@@ -500,6 +500,8 @@ class MagmaOrc8rCertifierCharm(CharmBase):
             - admin_operator.pem
             - admin_operator.key.pem
             - admin_operator.pfx
+            - admin_operator_password
+            - bootstrapper.key
 
         Returns:
             None

--- a/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
@@ -585,7 +585,10 @@ class MagmaOrc8rCertifierCharm(CharmBase):
         Returns:
             bool: Whether certificates have been generated.
         """
-        app_data = self.model.get_relation("replicas").data[self.app]  # type: ignore[union-attr]
+        replicas = self.model.get_relation("replicas")
+        if not replicas:
+            return False
+        app_data = replicas.data[self.app]
         return (
             app_data.get("certifier_pem")
             and app_data.get("certifier_key")  # noqa: W503

--- a/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/src/charm.py
@@ -45,7 +45,6 @@ from ops.charm import (
     PebbleReadyEvent,
     RelationJoinedEvent,
 )
-from ops.framework import StoredState
 from ops.main import main
 from ops.model import (
     ActiveStatus,
@@ -81,8 +80,6 @@ class MagmaOrc8rCertifierCharm(CharmBase):
     PROMETHEUS_URL = "http://orc8r-prometheus:9090"
     ALERTMANAGER_URL = "http://orc8r-alertmanager:9093"
 
-    _stored = StoredState()
-
     def __init__(self, *args):
         """Initializes all events that need to be observed."""
         super().__init__(*args)
@@ -95,7 +92,6 @@ class MagmaOrc8rCertifierCharm(CharmBase):
         self.provided_relation_name = list(self.meta.provides.keys())[0]
         self._container = self.unit.get_container(self._container_name)
         self._db = pgsql.PostgreSQLClient(self, "db")
-        self._stored.set_default(admin_operator_password="")
         self._service_patcher = KubernetesServicePatch(
             charm=self,
             ports=[ServicePort(name="grpc", port=9180, targetPort=9086)],
@@ -198,6 +194,15 @@ class MagmaOrc8rCertifierCharm(CharmBase):
             return True
         except psycopg2.OperationalError:
             return False
+
+    @property
+    def _replicas_relation_created(self) -> bool:
+        """Checks whether replicas relation is created.
+
+        Returns:
+            bool: Whether required relation
+        """
+        return self._relation_created("replicas")
 
     @property
     def _pebble_layer(self) -> Layer:
@@ -316,8 +321,18 @@ class MagmaOrc8rCertifierCharm(CharmBase):
             self.unit.status = BlockedStatus("Config 'domain' is not valid")
             event.defer()
             return
+        if not self._replicas_relation_created:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        if not self._certificates_are_generated():
+            if not self.unit.is_leader():
+                self.unit.status = WaitingStatus("Waiting for leader to generate certificates")
+                event.defer()
+                return
+            self._generate_application_certificates()
         self._write_metricsd_config_file()
-        self._generate_application_certificates()
+        self._push_application_certificates()
 
     def _on_magma_orc8r_certifier_pebble_ready(
         self, event: Union[PebbleReadyEvent, CertificateAvailableEvent]
@@ -348,11 +363,11 @@ class MagmaOrc8rCertifierCharm(CharmBase):
             event.defer()
             return
         if not self._root_certs_are_stored:
-            self.unit.status = WaitingStatus("Waiting for certs to be available")
+            self.unit.status = WaitingStatus("Waiting for root certs to be available")
             event.defer()
             return
         if not self._application_certs_are_stored:
-            self.unit.status = WaitingStatus("Waiting for certs to be available")
+            self.unit.status = WaitingStatus("Waiting for application certs to be available")
             event.defer()
             return
         self._configure_magma_orc8r_certifier(event)
@@ -477,7 +492,7 @@ class MagmaOrc8rCertifierCharm(CharmBase):
             )
 
     def _generate_application_certificates(self) -> None:
-        """Generates application certificates and pushes them to the workload container.
+        """Generates application certificates.
 
         The following certificates/keys are created:
             - certifier.pem
@@ -490,6 +505,7 @@ class MagmaOrc8rCertifierCharm(CharmBase):
             None
         """
         logger.info("Generating Application Certificates")
+        app_data = self.model.get_relation("replicas").data[self.app]  # type: ignore[union-attr]
         certifier_key = generate_private_key()
         certifier_pem = generate_ca(
             private_key=certifier_key,
@@ -512,21 +528,73 @@ class MagmaOrc8rCertifierCharm(CharmBase):
             password=password,
         )
         bootstrapper_key = generate_private_key()
-        self._container.push(path=f"{self.BASE_CERTS_PATH}/certifier.pem", source=certifier_pem)
-        self._container.push(path=f"{self.BASE_CERTS_PATH}/certifier.key", source=certifier_key)
+        app_data.update(
+            {
+                "certifier_pem": certifier_pem.decode(),
+                "certifier_key": certifier_key.decode(),
+                "admin_operator_pem": admin_operator_pem.decode(),
+                "admin_operator_key_pem": admin_operator_key_pem.decode(),
+                "admin_operator_pfx": base64.b64encode(admin_operator_pfx).decode(),
+                "bootstrapper_key": bootstrapper_key.decode(),
+                "admin_operator_password": password,
+            }
+        )
+
+    def _push_application_certificates(self) -> None:
+        """Pushes application certificates to the workload container.
+
+        The following certificates/keys are pushed:
+            - certifier.pem
+            - certifier.key
+            - admin_operator.pem
+            - admin_operator.key.pem
+            - admin_operator.pfx
+
+        Returns:
+            None
+        """
+        app_data = self.model.get_relation("replicas").data[self.app]  # type: ignore[union-attr]
         self._container.push(
-            path=f"{self.BASE_CERTS_PATH}/admin_operator.pem", source=admin_operator_pem
+            path=f"{self.BASE_CERTS_PATH}/certifier.pem",
+            source=app_data.get("certifier_pem").encode(),
         )
         self._container.push(
-            path=f"{self.BASE_CERTS_PATH}/admin_operator.key.pem", source=admin_operator_key_pem
+            path=f"{self.BASE_CERTS_PATH}/certifier.key",
+            source=app_data.get("certifier_key").encode(),
         )
         self._container.push(
-            path=f"{self.BASE_CERTS_PATH}/admin_operator.pfx", source=admin_operator_pfx
+            path=f"{self.BASE_CERTS_PATH}/admin_operator.pem",
+            source=app_data.get("admin_operator_pem").encode(),
         )
         self._container.push(
-            path=f"{self.BASE_CERTS_PATH}/bootstrapper.key", source=bootstrapper_key
+            path=f"{self.BASE_CERTS_PATH}/admin_operator.key.pem",
+            source=app_data.get("admin_operator_key_pem").encode(),
         )
-        self._stored.admin_operator_password = password
+        self._container.push(
+            path=f"{self.BASE_CERTS_PATH}/admin_operator.pfx",
+            source=base64.b64decode(app_data.get("admin_operator_pfx").encode()),
+        )
+        self._container.push(
+            path=f"{self.BASE_CERTS_PATH}/bootstrapper.key",
+            source=app_data.get("bootstrapper_key").encode(),
+        )
+
+    def _certificates_are_generated(self) -> bool:
+        """Returns whether certificates have been generated.
+
+        Returns:
+            bool: Whether certificates have been generated.
+        """
+        app_data = self.model.get_relation("replicas").data[self.app]  # type: ignore[union-attr]
+        return (
+            app_data.get("certifier_pem")
+            and app_data.get("certifier_key")  # noqa: W503
+            and app_data.get("admin_operator_pem")  # noqa: W503
+            and app_data.get("admin_operator_key_pem")  # noqa: W503
+            and app_data.get("admin_operator_pfx")  # noqa: W503
+            and app_data.get("bootstrapper_key")  # noqa: W503
+            and app_data.get("admin_operator_password")  # noqa: W503
+        )
 
     def _update_relation_active_status(self, relation: Relation, is_active: bool) -> None:
         """Updates the relation data content.
@@ -588,9 +656,10 @@ class MagmaOrc8rCertifierCharm(CharmBase):
         Returns:
             None
         """
+        app_data = self.model.get_relation("replicas").data[self.app]  # type: ignore[union-attr]
         event.set_results(
             {
-                "password": self._stored.admin_operator_password,
+                "password": app_data.get("admin_operator_password"),
             }
         )
 
@@ -697,7 +766,7 @@ class MagmaOrc8rCertifierCharm(CharmBase):
         try:
             private_key = self._container.pull(path=f"{self.BASE_CERTS_PATH}/bootstrapper.key")
         except (ops.pebble.PathError, FileNotFoundError):
-            logger.info("Certificate 'controller' not yet available")
+            logger.info("Certificate 'bootstrapper' not yet available")
             event.defer()
             return
         private_key_string = private_key.read()

--- a/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
@@ -61,14 +61,17 @@ class TestOrc8rCertifier:
         )
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
 
-    async def test_build_and_deploy_and_scale(self, ops_test, setup, build_and_deploy):
-        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+    async def test_build_and_deploy_and_scale_up(self, ops_test, setup, build_and_deploy):
         await ops_test.model.applications[APPLICATION_NAME].scale(2)
 
         await ops_test.model.wait_for_idle(
-            apps=[APPLICATION_NAME], status="active", timeout=1000, wait_for_units=2
+            apps=[APPLICATION_NAME], status="active", timeout=1000, wait_for_exact_units=2
         )
 
+    @pytest.mark.xfail(reason="Bug in Juju: https://bugs.launchpad.net/juju/+bug/1977582")
+    async def test_build_and_deploy_and_scale_down(self, ops_test, setup, build_and_deploy):
         await ops_test.model.applications[APPLICATION_NAME].scale(1)
 
-        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+        await ops_test.model.wait_for_idle(
+            apps=[APPLICATION_NAME], status="active", timeout=1000, wait_for_exact_units=1
+        )

--- a/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
@@ -60,3 +60,15 @@ class TestOrc8rCertifier:
             relation1=APPLICATION_NAME, relation2="tls-certificates-operator"
         )
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+
+    async def test_build_and_deploy_and_scale(self, ops_test, setup, build_and_deploy):
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+        await ops_test.model.applications[APPLICATION_NAME].scale(2)
+
+        await ops_test.model.wait_for_idle(
+            apps=[APPLICATION_NAME], status="active", timeout=1000, wait_for_units=2
+        )
+
+        await ops_test.model.applications[APPLICATION_NAME].scale(1)
+
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)

--- a/orchestrator-bundle/orc8r-certifier-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/tests/unit/test_charm.py
@@ -217,7 +217,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("ops.model.Container.exists")
     @patch("ops.model.Container.push")
-    def test_given_pebble_ready_when_install_and_unit_is_not_leader_then_status_is_waiting(
+    def test_given_pebble_ready_and_unit_is_not_leader_when_install_then_status_is_waiting(
         self,
         patch_push,
         patch_exists,
@@ -237,7 +237,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("ops.model.Container.exists")
     @patch("ops.model.Container.push")
-    def test_given_pebble_ready_when_install_and_unit_is_not_leader_and_certs_are_generated_then_admin_application_certificates_are_pushed(  # noqa: E501
+    def test_given_pebble_ready_and_unit_is_not_leader_when_install_and_certs_are_generated_then_admin_application_certificates_are_pushed(  # noqa: E501
         self,
         patch_push,
         patch_exists,


### PR DESCRIPTION
Move certificates from `StoredState` to the peer relation application data bag. This lets all the units use the same certificates.

Also updates the `tls-certificates-interface` library to support non-leader units receiving certificates.