### PR TITLE
Fixes when orc8r-orchestrator is set to active status

### DIFF
--- a/orchestrator-bundle/bundle-local-federated.yaml
+++ b/orchestrator-bundle/bundle-local-federated.yaml
@@ -273,6 +273,8 @@ relations:
   - orc8r-prometheus-cache:metrics-endpoint
 - - orc8r-orchestrator:magma-orc8r-accessd
   - orc8r-accessd:magma-orc8r-accessd
+- - orc8r-orchestrator:magma-orc8r-service-registry
+  - orc8r-service-registry:magma-orc8r-service-registry
 - - orc8r-smsd:db
   - postgresql-k8s:db
 - - orc8r-state:db

--- a/orchestrator-bundle/bundle-local.yaml
+++ b/orchestrator-bundle/bundle-local.yaml
@@ -249,6 +249,8 @@ relations:
   - orc8r-prometheus-cache:metrics-endpoint
 - - orc8r-orchestrator:magma-orc8r-accessd
   - orc8r-accessd:magma-orc8r-accessd
+- - orc8r-orchestrator:magma-orc8r-service-registry
+  - orc8r-service-registry:magma-orc8r-service-registry
 - - orc8r-smsd:db
   - postgresql-k8s:db
 - - orc8r-state:db

--- a/orchestrator-bundle/nms-magmalte-operator/src/charm.py
+++ b/orchestrator-bundle/nms-magmalte-operator/src/charm.py
@@ -300,6 +300,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
             return
         self._configure_pebble(event)
         self._create_master_nms_admin_user()
+        self.unit.status = ActiveStatus()
 
     def _create_master_nms_admin_user(self) -> None:
         """Creates NMS admin user.
@@ -392,7 +393,6 @@ class MagmaNmsMagmalteCharm(CharmBase):
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted service {self._service_name}")
                 self._update_relations()
-                self.unit.status = ActiveStatus()
         else:
             self.unit.status = WaitingStatus("Waiting for container to be ready")
             event.defer()

--- a/orchestrator-bundle/orc8r-bundle/bundle.yaml
+++ b/orchestrator-bundle/orc8r-bundle/bundle.yaml
@@ -223,6 +223,8 @@ relations:
   - orc8r-prometheus-cache:metrics-endpoint
 - - orc8r-orchestrator:magma-orc8r-accessd
   - orc8r-accessd:magma-orc8r-accessd
+- - orc8r-orchestrator:magma-orc8r-service-registry
+  - orc8r-service-registry:magma-orc8r-service-registry
 - - orc8r-smsd:db
   - postgresql-k8s:db
 - - orc8r-state:db

--- a/orchestrator-bundle/orc8r-metricsd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tests/integration/test_integration.py
@@ -179,6 +179,10 @@ class TestOrc8rMetricsd:
             relation1=f"{ORCHESTRATOR_APPLICATION_NAME}:magma-orc8r-accessd",
             relation2="orc8r-accessd:magma-orc8r-accessd",
         )
+        await ops_test.model.add_relation(
+            relation1=f"{ORCHESTRATOR_APPLICATION_NAME}:magma-orc8r-service-registry",
+            relation2="orc8r-service-registry:magma-orc8r-service-registry",
+        )
 
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail

--- a/orchestrator-bundle/orc8r-orchestrator-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/metadata.yaml
@@ -38,6 +38,9 @@ requires:
   cert-admin-operator:
     interface: cert-admin-operator
     limit: 1
+  magma-orc8r-service-registry:
+    interface: magma-orc8r-service-registry
+    limit: 1
 
 storage:
   config:

--- a/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
@@ -504,7 +504,6 @@ class MagmaOrc8rOrchestratorCharm(CharmBase):
         self._create_orchestrator_admin_user()
         self.unit.status = ActiveStatus()
 
-
     def _configure_orc8r(self, event: Union[PebbleReadyEvent, CertificateAvailableEvent]) -> None:
         """Adds layer to pebble config if the proposed config is different from the current one.
 

