### PR TITLE
Integrating Orc8r with Alertmanager Configurer

### DIFF
--- a/.github/workflows/orchestrator.main.yml
+++ b/.github/workflows/orchestrator.main.yml
@@ -106,7 +106,7 @@ jobs:
           echo "# Initialize microk8s"
           /usr/bin/bash -c "sudo usermod -a -G microk8s $USER"
           /usr/bin/sg microk8s -c "microk8s status --wait-ready"
-          /usr/bin/sg microk8s -c "microk8s enable storage rbac dns:185.125.188.1"
+          /usr/bin/sg microk8s -c "microk8s enable storage rbac dns:10.130.64.38,10.130.64.39"
           /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/coredns"
           /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/hostpath-provisioner"
 

--- a/.github/workflows/orchestrator.metricsd.yml
+++ b/.github/workflows/orchestrator.metricsd.yml
@@ -22,9 +22,23 @@ jobs:
       charm_dir: orc8r-metricsd-operator
 
   orc8r-metricsd-integration-test:
-    uses: ./.github/workflows/integration-tests.yml
-    with:
-      charm_dir: orc8r-metricsd-operator
+    name: Integration tests (orc8r-metricsd)
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: microk8s
+      - name: Run integration tests
+        run: cd orchestrator-bundle/orc8r-metricsd-operator && tox -e integration
+      - name: Archive charmcraft logs
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: charmcraft-logs
+          path: /home/runner/snap/charmcraft/common/cache/charmcraft/log/*.log
 
   orc8r-metricsd-charmhub-upload:
     if: github.ref_name == 'main'

--- a/.github/workflows/orchestrator.metricsd.yml
+++ b/.github/workflows/orchestrator.metricsd.yml
@@ -72,7 +72,7 @@ jobs:
           echo "# Initialize microk8s"
           /usr/bin/bash -c "sudo usermod -a -G microk8s $USER"
           /usr/bin/sg microk8s -c "microk8s status --wait-ready"
-          /usr/bin/sg microk8s -c "microk8s enable storage rbac dns:185.125.188.1"
+          /usr/bin/sg microk8s -c "microk8s enable storage rbac dns:10.130.64.38,10.130.64.39"
           /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/coredns"
           /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/hostpath-provisioner"
 

--- a/.github/workflows/orchestrator.metricsd.yml
+++ b/.github/workflows/orchestrator.metricsd.yml
@@ -28,9 +28,57 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: microk8s
+        run: |
+          echo "# Install core snap"
+          /usr/bin/sudo snap install core
+
+          echo "# Install LXD"
+          /usr/bin/sudo apt-get remove -qy lxd lxd-client || true
+          /usr/bin/sudo snap install lxd
+
+          echo "# Initialize LXD"
+          /usr/bin/sudo lxd waitready
+          /usr/bin/sudo lxd init --auto
+          /usr/bin/sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
+          /snap/bin/lxc network set lxdbr0 ipv6.address none
+          /usr/bin/sudo usermod -a -G lxd $USER
+
+          echo "# Configure LXD"
+          /usr/bin/sudo lxc --project charmcraft project create local:charmcraft || true
+          /usr/bin/sudo lxc --project charmcraft profile device add default root disk path=/ pool=default type=disk || true
+          /usr/bin/sudo lxc --project charmcraft profile device add default eth0 nic name=eth0 network=lxdbr0 || true
+          /usr/bin/sudo lxc --project charmcraft profile set default environment.http_proxy http://squid.internal:3128/
+          /usr/bin/sudo lxc --project charmcraft profile set default environment.https_proxy http://squid.internal:3128/
+          /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTP_PROXY http://squid.internal:3128/
+          /usr/bin/sudo lxc --project charmcraft profile set default environment.HTTPS_PROXY http://squid.internal:3128/
+
+          echo "# Install tox"
+          /usr/bin/sudo apt-get update -yqq
+          /usr/bin/sudo apt-get install -yqq python3-pip
+          /usr/bin/sudo --preserve-env=http_proxy,https_proxy,no_proxy pip3 install tox
+
+          echo "# Install Juju"
+          /usr/bin/sudo snap install juju --classic --channel=latest/stable
+
+          echo "# Install tools"
+          /usr/bin/sudo snap install jq
+          /usr/bin/sudo snap install charm --classic --channel=latest/stable
+          /usr/bin/sudo snap install charmcraft --classic --channel=latest/stable
+          /usr/bin/sudo snap install juju-bundle --classic --channel=latest/stable
+
+          echo "# Install microk8s"
+          /usr/bin/sudo snap install microk8s --classic
+
+          echo "# Initialize microk8s"
+          /usr/bin/bash -c "sudo usermod -a -G microk8s $USER"
+          /usr/bin/sg microk8s -c "microk8s status --wait-ready"
+          /usr/bin/sg microk8s -c "microk8s enable storage rbac dns:185.125.188.1"
+          /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/coredns"
+          /usr/bin/sg microk8s -c "microk8s kubectl -n kube-system rollout status deployment/hostpath-provisioner"
+
+          echo "# Bootstrap controller"
+          sleep 180  # Microk8s needs time to initialize properly
+          /usr/bin/sg microk8s -c "juju bootstrap --debug --verbose microk8s integration-tests --model-default test-mode=true --model-default automatically-retry-hooks=true --model-default logging-config='<root>=DEBUG'  --bootstrap-constraints=''"
       - name: Run integration tests
         run: cd orchestrator-bundle/orc8r-metricsd-operator && tox -e integration
       - name: Archive charmcraft logs

--- a/orchestrator-bundle/bundle-local-federated.yaml
+++ b/orchestrator-bundle/bundle-local-federated.yaml
@@ -214,6 +214,13 @@ applications:
     channel: edge
     scale: 1
     trust: true
+  orc8r-alertmanager-configurer:
+    charm: alertmanager-configurer-k8s
+    channel: edge
+    scale: 1
+    trust: true
+    options:
+      multitenant_label: "networkID"
   orc8r-prometheus-cache:
     charm: prometheus-edge-hub
     channel: edge
@@ -226,6 +233,8 @@ applications:
     channel: edge
     scale: 1
     trust: true
+    options:
+      multitenant_label: "networkID"
   tls-certificates-operator:
     charm: tls-certificates-operator
     channel: edge
@@ -242,6 +251,8 @@ relations:
   - nms-magmalte:magma-nms-magmalte
 - - orc8r-accessd:db
   - postgresql-k8s:db
+- - orc8r-alertmanager:remote-configuration
+  - orc8r-alertmanager-configurer:alertmanager
 - - orc8r-certifier
   - tls-certificates-operator
 - - orc8r-certifier:db

--- a/orchestrator-bundle/bundle-local.yaml
+++ b/orchestrator-bundle/bundle-local.yaml
@@ -190,6 +190,13 @@ applications:
     channel: edge
     scale: 1
     trust: true
+  orc8r-alertmanager-configurer:
+    charm: alertmanager-configurer-k8s
+    channel: edge
+    scale: 1
+    trust: true
+    options:
+      multitenant_label: "networkID"
   orc8r-prometheus-cache:
     charm: prometheus-edge-hub
     channel: edge
@@ -202,6 +209,8 @@ applications:
     channel: edge
     scale: 1
     trust: true
+    options:
+      multitenant_label: "networkID"
   tls-certificates-operator:
     charm: tls-certificates-operator
     channel: edge
@@ -218,6 +227,8 @@ relations:
   - nms-magmalte:magma-nms-magmalte
 - - orc8r-accessd:db
   - postgresql-k8s:db
+- - orc8r-alertmanager:remote-configuration
+  - orc8r-alertmanager-configurer:alertmanager
 - - orc8r-certifier:db
   - postgresql-k8s:db
 - - orc8r-configurator:db

--- a/orchestrator-bundle/orc8r-bundle/bundle.yaml.j2
+++ b/orchestrator-bundle/orc8r-bundle/bundle.yaml.j2
@@ -25,6 +25,13 @@ applications:
     channel: edge
     scale: 1
     trust: true
+  orc8r-alertmanager-configurer:
+    charm: alertmanager-configurer-k8s
+    channel: edge
+    scale: 1
+    trust: true
+    options:
+      multitenant_label: "networkID"
   orc8r-analytics:
     charm: magma-orc8r-analytics
     channel: {{ channel|default("edge") }}
@@ -128,6 +135,8 @@ applications:
     channel: edge
     scale: 1
     trust: true
+    options:
+      multitenant_label: "networkID"
   orc8r-service-registry:
     charm: magma-orc8r-service-registry
     channel: {{ channel|default("edge") }}
@@ -191,6 +200,8 @@ relations:
   - nms-magmalte:magma-nms-magmalte
 - - orc8r-accessd:db
   - postgresql-k8s:db
+- - orc8r-alertmanager:remote-configuration
+  - orc8r-alertmanager-configurer:alertmanager
 - - orc8r-certifier
   - tls-certificates-operator
 - - orc8r-certifier:db

--- a/orchestrator-bundle/orc8r-feg-bundle/bundle.yaml
+++ b/orchestrator-bundle/orc8r-feg-bundle/bundle.yaml
@@ -27,6 +27,13 @@ applications:
     channel: edge
     scale: 1
     trust: true
+  orc8r-alertmanager-configurer:
+    charm: alertmanager-configurer-k8s
+    channel: edge
+    scale: 1
+    trust: true
+    options:
+      multitenant_label: "networkID"
   orc8r-analytics:
     charm: magma-orc8r-analytics
     channel: edge
@@ -150,6 +157,8 @@ applications:
     channel: edge
     scale: 1
     trust: true
+    options:
+      multitenant_label: "networkID"
   orc8r-service-registry:
     charm: magma-orc8r-service-registry
     channel: edge
@@ -214,6 +223,8 @@ relations:
   - nms-magmalte:magma-nms-magmalte
 - - orc8r-accessd:db
   - postgresql-k8s:db
+- - orc8r-alertmanager:remote-configuration
+  - orc8r-alertmanager-configurer:alertmanager
 - - orc8r-certifier:db
   - postgresql-k8s:db
 - - orc8r-configurator:db

--- a/orchestrator-bundle/orc8r-metricsd-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-metricsd-operator/metadata.yaml
@@ -27,6 +27,8 @@ provides:
 requires:
   alertmanager-k8s:
     interface: alertmanager_dispatch
+  alertmanager-configurer-k8s:
+    interface: alertmanager_configurer
   magma-orc8r-orchestrator:
     interface: magma-orc8r-orchestrator
   prometheus-k8s:

--- a/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
@@ -5,6 +5,7 @@
 """Collects runtime metrics from gateways and Orchestrator services."""
 
 import logging
+from typing import Optional
 
 from charms.observability_libs.v1.kubernetes_service_patch import (
     KubernetesServicePatch,
@@ -31,13 +32,11 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
     BASE_CONFIG_PATH = "/var/opt/magma/configs/orc8r"
     REQUIRED_EXTERNAL_RELATIONS = [
         "alertmanager-k8s",
+        "alertmanager-configurer-k8s",
         "prometheus-k8s",
         "prometheus-configurer-k8s",
     ]
     REQUIRED_ORC8R_RELATIONS = ["magma-orc8r-orchestrator"]
-
-    # TODO: The various URL's should be provided through relationships.
-    ALERTMANAGER_CONFIGURER_URL = "http://orc8r-alertmanager:9101"
 
     def __init__(self, *args):
         """Uses the Orc8rBase library to manage events."""
@@ -84,10 +83,10 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
         if not self._relations_created:
             event.defer()
             return
-        self._write_config_file()
         if not self._relations_ready:
             event.defer()
             return
+        self._write_config_file()
         if not self._container.can_connect():
             self.unit.status = WaitingStatus("Waiting for container to be ready")
             event.defer()
@@ -104,7 +103,7 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
             f'prometheusQueryAddress: "{self._prometheus_url}"\n'
             f'alertmanagerApiURL: "{self._alertmanager_url}/api/v2"\n'
             f'prometheusConfigServiceURL: "{self._prometheus_configurer_url}/v1"\n'
-            f'alertmanagerConfigServiceURL: "{self.ALERTMANAGER_CONFIGURER_URL}/v1"\n'
+            f'alertmanagerConfigServiceURL: "{self._alertmanager_configurer_url}/v1"\n'
             '"profile": "prometheus"\n'
         )
         self._container.push(f"{self.BASE_CONFIG_PATH}/metricsd.yml", metricsd_config)
@@ -218,11 +217,19 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
         Returns:
             str: Prometheus Configurer URL
         """
-        prometheus_configurer_service_name = self.model.get_relation(
-            "prometheus-configurer-k8s"
-        ).app.name  # type: ignore[union-attr]
-        # TODO: Get port from the relation data once such information is available.
-        return f"http://{prometheus_configurer_service_name}:9100"
+        prometheus_configurer_relation = self.model.get_relation("prometheus-configurer-k8s")
+        prometheus_configurer_app = prometheus_configurer_relation.app  # type: ignore[union-attr]
+        prometheus_configurer_service_name = prometheus_configurer_relation.data[  # type: ignore[union-attr]  # noqa: E501
+            prometheus_configurer_app  # type: ignore[index]
+        ][
+            "service_name"
+        ]
+        prometheus_configurer_port = prometheus_configurer_relation.data[  # type: ignore[union-attr]  # noqa: E501
+            prometheus_configurer_app  # type: ignore[index]
+        ][
+            "port"
+        ]
+        return f"http://{prometheus_configurer_service_name}:{prometheus_configurer_port}"
 
     @property
     def _alertmanager_url(self) -> str:
@@ -234,6 +241,27 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
         alertmanager_service_name = self.model.get_relation("alertmanager-k8s").app.name  # type: ignore[union-attr]  # noqa: E501
         # TODO: Get port from the relation data once such information is available.
         return f"http://{alertmanager_service_name}:9093"
+
+    @property
+    def _alertmanager_configurer_url(self) -> Optional[str]:
+        """Returns the URL of the Alertmanager Configurer API.
+
+        Returns:
+            str: Alertmanager Configurer URL
+        """
+        alertmanager_configurer_relation = self.model.get_relation("alertmanager-configurer-k8s")
+        alertmanager_configurer_app = alertmanager_configurer_relation.app  # type: ignore[union-attr]  # noqa: E501
+        alertmanager_configurer_service_name = alertmanager_configurer_relation.data[  # type: ignore[union-attr]  # noqa: E501
+            alertmanager_configurer_app  # type: ignore[index]
+        ][
+            "service_name"
+        ]
+        alertmanager_configurer_port = alertmanager_configurer_relation.data[  # type: ignore[union-attr]  # noqa: E501
+            alertmanager_configurer_app  # type: ignore[index]
+        ][
+            "port"
+        ]
+        return f"http://{alertmanager_configurer_service_name}:{alertmanager_configurer_port}"
 
     @property
     def _relations_created(self) -> bool:

--- a/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
@@ -85,11 +85,11 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
         if not self._relations_ready:
             event.defer()
             return
-        self._write_config_file()
         if not self._container.can_connect():
             self.unit.status = WaitingStatus("Waiting for container to be ready")
             event.defer()
             return
+        self._write_config_file()
         self._configure_pebble()
 
     def _write_config_file(self) -> None:

--- a/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/src/charm.py
@@ -5,7 +5,6 @@
 """Collects runtime metrics from gateways and Orchestrator services."""
 
 import logging
-from typing import Optional
 
 from charms.observability_libs.v1.kubernetes_service_patch import (
     KubernetesServicePatch,
@@ -243,7 +242,7 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
         return f"http://{alertmanager_service_name}:9093"
 
     @property
-    def _alertmanager_configurer_url(self) -> Optional[str]:
+    def _alertmanager_configurer_url(self) -> str:
         """Returns the URL of the Alertmanager Configurer API.
 
         Returns:

--- a/orchestrator-bundle/orc8r-metricsd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tests/integration/test_integration.py
@@ -43,6 +43,7 @@ class TestOrc8rMetricsd:
         await ops_test.model.set_config({"update-status-hook-interval": "2s"})
         await self._deploy_postgresql(ops_test)
         await self._deploy_alertmanager(ops_test)
+        await self._deploy_alertmanager_configurer(ops_test)
         await self._deploy_prometheus(ops_test)
         await self._deploy_prometheus_configurer(ops_test)
         await self._deploy_tls_certificates_operator(ops_test)
@@ -72,6 +73,19 @@ class TestOrc8rMetricsd:
             application_name="orc8r-alertmanager",
             channel="edge",
             trust=True,
+        )
+
+    @staticmethod
+    async def _deploy_alertmanager_configurer(ops_test):
+        await ops_test.model.deploy(
+            "alertmanager-configurer-k8s",
+            application_name="orc8r-alertmanager-configurer",
+            channel="edge",
+            trust=True,
+        )
+        await ops_test.model.add_relation(
+            relation1="orc8r-alertmanager-configurer:alertmanager",
+            relation2="orc8r-alertmanager:remote-configuration",
         )
 
     @staticmethod
@@ -242,6 +256,10 @@ class TestOrc8rMetricsd:
         await ops_test.model.add_relation(
             relation1=f"{APPLICATION_NAME}:alertmanager-k8s",
             relation2="orc8r-alertmanager:alerting",
+        )
+        await ops_test.model.add_relation(
+            relation1=f"{APPLICATION_NAME}:alertmanager-configurer-k8s",
+            relation2="orc8r-alertmanager-configurer:alertmanager-configurer",
         )
         await ops_test.model.add_relation(
             relation1=f"{APPLICATION_NAME}:magma-orc8r-orchestrator",

--- a/orchestrator-bundle/orc8r-metricsd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tests/integration/test_integration.py
@@ -34,6 +34,7 @@ SERVICE_REGISTRY_APPLICATION_NAME = "orc8r-service-registry"
 SERVICE_REGISTRY_CHARM_NAME = "magma-orc8r-service-registry"
 SERVICE_REGISTRY_CHARM_FILE_NAME = "magma-orc8r-service-registry_ubuntu-20.04-amd64.charm"
 DOMAIN = "whatever.com"
+WAIT_FOR_STATUS_TIMEOUT = 5 * 60
 
 
 class TestOrc8rMetricsd:
@@ -64,7 +65,11 @@ class TestOrc8rMetricsd:
     @staticmethod
     async def _deploy_postgresql(ops_test):
         await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
-        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
+        await ops_test.model.wait_for_idle(
+            apps=["postgresql-k8s"],
+            status="active",
+            timeout=WAIT_FOR_STATUS_TIMEOUT,
+        )
 
     @staticmethod
     async def _deploy_alertmanager(ops_test):
@@ -143,7 +148,9 @@ class TestOrc8rMetricsd:
             trust=True,
         )
         await ops_test.model.wait_for_idle(
-            apps=[SERVICE_REGISTRY_APPLICATION_NAME], status="active", timeout=1000
+            apps=[SERVICE_REGISTRY_APPLICATION_NAME],
+            status="active",
+            timeout=WAIT_FOR_STATUS_TIMEOUT,
         )
 
     async def _deploy_orc8r_certifier(self, ops_test):
@@ -171,7 +178,7 @@ class TestOrc8rMetricsd:
             relation1=CERTIFIER_APPLICATION_NAME, relation2="tls-certificates-operator"
         )
         await ops_test.model.wait_for_idle(
-            apps=[CERTIFIER_APPLICATION_NAME], status="active", timeout=1000
+            apps=[CERTIFIER_APPLICATION_NAME], status="active", timeout=WAIT_FOR_STATUS_TIMEOUT
         )
 
     @staticmethod
@@ -202,7 +209,7 @@ class TestOrc8rMetricsd:
             relation1=ACCESSD_APPLICATION_NAME, relation2="postgresql-k8s:db"
         )
         await ops_test.model.wait_for_idle(
-            apps=[ACCESSD_APPLICATION_NAME], status="active", timeout=1000
+            apps=[ACCESSD_APPLICATION_NAME], status="active", timeout=WAIT_FOR_STATUS_TIMEOUT
         )
 
     async def _deploy_orc8r_orchestrator(self, ops_test):
@@ -243,7 +250,7 @@ class TestOrc8rMetricsd:
             relation2="orc8r-service-registry:magma-orc8r-service-registry",
         )
         await ops_test.model.wait_for_idle(
-            apps=[ORCHESTRATOR_APPLICATION_NAME], status="active", timeout=1000
+            apps=[ORCHESTRATOR_APPLICATION_NAME], status="active", timeout=WAIT_FOR_STATUS_TIMEOUT
         )
 
     @pytest.fixture(scope="module")
@@ -259,7 +266,9 @@ class TestOrc8rMetricsd:
 
     @pytest.mark.abort_on_fail
     async def test_wait_for_blocked_status(self, ops_test, build_and_deploy):
-        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
+        await ops_test.model.wait_for_idle(
+            apps=[APPLICATION_NAME], status="blocked", timeout=WAIT_FOR_STATUS_TIMEOUT
+        )
 
     async def test_relate_and_wait_for_idle(self, ops_test, build_and_deploy):
         await ops_test.model.add_relation(
@@ -282,13 +291,18 @@ class TestOrc8rMetricsd:
             relation1=f"{APPLICATION_NAME}:prometheus-configurer-k8s",
             relation2="orc8r-prometheus-configurer:prometheus-configurer",
         )
-        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+        await ops_test.model.wait_for_idle(
+            apps=[APPLICATION_NAME], status="active", timeout=WAIT_FOR_STATUS_TIMEOUT
+        )
 
     async def test_scale_up(self, ops_test, setup, build_and_deploy):
         await ops_test.model.applications[APPLICATION_NAME].scale(2)
 
         await ops_test.model.wait_for_idle(
-            apps=[APPLICATION_NAME], status="active", timeout=1000, wait_for_exact_units=2
+            apps=[APPLICATION_NAME],
+            status="active",
+            timeout=WAIT_FOR_STATUS_TIMEOUT,
+            wait_for_exact_units=2,
         )
 
     @pytest.mark.xfail(reason="Bug in Juju: https://bugs.launchpad.net/juju/+bug/1977582")
@@ -296,5 +310,8 @@ class TestOrc8rMetricsd:
         await ops_test.model.applications[APPLICATION_NAME].scale(1)
 
         await ops_test.model.wait_for_idle(
-            apps=[APPLICATION_NAME], status="active", timeout=1000, wait_for_exact_units=1
+            apps=[APPLICATION_NAME],
+            status="active",
+            timeout=WAIT_FOR_STATUS_TIMEOUT,
+            wait_for_exact_units=1,
         )

--- a/orchestrator-bundle/orc8r-metricsd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tests/integration/test_integration.py
@@ -170,6 +170,9 @@ class TestOrc8rMetricsd:
         await ops_test.model.add_relation(
             relation1=CERTIFIER_APPLICATION_NAME, relation2="tls-certificates-operator"
         )
+        await ops_test.model.wait_for_idle(
+            apps=[CERTIFIER_APPLICATION_NAME], status="active", timeout=1000
+        )
 
     @staticmethod
     async def _deploy_prometheus_cache(ops_test):
@@ -197,6 +200,9 @@ class TestOrc8rMetricsd:
         )
         await ops_test.model.add_relation(
             relation1=ACCESSD_APPLICATION_NAME, relation2="postgresql-k8s:db"
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[ACCESSD_APPLICATION_NAME], status="active", timeout=1000
         )
 
     async def _deploy_orc8r_orchestrator(self, ops_test):
@@ -235,6 +241,9 @@ class TestOrc8rMetricsd:
         await ops_test.model.add_relation(
             relation1=f"{ORCHESTRATOR_APPLICATION_NAME}:magma-orc8r-service-registry",
             relation2="orc8r-service-registry:magma-orc8r-service-registry",
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[ORCHESTRATOR_APPLICATION_NAME], status="active", timeout=1000
         )
 
     @pytest.fixture(scope="module")

--- a/orchestrator-bundle/orc8r-metricsd-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tests/unit/test_charm.py
@@ -59,7 +59,7 @@ class TestCharm(unittest.TestCase):
     def test_given_all_relations_created_when_pebble_ready_then_config_file_is_created(
         self, patch_push
     ):
-        self._create_relations()
+        self._create_relations(activate=True)
 
         self.harness.charm.on.magma_orc8r_metricsd_pebble_ready.emit(self.container)
 

--- a/orchestrator-bundle/orc8r-metricsd-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tests/unit/test_charm.py
@@ -3,7 +3,7 @@
 # See LICENSE file for licensing details.
 
 import unittest
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, patch
 
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus


### PR DESCRIPTION
# Description

- Integrates Magma Orc8r with Alertmanager Configurer.
- Updates DNS used by microk8s in self-hosted runners ([TELCO-270](https://warthogs.atlassian.net/browse/TELCO-270))

# Checklist:

- [X] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that validate the behaviour of the software
- [X] I validated that new and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
