### PR TITLE
Adding provided relation to magma-orc8r-nginx

### DIFF
--- a/orchestrator-bundle/orc8r-nginx-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-nginx-operator/metadata.yaml
@@ -27,6 +27,10 @@ storage:
     description: Certs storage
     minimum-size: 1M
 
+provides:
+  magma-orc8r-nginx:
+    interface: magma-orc8r-nginx
+
 requires:
   magma-orc8r-bootstrapper:
     interface: magma-orc8r-bootstrapper

--- a/orchestrator-bundle/orc8r-nginx-operator/src/charm.py
+++ b/orchestrator-bundle/orc8r-nginx-operator/src/charm.py
@@ -5,6 +5,7 @@
 """Proxies traffic between nms and obsidian."""
 
 import logging
+import re
 from typing import List, Union
 
 from charms.magma_orc8r_certifier.v0.cert_certifier import CertCertifierRequires
@@ -26,10 +27,17 @@ from ops.charm import (
     ConfigChangedEvent,
     InstallEvent,
     PebbleReadyEvent,
-    RemoveEvent,
+    RelationJoinedEvent,
 )
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
+from ops.model import (
+    ActiveStatus,
+    BlockedStatus,
+    MaintenanceStatus,
+    ModelError,
+    Relation,
+    WaitingStatus,
+)
 from ops.pebble import ExecError, Layer
 
 logger = logging.getLogger(__name__)
@@ -39,6 +47,8 @@ class MagmaOrc8rNginxCharm(CharmBase):
     """An instance of this object everytime an event occurs."""
 
     BASE_CERTS_PATH = "/var/opt/magma/certs"
+    REQUIRED_RELATIONS = ["cert-certifier", "cert-controller"]
+    REQUIRED_MAGMA_SERVICES_RELATIONS = ["magma-orc8r-bootstrapper", "magma-orc8r-obsidian"]
 
     def __init__(self, *args):
         """Initializes all event that need to be observed."""
@@ -60,11 +70,17 @@ class MagmaOrc8rNginxCharm(CharmBase):
             additional_labels={"app.kubernetes.io/part-of": "orc8r"},
             additional_selectors={"app.kubernetes.io/name": "orc8r-nginx"},
         )
+
+        self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(self.on.config_changed, self._on_magma_orc8r_nginx_pebble_ready)
         self.framework.observe(
             self.on.magma_orc8r_nginx_pebble_ready, self._on_magma_orc8r_nginx_pebble_ready
         )
-        self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(
+            self.on.magma_orc8r_nginx_relation_joined, self._on_magma_orc8r_nginx_relation_joined
+        )
         self.framework.observe(self.on.remove, self._on_remove)
+
         self.framework.observe(
             self._cert_certifier.on.certificate_available, self._on_certifier_certificate_available
         )
@@ -72,36 +88,245 @@ class MagmaOrc8rNginxCharm(CharmBase):
             self._cert_controller.on.certificate_available,
             self._on_controller_certificate_available,
         )
-        self.framework.observe(self.on.config_changed, self._on_magma_orc8r_nginx_pebble_ready)
 