--- a/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
@@ -243,6 +243,24 @@ class MagmaOrc8rOrchestratorCharm(CharmBase):
         """
         return self._relation_created("metrics-endpoint")
 
+    @property
+    def _service_registry_relation_created(self) -> bool:
+        """Returns whether magma-orc8r-service-registry relation is created.
+
+        Returns:
+            bool: True/False
+        """
+        return self._relation_created("magma-orc8r-service-registry")
+
+    @property
+    def _service_registry_relation_active(self) -> bool:
+        """Returns whether magma-orc8r-service-registry relation is ready.
+
+        Returns:
+            bool: True/False
+        """
+        return self._relation_active("magma-orc8r-service-registry")
+
     def _relation_created(self, relation_name: str) -> bool:
         """Returns whether given relation was created.
 
@@ -490,6 +508,10 @@ class MagmaOrc8rOrchestratorCharm(CharmBase):
             )
             event.defer()
             return
+        if not self._service_registry_relation_created:
+            self.unit.status = BlockedStatus("Waiting for service-registry relation to be created")
+            event.defer()
+            return
         if not self._certs_are_stored:
             self.unit.status = WaitingStatus("Waiting for certs to be available")
             event.defer()
@@ -497,6 +519,12 @@ class MagmaOrc8rOrchestratorCharm(CharmBase):
         if not self._accessd_operator_relation_active:
             self.unit.status = WaitingStatus(
                 "Waiting for magma-orc8r-accessd relation to be active"
+            )
+            event.defer()
+            return
+        if not self._service_registry_relation_active:
+            self.unit.status = WaitingStatus(
+                "waiting for magma-orc8r-service-registry to be active"
             )
             event.defer()
             return

--- a/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/src/charm.py
@@ -502,6 +502,8 @@ class MagmaOrc8rOrchestratorCharm(CharmBase):
             return
         self._configure_orc8r(event)
         self._create_orchestrator_admin_user()
