### PR TITLE
Adding logs gathering after failed upload

### DIFF
--- a/.github/workflows/upload-charm.yml
+++ b/.github/workflows/upload-charm.yml
@@ -42,3 +42,10 @@ jobs:
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: ./orchestrator-bundle/${{ inputs.charm }}-operator
           tag-prefix: magma-${{ inputs.charm }}
+
+      - name: Archive charmcraft logs
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: charmcraft-upload-logs
+          path: /home/runner/snap/charmcraft/common/cache/charmcraft/log/*.log

--- a/orchestrator-bundle/orc8r-certifier-operator/actions.yaml
+++ b/orchestrator-bundle/orc8r-certifier-operator/actions.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 get-pfx-package-password:


### PR DESCRIPTION
# Description

Gathers charmcraft logs if charmhub upload fails.

Change in `magma-orc8r-certifier` was done to trigger charm publishing.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