-    @property
-    def _certs_are_stored(self) -> bool:
+    def _on_install(self, event: InstallEvent) -> None:
+        """Triggerred once when charm is installed.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
         if not self._container.can_connect():
-            return False
-        return (
-            self._container.exists(f"{self.BASE_CERTS_PATH}/controller.crt")
-            and self._container.exists(f"{self.BASE_CERTS_PATH}/controller.key")  # noqa: W503
-            and self._container.exists(f"{self.BASE_CERTS_PATH}/certifier.pem")  # noqa: W503
-        )
+            logger.info("Can't connect to container - Deferring")
+            event.defer()
+            return
+        self._generate_nginx_config()
+        self._create_additional_orc8r_nginx_services()
 
-    @property
-    def _pebble_layer(self) -> Layer:
-        return Layer(
+    def _on_magma_orc8r_nginx_pebble_ready(
+        self,
+        event: Union[
+            PebbleReadyEvent,
+            CertifierCertificateAvailableEvent,
+            ControllerCertificateAvailableEvent,
+            ConfigChangedEvent,
+        ],
+    ) -> None:
+        """Triggerred when pebble ready.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        if not self._domain_config_is_valid:
+            self.unit.status = BlockedStatus("Domain config is not valid")
+            return
+        if not self._relations_created:
+            event.defer()
+            return
+        if not self._relations_ready:
+            event.defer()
+            return
+        if not self._certs_are_stored:
+            self.unit.status = WaitingStatus("Waiting for certificates to be available.")
+            event.defer()
+            return
+        self._configure_pebble_layer(event)
+
+    def _on_magma_orc8r_nginx_relation_joined(self, event: RelationJoinedEvent) -> None:
+        """Event handler for magma-orc8r-nginx RelationJoinedEvent.
+
+        Updates the status of the `orc8r-nginx` service in the relation data bags so that relation
+        consumers know if it's running or not. If `orc8r-nginx` is not running, event is also
+        deferred.
+
+        Args:
+            event (RelationJoinedEvent): Juju event
+        """
+        self._update_relations()
+        if not self._service_is_running:
+            event.defer()
+            return
+
+    def _on_remove(self, _) -> None:
+        """Remove additional magma-orc8r-nginx services.
+
+        Returns:
+            None
+        """
+        client = Client()
+        for service in self._magma_orc8r_nginx_additional_services:
+            client.delete(Service, name=service.metadata.name, namespace=self._namespace)
+
+    def _on_certifier_certificate_available(
+        self, event: CertifierCertificateAvailableEvent
+    ) -> None:
+        """Triggered when certifier certificate is available.
+
+        Args:
+            event (CertifierCertificateAvailableEvent): Juju event
+
+        Returns:
+            None
+        """
+        logger.info("Certifier certificate available")
+        if not self._container.can_connect():
+            logger.info("Can't connect to container - Deferring")
+            event.defer()
+            return
+        self._container.push(
+            path=f"{self.BASE_CERTS_PATH}/certifier.pem", source=event.certificate
+        )
+        self._on_magma_orc8r_nginx_pebble_ready(event)
+
+    def _on_controller_certificate_available(
+        self, event: ControllerCertificateAvailableEvent
+    ) -> None:
+        """Triggered when controller certificate is available.
+
+        Args:
+            event (ControllerCertificateAvailableEvent): Juju event
+
+        Returns:
+            None
+        """
+        logger.info("Controller certificate available")
+        if not self._container.can_connect():
+            logger.info("Can't connect to container - Deferring")
+            event.defer()
+            return
+        self._container.push(
+            path=f"{self.BASE_CERTS_PATH}/controller.crt", source=event.certificate
+        )
+        self._container.push(
+            path=f"{self.BASE_CERTS_PATH}/controller.key", source=event.private_key
+        )
+        self._on_magma_orc8r_nginx_pebble_ready(event)
+
+    def _generate_nginx_config(self) -> None:
+        """Generates nginx config to /etc/nginx/nginx.conf.
+
+        Returns:
+            None
+        """
+        logger.info("Generating nginx config file...")
+        domain_name = self.model.config.get("domain")
+        process = self._container.exec(
+            command=["/usr/local/bin/generate_nginx_configs.py"],
+            environment={
+                "PROXY_BACKENDS": f"{self._namespace}.svc.cluster.local",
+                "CONTROLLER_HOSTNAME": f"controller.{domain_name}",
+                "RESOLVER": "kube-dns.kube-system.svc.cluster.local valid=10s",
+                "SERVICE_REGISTRY_MODE": "k8s",
+            },
+        )
+        try:
+            process.wait_output()
+        except ExecError as e:
+            logger.error("Exited with code %d. Stderr:", e.exit_code)
+            for line in e.stderr.splitlines():
+                logger.error("    %s", line)
+            raise e
+        logger.info("Successfully generated nginx config file")
+
+    def _create_additional_orc8r_nginx_services(self) -> None:
+        """Creates additional K8s services.
+
+        Those services are expected to be delivered by the magma-orc8r-nginx service.
+
+        Returns:
+            None
+        """
+        client = Client()
+        logger.info("Creating additional magma-orc8r-nginx services")
+        for service in self._magma_orc8r_nginx_additional_services:
+            if not self._orc8r_nginx_service_created(service.metadata.name):
+                logger.info(f"Creating {service.metadata.name} service")
+                client.create(service)
+
+    def _configure_pebble_layer(
+        self,
+        event: Union[
+            PebbleReadyEvent,
+            CertifierCertificateAvailableEvent,
+            ControllerCertificateAvailableEvent,
+            ConfigChangedEvent,
+        ],
+    ) -> None:
+        """Adds service to workload and restarts it.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        if self._container.can_connect():
+            plan = self._container.get_plan()
+            layer = self._pebble_layer
+            if plan.services != layer.services:
+                self.unit.status = MaintenanceStatus(
+                    f"Configuring pebble layer for {self._service_name}"
+                )
+                self._container.add_layer(self._container_name, layer, combine=True)
+                self._container.restart(self._service_name)
+                logger.info(f"Restarted service {self._service_name}")
+                self._update_relations()
+                self.unit.status = ActiveStatus()
+        else:
+            self.unit.status = WaitingStatus(f"Waiting for {self._container} to be ready")
+            event.defer()
+            return
+
+    def _update_relations(self) -> None:
+        """Updates the status of the `orc8r-nginx` service.
+
+        Updates the status of the `orc8r-nginx` service in the relation data bags so that relation
+        consumers know if it's running or not.
+        """
+        if not self.unit.is_leader():
+            return
+        relations = self.model.relations[self.meta.name]
+        for relation in relations:
+            self._update_relation_active_status(
+                relation=relation, is_active=self._service_is_running
+            )
+
+    def _update_relation_active_status(self, relation: Relation, is_active: bool) -> None:
+        """Updates service status in the relation data bag.
+
+        Args:
+            relation: Juju Relation object to update
+            is_active: Workload service status
+
+        Returns:
+            None
+        """
+        relation.data[self.unit].update(
             {
-                "summary": f"{self._service_name} pebble layer",
-                "services": {
-                    self._service_name: {
-                        "override": "replace",
-                        "startup": "enabled",
-                        "command": "nginx",
-                        "environment": {
-                            "SERVICE_REGISTRY_MODE": "k8s",
-                            "SERVICE_REGISTRY_NAMESPACE": self._namespace,
-                        },
-                    }
-                },
+                "active": str(is_active),
             }
         )
+
+    def _orc8r_nginx_service_created(self, service_name: str) -> bool:
+        """Checks whether given K8s service exists or not.
+
+        Args:
+            service_name (str): Kubernetes service name
+
+        Returns:
+            bool: True/False
+        """
+        client = Client()
+        try:
+            client.get(Service, name=service_name, namespace=self._namespace)
+            return True
+        except HTTPStatusError:
+            return False
 
     @property
     def _magma_orc8r_nginx_additional_services(self) -> List[Service]:
@@ -178,332 +403,125 @@ class MagmaOrc8rNginxCharm(CharmBase):
         ]
 
     @property
-    def _namespace(self) -> str:
-        return self.model.name
-
-    @property
-    def _magma_orc8r_bootstrapper_relation_created(self) -> bool:
-        """Returns whether magma-orc8r-bootstrapper relation is created.
-
-        Returns:
-            bool: True/False
-        """
-        return self._relation_created("magma-orc8r-bootstrapper")
-
-    @property
-    def _magma_orc8r_obsidian_relation_created(self) -> bool:
-        """Returns whether magma-orc8r-obsidian relation is created.
-
-        Returns:
-            bool: True/False
-        """
-        return self._relation_created("magma-orc8r-obsidian")
-
-    @property
-    def _cert_certifier_relation_created(self) -> bool:
-        """Returns whether cert-certifier relation is created.
-
-        Returns:
-            bool: True/False
-        """
-        return self._relation_created("cert-certifier")
-
-    @property
-    def _cert_controller_relation_created(self) -> bool:
-        """Returns whether cert-controller relation is created.
-
-        Returns:
-            bool: True/False
-        """
-        return self._relation_created("cert-controller")
-
-    @property
     def _domain_config_is_valid(self) -> bool:
-        """Returns whether the `domain` config is valid.
+        """Returns whether the "domain" config is valid.
 
         Returns:
-            bool: True/False
+            bool: Whether the domain is a valid one.
         """
         domain = self.model.config.get("domain")
         if not domain:
             return False