+        self.unit.status = ActiveStatus()
+
 
     def _configure_orc8r(self, event: Union[PebbleReadyEvent, CertificateAvailableEvent]) -> None:
         """Adds layer to pebble config if the proposed config is different from the current one.
@@ -522,7 +524,6 @@ class MagmaOrc8rOrchestratorCharm(CharmBase):
                 self._container.restart(self._service_name)
                 logger.info(f"Restarted container {self._service_name}")
                 self._update_relations()
-                self.unit.status = ActiveStatus()
         except ConnectionError:
             logger.error(
                 f"Could not restart {self._service_name} -- Pebble socket does "

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tests/integration/test_integration.py
@@ -171,4 +171,7 @@ class TestOrchestrator:
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="orc8r-accessd:magma-orc8r-accessd"
         )
+        await ops_test.model.add_relation(
+            relation1=APPLICATION_NAME, relation2="orc8r-service-registry:magma-orc8r-service-registry"
+        )
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tests/integration/test_integration.py
@@ -172,6 +172,7 @@ class TestOrchestrator:
             relation1=APPLICATION_NAME, relation2="orc8r-accessd:magma-orc8r-accessd"
         )
         await ops_test.model.add_relation(
-            relation1=APPLICATION_NAME, relation2="orc8r-service-registry:magma-orc8r-service-registry"
+            relation1=APPLICATION_NAME,
+            relation2="orc8r-service-registry:magma-orc8r-service-registry",
         )
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tests/integration/test_integration.py
@@ -16,6 +16,9 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 CERTIFIER_METADATA = yaml.safe_load(Path("../orc8r-certifier-operator/metadata.yaml").read_text())
 ACCESSD_METADATA = yaml.safe_load(Path("../orc8r-accessd-operator/metadata.yaml").read_text())
+SERVICE_REGISTRY_METADATA = yaml.safe_load(
+    Path("../orc8r-service-registry-operator/metadata.yaml").read_text()
+)
 APPLICATION_NAME = "orc8r-orchestrator"
 CHARM_NAME = "magma-orc8r-orchestrator"
 CERTIFIER_APPLICATION_NAME = "orc8r-certifier"
@@ -24,6 +27,9 @@ CERTIFIER_CHARM_FILE_NAME = "magma-orc8r-certifier_ubuntu-20.04-amd64.charm"
 ACCESSD_APPLICATION_NAME = "orc8r-accessd"
 ACCESSD_CHARM_NAME = "magma-orc8r-accessd"
 ACCESSD_CHARM_FILE_NAME = "magma-orc8r-accessd_ubuntu-20.04-amd64.charm"
+SERVICE_REGISTRY_APPLICATION_NAME = "orc8r-service-registry"
+SERVICE_REGISTRY_CHARM_NAME = "magma-orc8r-service-registry"
+SERVICE_REGISTRY_CHARM_FILE_NAME = "magma-orc8r-service-registry_ubuntu-20.04-amd64.charm"
 
 
 class TestOrchestrator:
@@ -32,6 +38,7 @@ class TestOrchestrator:
     async def setup(self, ops_test):
         await self._deploy_postgresql(ops_test)
         await self._deploy_tls_certificates_operator(ops_test)
+        await self._deploy_orc8r_service_registry(ops_test)
         await self._deploy_prometheus_cache(ops_test)
         await self._deploy_orc8r_certifier(ops_test)
         await self._deploy_orc8r_accessd(ops_test)
@@ -64,6 +71,29 @@ class TestOrchestrator:
             application_name="orc8r-prometheus-cache",
             channel="edge",
             trust=True,
+        )
+
+    async def _deploy_orc8r_service_registry(self, ops_test):
+        service_registry_charm = self._find_charm(
+            "../orc8r-service-registry-operator", SERVICE_REGISTRY_CHARM_FILE_NAME
+        )
+        if not service_registry_charm:
+            service_registry_charm = await ops_test.build_charm(
+                "../orc8r-service-registry-operator"
+            )
+        resources = {
+            f"{SERVICE_REGISTRY_CHARM_NAME}-image": SERVICE_REGISTRY_METADATA["resources"][
+                f"{SERVICE_REGISTRY_CHARM_NAME}-image"
+            ]["upstream-source"],
+        }
+        await ops_test.model.deploy(
+            service_registry_charm,
+            resources=resources,
+            application_name=SERVICE_REGISTRY_APPLICATION_NAME,
+            trust=True,
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[SERVICE_REGISTRY_APPLICATION_NAME], status="active", timeout=1000
         )
 
     async def _deploy_orc8r_accessd(self, ops_test):

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tests/unit/test_charm.py
@@ -69,6 +69,7 @@ class TestCharm(unittest.TestCase):
             relation_name="cert-admin-operator", remote_app="orc8r-certifier"
         )
         self.harness.add_relation(relation_name="metrics-endpoint", remote_app="prometheus-k8s")
+
         accessd_relation = self.harness.add_relation(
             relation_name="magma-orc8r-accessd", remote_app="orc8r-accessd"
         )
@@ -82,6 +83,22 @@ class TestCharm(unittest.TestCase):
             app_or_unit="magma-orc8r-accessd/0",
             key_values={"active": "True"},
         )
+
+        service_registry_relation = self.harness.add_relation(
+            relation_name="magma-orc8r-service-registry", remote_app="orc8r-service-registry"
+        )
+
+        self.harness.add_relation_unit(
+            relation_id=service_registry_relation,
+            remote_unit_name="magma-orc8r-service-registry/0",
+        )
+
+        self.harness.update_relation_data(
+            relation_id=service_registry_relation,
+            app_or_unit="magma-orc8r-service-registry/0",
+            key_values={"active": "True"},
+        )
+
         patch_exists.return_value = True
         expected_plan = {
             "services": {
@@ -179,6 +196,22 @@ class TestCharm(unittest.TestCase):
             app_or_unit="magma-orc8r-accessd/0",
             key_values={"active": "True"},
         )
+
+        service_registry_relation = self.harness.add_relation(
+            relation_name="magma-orc8r-service-registry", remote_app="orc8r-service-registry"
+        )
+
+        self.harness.add_relation_unit(
+            relation_id=service_registry_relation,
+            remote_unit_name="magma-orc8r-service-registry/0",
+        )
+
+        self.harness.update_relation_data(
+            relation_id=service_registry_relation,
+            app_or_unit="magma-orc8r-service-registry/0",
+            key_values={"active": "True"},
+        )
+
         self.harness.container_pebble_ready("magma-orc8r-orchestrator")
 
         args, _ = patch_exec.call_args


### PR DESCRIPTION
- Sets `orc8r-orchestrator-operator` to active status only after admin user creation
- Sets `nms-magmalte-operator`to active status only after admin user creation
- Adds a relation between `service-registry` and `orc8r-orchestrator`
- Fixes tests