+        pattern = re.compile(
+            r"^(?:[a-zA-Z0-9]"  # First character of the domain
+            r"(?:[a-zA-Z0-9-_]{0,61}[A-Za-z0-9])?\.)"  # Sub domain + hostname
+            r"+[A-Za-z0-9][A-Za-z0-9-_]{0,61}"  # First 61 characters of the gTLD
+            r"[A-Za-z]$"  # Last character of the gTLD
+        )
+        if pattern.match(domain):
+            return True
+        return False
+
+    @property
+    def _relations_created(self) -> bool:
+        """Checks whether required relations are created.
+
+        Returns:
+            bool: True/False
+        """
+        if missing_relations := [
+            relation
+            for relation in self.REQUIRED_RELATIONS + self.REQUIRED_MAGMA_SERVICES_RELATIONS
+            if not self.model.get_relation(relation)
+        ]:
+            msg = f"Waiting for relation(s) to be created: {', '.join(missing_relations)}"
+            self.unit.status = BlockedStatus(msg)
+            return False
         return True
 
     @property
-    def _magma_orc8r_bootstrapper_relation_ready(self) -> bool:
-        """Returns whether the magma-orc8r-bootstrapper workload service is running.
+    def _relations_ready(self) -> bool:
+        """Checks whether required relations are ready.
 
         Returns:
             bool: True/False
         """
-        return self._magma_relation_ready(relation_name="magma-orc8r-bootstrapper")
+        if missing_relations := [
+            relation
+            for relation in self.REQUIRED_MAGMA_SERVICES_RELATIONS
+            if not self._relation_active(relation)
+        ]:
+            msg = f"Waiting for relation(s) to be ready: {', '.join(missing_relations)}"
+            self.unit.status = WaitingStatus(msg)
+            return False
+        return True
 
-    @property
-    def _magma_orc8r_obsidian_relation_ready(self) -> bool:
-        """Returns whether the magma-orc8r-obsidian workload service is running.
+    def _relation_active(self, relation_name: str) -> bool:
+        """Checks whether related service is ready.
 
-        Returns:
-            bool: True/False
-        """
-        return self._magma_relation_ready(relation_name="magma-orc8r-obsidian")
-
-    def _magma_relation_ready(self, relation_name: str) -> bool:
-        """Returns whether a given Magma relation is ready.
-
-        Looks at the relation data and checks if the "active" key is set to "True".
+        Checks whether related service is running by checking the value of the `active` key
+        provided in the relation data bag.
 
         Args:
-            relation_name (str): Juju relation name
+            relation_name: The name of the relation
 
         Returns:
             bool: True/False
         """
         try:
-            relation = self.model.get_relation(relation_name)
-            units = relation.units  # type: ignore[union-attr]
-            return relation.data[next(iter(units))]["active"] == "True"  # type: ignore[union-attr]
+            rel = self.model.get_relation(relation_name)
+            units = rel.units  # type: ignore[union-attr]
+            return rel.data[next(iter(units))]["active"] == "True"  # type: ignore[union-attr]
         except (AttributeError, KeyError, StopIteration):
             return False
 
-    def _relation_created(self, relation_name: str) -> bool:
-        """Returns whether given relation was created.
+    @property
+    def _certs_are_stored(self) -> bool:
+        if not self._container.can_connect():
+            return False
+        return (
+            self._container.exists(f"{self.BASE_CERTS_PATH}/controller.crt")
+            and self._container.exists(f"{self.BASE_CERTS_PATH}/controller.key")  # noqa: W503
+            and self._container.exists(f"{self.BASE_CERTS_PATH}/certifier.pem")  # noqa: W503
+        )
 
-        Args:
-            relation_name (str): Relation name
+    @property
+    def _service_is_running(self) -> bool:
+        """Checks whether the workload service is running.
 
         Returns:
             bool: True/False
-        """
-        try:
-            if self.model.get_relation(relation_name):
-                return True
-            return False
-        except KeyError:
-            return False
-
-    def _on_install(self, event: InstallEvent) -> None:
-        """Triggerred once when charm is installed.
-
-        Args:
-            event: Juju event
-
-        Returns:
-            None
-        """
-        if not self._container.can_connect():
-            logger.info("Can't connect to container - Deferring")
-            event.defer()
-            return
-        self._generate_nginx_config()
-        self._create_additional_orc8r_nginx_services()
-
-    def _on_magma_orc8r_nginx_pebble_ready(
-        self,
-        event: Union[
-            PebbleReadyEvent,
-            CertifierCertificateAvailableEvent,
-            ControllerCertificateAvailableEvent,
-            ConfigChangedEvent,
-        ],
-    ) -> None:
-        """Triggerred when pebble ready.
-
-        Args:
-            event: Juju event
-
-        Returns:
-            None
-        """
-        if not self._domain_config_is_valid:
-            self.unit.status = BlockedStatus("Domain config is not valid")
-            return
-        if not self._magma_orc8r_bootstrapper_relation_created:
-            self.unit.status = BlockedStatus(
-                "Waiting for 'magma-orc8r-bootstrapper' relation to be created"
-            )
-            event.defer()
-            return
-        if not self._magma_orc8r_obsidian_relation_created:
-            self.unit.status = BlockedStatus(
-                "Waiting for 'magma-orc8r-obsidian' relation to be created"
-            )
-            event.defer()
-            return
-        if not self._cert_certifier_relation_created:
-            self.unit.status = BlockedStatus("Waiting for 'cert-certifier' relation to be created")
-            event.defer()
-            return
-        if not self._cert_controller_relation_created:
-            self.unit.status = BlockedStatus(
-                "Waiting for 'cert-controller' relation to be created"
-            )
-            event.defer()
-            return
-        if not self._certs_are_stored:
-            self.unit.status = WaitingStatus("Waiting for certificates to be available.")
-            event.defer()
-            return
-        if not self._magma_orc8r_bootstrapper_relation_ready:
-            self.unit.status = WaitingStatus(
-                "Waiting for 'magma-orc8r-bootstrapper' relation to be ready"
-            )
-            event.defer()
-            return
-        if not self._magma_orc8r_obsidian_relation_ready:
-            self.unit.status = WaitingStatus(
-                "Waiting for 'magma-orc8r-obsidian' relation to be ready"
-            )
-            event.defer()
-            return
-        self._configure_pebble_layer(event)
-
-    def _configure_pebble_layer(
-        self,
-        event: Union[
-            PebbleReadyEvent,
-            CertifierCertificateAvailableEvent,
-            ControllerCertificateAvailableEvent,
-            ConfigChangedEvent,
-        ],
-    ) -> None:
-        """Adds service to workload and restarts it.
-
-        Args:
-            event: Juju event
-
-        Returns:
-            None
         """
         if self._container.can_connect():
-            plan = self._container.get_plan()
-            layer = self._pebble_layer
-            if plan.services != layer.services:
-                self.unit.status = MaintenanceStatus(
-                    f"Configuring pebble layer for {self._service_name}"
-                )
-                self._container.add_layer(self._container_name, layer, combine=True)
-                self._container.restart(self._service_name)
-                logger.info(f"Restarted service {self._service_name}")
-                self.unit.status = ActiveStatus()
-        else:
-            self.unit.status = WaitingStatus(f"Waiting for {self._container} to be ready")
-            event.defer()
-            return
+            try:
+                self._container.get_service(self._service_name)
+                return True
+            except ModelError:
+                pass
+        return False
 
-    def _generate_nginx_config(self) -> None:
-        """Generates nginx config to /etc/nginx/nginx.conf.
-
-        Returns:
-            None
-        """
-        logger.info("Generating nginx config file...")
-        domain_name = self.model.config.get("domain")
-        process = self._container.exec(
-            command=["/usr/local/bin/generate_nginx_configs.py"],
-            environment={
-                "PROXY_BACKENDS": f"{self._namespace}.svc.cluster.local",
-                "CONTROLLER_HOSTNAME": f"controller.{domain_name}",
-                "RESOLVER": "kube-dns.kube-system.svc.cluster.local valid=10s",
-                "SERVICE_REGISTRY_MODE": "k8s",
-            },
+    @property
+    def _pebble_layer(self) -> Layer:
+        return Layer(
+            {
+                "summary": f"{self._service_name} pebble layer",
+                "services": {
+                    self._service_name: {
+                        "override": "replace",
+                        "startup": "enabled",
+                        "command": "nginx",
+                        "environment": {
+                            "SERVICE_REGISTRY_MODE": "k8s",
+                            "SERVICE_REGISTRY_NAMESPACE": self._namespace,
+                        },
+                    }
+                },
+            }
         )
-        try:
-            process.wait_output()
-        except ExecError as e:
-            logger.error("Exited with code %d. Stderr:", e.exit_code)
-            for line in e.stderr.splitlines():
-                logger.error("    %s", line)
-            raise e
-        logger.info("Successfully generated nginx config file")
 
-    def _create_additional_orc8r_nginx_services(self) -> None:
-        """Creates additional K8s services.
-
-        Those services are expected to be delivered by the magma-orc8r-nginx service.
-
-        Returns:
-            None
-        """
-        client = Client()
-        logger.info("Creating additional magma-orc8r-nginx services")
-        for service in self._magma_orc8r_nginx_additional_services:
-            if not self._orc8r_nginx_service_created(service.metadata.name):
-                logger.info(f"Creating {service.metadata.name} service")
-                client.create(service)
-
-    def _on_remove(self, event: RemoveEvent) -> None:
-        """Remove additional magma-orc8r-nginx services.
-
-        Args:
-            event (RemoveEvent): Juju event
-
-        Returns:
-            None
-        """
-        client = Client()
-        for service in self._magma_orc8r_nginx_additional_services:
-            client.delete(Service, name=service.metadata.name, namespace=self._namespace)
-
-    def _orc8r_nginx_service_created(self, service_name: str) -> bool:
-        """Checks whether given K8s service exists or not.
-
-        Args:
-            service_name (str): Kubernetes service name
-
-        Returns:
-            bool: True/False
-        """
-        client = Client()
-        try:
-            client.get(Service, name=service_name, namespace=self._namespace)
-            return True
-        except HTTPStatusError:
-            return False
-
-    def _on_controller_certificate_available(
-        self, event: ControllerCertificateAvailableEvent
-    ) -> None:
-        """Triggered when controller certificate is available.
-
-        Args:
-            event (ControllerCertificateAvailableEvent): Juju event
-
-        Returns:
-            None
-        """
-        logger.info("Controller certificate available")
-        if not self._container.can_connect():
-            logger.info("Can't connect to container - Deferring")
-            event.defer()
-            return
-        self._container.push(
-            path=f"{self.BASE_CERTS_PATH}/controller.crt", source=event.certificate
-        )
-        self._container.push(
-            path=f"{self.BASE_CERTS_PATH}/controller.key", source=event.private_key
-        )
-        self._on_magma_orc8r_nginx_pebble_ready(event)
-
-    def _on_certifier_certificate_available(
-        self, event: CertifierCertificateAvailableEvent
-    ) -> None:
-        """Triggered when certifier certificate is available.
-
-        Args:
-            event (CertifierCertificateAvailableEvent): Juju event
-
-        Returns:
-            None
-        """
-        logger.info("Certifier certificate available")
-        if not self._container.can_connect():
-            logger.info("Can't connect to container - Deferring")
-            event.defer()
-            return
-        self._container.push(
-            path=f"{self.BASE_CERTS_PATH}/certifier.pem", source=event.certificate
-        )
-        self._on_magma_orc8r_nginx_pebble_ready(event)
+    @property
+    def _namespace(self) -> str:
+        return self.model.name
 
 
 if __name__ == "__main__":

--- a/orchestrator-bundle/orc8r-nginx-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-nginx-operator/tests/unit/test_charm.py
@@ -291,7 +291,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("ops.model.Container.exists")
     def test_given_magma_orc8r_bootstrapper_relation_not_ready_when_pebble_ready_event_emitted_then_status_is_waiting(  # noqa: E501
-    self, patch_file_exists
+        self, patch_file_exists
     ):
         patch_file_exists.return_value = True
         self.harness.update_config(key_values={"domain": "whatever.com"})

--- a/orchestrator-bundle/orc8r-nginx-operator/tests/unit/test_charm.py
+++ b/orchestrator-bundle/orc8r-nginx-operator/tests/unit/test_charm.py
@@ -9,7 +9,7 @@ from lightkube.models.core_v1 import ServicePort, ServiceSpec
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Service
 from ops import testing
-from ops.model import BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
 from charm import MagmaOrc8rNginxCharm
 
@@ -148,6 +148,181 @@ class TestCharm(unittest.TestCase):
 
         patch_create.assert_has_calls(calls=calls)
 
+    def test_given_no_relations_created_when_pebble_ready_event_emitted_then_status_is_blocked(
+        self,
+    ):
+        self.harness.update_config(key_values={"domain": "whatever.com"})
+
+        self.harness.container_pebble_ready(container_name="magma-orc8r-nginx")
+
+        self.assertEqual(
+            BlockedStatus(
+                "Waiting for relation(s) to be created: cert-certifier, cert-controller, "
+                "magma-orc8r-bootstrapper, magma-orc8r-obsidian"
+            ),
+            self.harness.charm.unit.status,
+        )
+
+    @patch("ops.model.Container.exists")
+    def test_given_cert_certifier_relation_not_created_when_pebble_ready_event_emitted_then_status_is_blocked(  # noqa: E501
+        self, patch_file_exists
+    ):
+        patch_file_exists.return_value = True
+        self.harness.update_config(key_values={"domain": "whatever.com"})
+        self.harness.add_relation(
+            relation_name="magma-orc8r-bootstrapper", remote_app="magma-orc8r-bootstrapper"
+        )
+        self.harness.add_relation(
+            relation_name="magma-orc8r-obsidian", remote_app="magma-orc8r-obsidian"
+        )
+        self.harness.add_relation(
+            relation_name="cert-controller", remote_app="magma-orc8r-certifier"
+        )
+
+        self.harness.container_pebble_ready(container_name="magma-orc8r-nginx")
+
+        self.assertEqual(
+            BlockedStatus("Waiting for relation(s) to be created: cert-certifier"),
+            self.harness.charm.unit.status,
+        )
+
+    @patch("ops.model.Container.exists")
+    def test_given_cert_controller_relation_not_created_when_pebble_ready_event_emitted_then_status_is_blocked(  # noqa: E501
+        self, patch_file_exists
+    ):
+        patch_file_exists.return_value = True
+        self.harness.update_config(key_values={"domain": "whatever.com"})
+        self.harness.add_relation(
+            relation_name="magma-orc8r-bootstrapper", remote_app="magma-orc8r-bootstrapper"
+        )
+        self.harness.add_relation(
+            relation_name="magma-orc8r-obsidian", remote_app="magma-orc8r-obsidian"
+        )
+        self.harness.add_relation(
+            relation_name="cert-certifier", remote_app="magma-orc8r-certifier"
+        )
+
+        self.harness.container_pebble_ready(container_name="magma-orc8r-nginx")
+
+        self.assertEqual(
+            BlockedStatus("Waiting for relation(s) to be created: cert-controller"),
+            self.harness.charm.unit.status,
+        )
+
+    @patch("ops.model.Container.exists")
+    def test_given_magma_orc8r_bootstrapper_relation_not_created_when_pebble_ready_event_emitted_then_status_is_blocked(  # noqa: E501
+        self, patch_file_exists
+    ):
+        patch_file_exists.return_value = True
+        self.harness.update_config(key_values={"domain": "whatever.com"})
+        self.harness.add_relation(
+            relation_name="magma-orc8r-obsidian", remote_app="magma-orc8r-obsidian"
+        )
+        self.harness.add_relation(
+            relation_name="cert-certifier", remote_app="magma-orc8r-certifier"
+        )
+        self.harness.add_relation(
+            relation_name="cert-controller", remote_app="magma-orc8r-certifier"
+        )
+
+        self.harness.container_pebble_ready(container_name="magma-orc8r-nginx")
+
+        self.assertEqual(
+            BlockedStatus("Waiting for relation(s) to be created: magma-orc8r-bootstrapper"),
+            self.harness.charm.unit.status,
+        )
+
+    @patch("ops.model.Container.exists")
+    def test_given_magma_orc8r_obsidian_relation_not_created_when_pebble_ready_event_emitted_then_status_is_blocked(  # noqa: E501
+        self, patch_file_exists
+    ):
+        patch_file_exists.return_value = True
+        self.harness.update_config(key_values={"domain": "whatever.com"})
+        self.harness.add_relation(
+            relation_name="magma-orc8r-bootstrapper", remote_app="magma-orc8r-bootstrapper"
+        )
+        self.harness.add_relation(
+            relation_name="cert-certifier", remote_app="magma-orc8r-certifier"
+        )
+        self.harness.add_relation(
+            relation_name="cert-controller", remote_app="magma-orc8r-certifier"
+        )
+
+        self.harness.container_pebble_ready(container_name="magma-orc8r-nginx")
+
+        self.assertEqual(
+            BlockedStatus("Waiting for relation(s) to be created: magma-orc8r-obsidian"),
+            self.harness.charm.unit.status,
+        )
+
+    @patch("ops.model.Container.exists")
+    def test_given_magma_orc8r_obsidian_relation_not_ready_when_pebble_ready_event_emitted_then_status_is_waiting(  # noqa: E501
+        self, patch_file_exists
+    ):
+        patch_file_exists.return_value = True
+        self.harness.update_config(key_values={"domain": "whatever.com"})
+        bootstrapper_relation = self.harness.add_relation(
+            relation_name="magma-orc8r-bootstrapper", remote_app="magma-orc8r-bootstrapper"
+        )
+        self.harness.add_relation_unit(
+            relation_id=bootstrapper_relation, remote_unit_name="orc8r-bootstrapper/0"
+        )
+        self.harness.update_relation_data(
+            relation_id=bootstrapper_relation,
+            app_or_unit="orc8r-bootstrapper/0",
+            key_values={"active": "True"},
+        )
+        self.harness.add_relation(
+            relation_name="magma-orc8r-obsidian", remote_app="magma-orc8r-obsidian"
+        )
+        self.harness.add_relation(
+            relation_name="cert-certifier", remote_app="magma-orc8r-certifier"
+        )
+        self.harness.add_relation(
+            relation_name="cert-controller", remote_app="magma-orc8r-certifier"
+        )
+
+        self.harness.container_pebble_ready(container_name="magma-orc8r-nginx")
+
+        self.assertEqual(
+            WaitingStatus("Waiting for relation(s) to be ready: magma-orc8r-obsidian"),
+            self.harness.charm.unit.status,
+        )
+
+    @patch("ops.model.Container.exists")
+    def test_given_magma_orc8r_bootstrapper_relation_not_ready_when_pebble_ready_event_emitted_then_status_is_waiting(  # noqa: E501
+    self, patch_file_exists
+    ):
+        patch_file_exists.return_value = True
+        self.harness.update_config(key_values={"domain": "whatever.com"})
+        obsidian_relation = self.harness.add_relation(
+            relation_name="magma-orc8r-obsidian", remote_app="magma-orc8r-obsidian"
+        )
+        self.harness.add_relation_unit(
+            relation_id=obsidian_relation, remote_unit_name="orc8r-obsidian/0"
+        )
+        self.harness.update_relation_data(
+            relation_id=obsidian_relation,
+            app_or_unit="orc8r-obsidian/0",
+            key_values={"active": "True"},
+        )
+        self.harness.add_relation(
+            relation_name="magma-orc8r-bootstrapper", remote_app="magma-orc8r-bootstrapper"
+        )
+        self.harness.add_relation(
+            relation_name="cert-certifier", remote_app="magma-orc8r-certifier"
+        )
+        self.harness.add_relation(
+            relation_name="cert-controller", remote_app="magma-orc8r-certifier"
+        )
+
+        self.harness.container_pebble_ready(container_name="magma-orc8r-nginx")
+
+        self.assertEqual(
+            WaitingStatus("Waiting for relation(s) to be ready: magma-orc8r-bootstrapper"),
+            self.harness.charm.unit.status,
+        )
+
     @patch("ops.model.Container.exists")
     def test_given_all_relations_created_and_ready_and_nginx_services_are_created_when_pebble_ready_event_emitted_then_pebble_layer_is_configured(  # noqa: E501
         self, patch_file_exists
@@ -204,99 +379,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(expected_plan, updated_plan)
 
     @patch("ops.model.Container.exists")
-    def test_given_cert_certifier_relation_not_created_when_pebble_ready_event_emitted_then_status_is_blocked(  # noqa: E501
-        self, patch_file_exists
-    ):
-        patch_file_exists.return_value = True
-        self.harness.update_config(key_values={"domain": "whatever.com"})
-        self.harness.add_relation(
-            relation_name="magma-orc8r-bootstrapper", remote_app="magma-orc8r-bootstrapper"
-        )
-        self.harness.add_relation(
-            relation_name="magma-orc8r-obsidian", remote_app="magma-orc8r-obsidian"
-        )
-        self.harness.add_relation(
-            relation_name="cert-controller", remote_app="magma-orc8r-certifier"
-        )
-
-        self.harness.container_pebble_ready(container_name="magma-orc8r-nginx")
-
-        self.assertEqual(
-            BlockedStatus("Waiting for 'cert-certifier' relation to be created"),
-            self.harness.charm.unit.status,
-        )
-
-    @patch("ops.model.Container.exists")
-    def test_given_cert_controller_relation_not_created_when_pebble_ready_event_emitted_then_status_is_blocked(  # noqa: E501
-        self, patch_file_exists
-    ):
-        patch_file_exists.return_value = True
-        self.harness.update_config(key_values={"domain": "whatever.com"})
-        self.harness.add_relation(
-            relation_name="magma-orc8r-bootstrapper", remote_app="magma-orc8r-bootstrapper"
-        )
-        self.harness.add_relation(
-            relation_name="magma-orc8r-obsidian", remote_app="magma-orc8r-obsidian"
-        )
-        self.harness.add_relation(
-            relation_name="cert-certifier", remote_app="magma-orc8r-certifier"
-        )
-
-        self.harness.container_pebble_ready(container_name="magma-orc8r-nginx")
-
-        self.assertEqual(
-            BlockedStatus("Waiting for 'cert-controller' relation to be created"),
-            self.harness.charm.unit.status,
-        )
-
-    @patch("ops.model.Container.exists")
-    def test_given_magma_orc8r_bootstrapper_relation_not_created_when_pebble_ready_event_emitted_then_status_is_blocked(  # noqa: E501
-        self, patch_file_exists
-    ):
-        patch_file_exists.return_value = True
-        self.harness.update_config(key_values={"domain": "whatever.com"})
-        self.harness.add_relation(
-            relation_name="magma-orc8r-obsidian", remote_app="magma-orc8r-obsidian"
-        )
-        self.harness.add_relation(
-            relation_name="cert-certifier", remote_app="magma-orc8r-certifier"
-        )
-        self.harness.add_relation(
-            relation_name="cert-controller", remote_app="magma-orc8r-certifier"
-        )
-
-        self.harness.container_pebble_ready(container_name="magma-orc8r-nginx")
-
-        self.assertEqual(
-            BlockedStatus("Waiting for 'magma-orc8r-bootstrapper' relation to be created"),
-            self.harness.charm.unit.status,
-        )
-
-    @patch("ops.model.Container.exists")
-    def test_given_magma_orc8r_obsidian_relation_not_created_when_pebble_ready_event_emitted_then_status_is_blocked(  # noqa: E501
-        self, patch_file_exists
-    ):
-        patch_file_exists.return_value = True
-        self.harness.update_config(key_values={"domain": "whatever.com"})
-        self.harness.add_relation(
-            relation_name="magma-orc8r-bootstrapper", remote_app="magma-orc8r-bootstrapper"
-        )
-        self.harness.add_relation(
-            relation_name="cert-certifier", remote_app="magma-orc8r-certifier"
-        )
-        self.harness.add_relation(
-            relation_name="cert-controller", remote_app="magma-orc8r-certifier"
-        )
-
-        self.harness.container_pebble_ready(container_name="magma-orc8r-nginx")
-
-        self.assertEqual(
-            BlockedStatus("Waiting for 'magma-orc8r-obsidian' relation to be created"),
-            self.harness.charm.unit.status,
-        )
-
-    @patch("ops.model.Container.exists")
-    def test_given_magma_orc8r_obsidian_relation_not_ready_when_pebble_ready_event_emitted_then_status_is_blocked(  # noqa: E501
+    def test_given_all_relations_created_and_ready_and_nginx_services_are_created_when_pebble_ready_event_emitted_then_status_is_active(  # noqa: E501
         self, patch_file_exists
     ):
         patch_file_exists.return_value = True
@@ -304,50 +387,62 @@ class TestCharm(unittest.TestCase):
         bootstrapper_relation = self.harness.add_relation(
             relation_name="magma-orc8r-bootstrapper", remote_app="magma-orc8r-bootstrapper"
         )
-        self.harness.add_relation_unit(
-            relation_id=bootstrapper_relation, remote_unit_name="orc8r-bootstrapper/0"
-        )
-        self.harness.update_relation_data(
-            relation_id=bootstrapper_relation,
-            app_or_unit="orc8r-bootstrapper/0",
-            key_values={"active": "True"},
-        )
-        self.harness.add_relation(
-            relation_name="magma-orc8r-obsidian", remote_app="magma-orc8r-obsidian"
-        )
-        self.harness.add_relation(
-            relation_name="cert-certifier", remote_app="magma-orc8r-certifier"
-        )
-        self.harness.add_relation(
-            relation_name="cert-controller", remote_app="magma-orc8r-certifier"
-        )
-
-        self.harness.container_pebble_ready(container_name="magma-orc8r-nginx")
-
-        self.assertEqual(
-            WaitingStatus("Waiting for 'magma-orc8r-obsidian' relation to be ready"),
-            self.harness.charm.unit.status,
-        )
-
-    @patch("ops.model.Container.exists")
-    def test_given_magma_orc8r_bootstrapper_relation_not_ready_when_pebble_ready_event_emitted_then_status_is_blocked(  # noqa: E501
-        self, patch_file_exists
-    ):
-        patch_file_exists.return_value = True
-        self.harness.update_config(key_values={"domain": "whatever.com"})
         obsidian_relation = self.harness.add_relation(
             relation_name="magma-orc8r-obsidian", remote_app="magma-orc8r-obsidian"
         )
+        self.harness.add_relation(
+            relation_name="cert-certifier", remote_app="magma-orc8r-certifier"
+        )
+        self.harness.add_relation(
+            relation_name="cert-controller", remote_app="magma-orc8r-certifier"
+        )
         self.harness.add_relation_unit(
-            relation_id=obsidian_relation, remote_unit_name="orc8r-obsidian/0"
+            relation_id=bootstrapper_relation, remote_unit_name="magma-orc8r-bootstrapper/0"
+        )
+
+        self.harness.update_relation_data(
+            relation_id=bootstrapper_relation,
+            app_or_unit="magma-orc8r-bootstrapper/0",
+            key_values={"active": "True"},
+        )
+        self.harness.add_relation_unit(
+            relation_id=obsidian_relation, remote_unit_name="magma-orc8r-obsidian/0"
         )
         self.harness.update_relation_data(
             relation_id=obsidian_relation,
-            app_or_unit="orc8r-obsidian/0",
+            app_or_unit="magma-orc8r-obsidian/0",
             key_values={"active": "True"},
         )
-        self.harness.add_relation(
+
+        self.harness.container_pebble_ready(container_name="magma-orc8r-nginx")
+
+        self.assertEqual(ActiveStatus(), self.harness.charm.unit.status)
+
+    def test_given_orc8r_nginx_service_not_running_when_orc8r_nginx_relation_joined_then_service_active_status_in_the_relation_data_bag_is_false(  # noqa: E501
+        self,
+    ):
+        self.harness.set_leader(True)
+        relation_id = self.harness.add_relation("magma-orc8r-nginx", "orc8r-nginx")
+        self.harness.add_relation_unit(relation_id, "magma-orc8r-nginx/0")
+
+        self.assertEqual(
+            self.harness.get_relation_data(relation_id, "magma-orc8r-nginx/0"),
+            {"active": "False"},
+        )
+
+    @patch("ops.model.Container.exists")
+    @patch("ops.model.Container.push", Mock())
+    def test_given_metricsd_service_running_when_metricsd_relation_joined_then_service_active_status_in_the_relation_data_bag_is_true(  # noqa: E501
+        self, patch_file_exists
+    ):
+        self.harness.set_leader(True)
+        patch_file_exists.return_value = True
+        self.harness.update_config(key_values={"domain": "whatever.com"})
+        bootstrapper_relation = self.harness.add_relation(
             relation_name="magma-orc8r-bootstrapper", remote_app="magma-orc8r-bootstrapper"
+        )
+        obsidian_relation = self.harness.add_relation(
+            relation_name="magma-orc8r-obsidian", remote_app="magma-orc8r-obsidian"
         )
         self.harness.add_relation(
             relation_name="cert-certifier", remote_app="magma-orc8r-certifier"
@@ -355,12 +450,32 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="cert-controller", remote_app="magma-orc8r-certifier"
         )
+        self.harness.add_relation_unit(
+            relation_id=bootstrapper_relation, remote_unit_name="magma-orc8r-bootstrapper/0"
+        )
+
+        self.harness.update_relation_data(
+            relation_id=bootstrapper_relation,
+            app_or_unit="magma-orc8r-bootstrapper/0",
+            key_values={"active": "True"},
+        )
+        self.harness.add_relation_unit(
+            relation_id=obsidian_relation, remote_unit_name="magma-orc8r-obsidian/0"
+        )
+        self.harness.update_relation_data(
+            relation_id=obsidian_relation,
+            app_or_unit="magma-orc8r-obsidian/0",
+            key_values={"active": "True"},
+        )
 
         self.harness.container_pebble_ready(container_name="magma-orc8r-nginx")
 
+        relation_id = self.harness.add_relation("magma-orc8r-nginx", "orc8r-nginx")
+        self.harness.add_relation_unit(relation_id, "magma-orc8r-nginx/0")
+
         self.assertEqual(
-            WaitingStatus("Waiting for 'magma-orc8r-bootstrapper' relation to be ready"),
-            self.harness.charm.unit.status,
+            self.harness.get_relation_data(relation_id, "magma-orc8r-nginx/0"),
+            {"active": "True"},
         )
 
 


### PR DESCRIPTION
# Description

Adds provided relation to `magma-orc8r-nginx`.
This PR is part of [TELCO-184](https://warthogs.atlassian.net/jira/software/c/projects/TELCO/boards/51?selectedIssue=TELCO-184). `magma-orc8r-nginx` needs to provide a relation which then can be consumed by the `magma-orc8r-certifier` which will be responsible for exposing the Orc8r services information to the outside world (in Magma use case that would be AGW).

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
