### PR TITLE
Adding upload-libs workflow

### DIFF
--- a/.github/workflows/orchestrator.certifier.yml
+++ b/.github/workflows/orchestrator.certifier.yml
@@ -32,3 +32,14 @@ jobs:
     secrets: inherit
     with:
       charm: orc8r-certifier
+
+  orc8r-certifier-libs-charmhub-upload:
+    if: github.ref_name == 'main'
+    uses: ./.github/workflows/upload-libs.yml
+    secrets: inherit
+    with:
+      charm: orc8r-certifier
+      libs: "charms.magma_orc8r_certifier.v0.cert_admin_operator
+      charms.magma_orc8r_certifier.v0.cert_certifier 
+      charms.magma_orc8r_certifier.v0.cert_controller 
+      charms.magma_orc8r_certifier.v0.cert_root_ca"

--- a/.github/workflows/orchestrator.libs.yml
+++ b/.github/workflows/orchestrator.libs.yml
@@ -23,35 +23,8 @@ jobs:
 
   orc8r-libs-charmhub-upload:
     if: github.ref_name == 'main'
-    runs-on: ubuntu-20.04
-    name: Charmhub upload orc8r-libs
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Wait for integration tests to succeed
-        uses: lewagon/wait-on-check-action@v1.1.2
-        with:
-          ref: main
-          check-name: "Integration tests"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 20
-
-      - uses: canonical/charmhub-upload-action@0.2.1
-        with:
-          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          charm-path: ./orchestrator-bundle/orc8r-libs
-          upload-image: "false"
-
-      - name: Publish libs
-        env:
-          CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"
-        run: |
-          set -eux
-          orc8r_libs="
-          charms.magma_orc8r_libs.v0.orc8r_base 
-          charms.magma_orc8r_libs.v0.orc8r_base_db
-          "
-          for lib in ${orc8r_libs}; do
-            echo "Publishing ${lib}"
-            (cd ./orchestrator-bundle/orc8r-libs && charmcraft publish-lib ${lib})
-          done
+    uses: ./.github/workflows/upload-libs.yml
+    secrets: inherit
+    with:
+      charm: orc8r-libs
+      libs: "charms.magma_orc8r_libs.v0.orc8r_base charms.magma_orc8r_libs.v0.orc8r_base_db"

--- a/.github/workflows/upload-charm.yml
+++ b/.github/workflows/upload-charm.yml
@@ -48,4 +48,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: charmcraft-upload-logs
-          path: /home/runner/snap/charmcraft/common/cache/charmcraft/log/*.log
+          path: /root/snap/charmcraft/common/cache/charmcraft/log/*.log

--- a/.github/workflows/upload-libs.yml
+++ b/.github/workflows/upload-libs.yml
@@ -1,0 +1,42 @@
+name: Upload Libraries
+
+on:
+  workflow_call:
+    inputs:
+      charm:
+        required: true
+        type: string
+      libs:
+        required: true
+        type: string
+
+jobs:
+  libs-charmhub-upload:
+    runs-on: ubuntu-20.04
+    name: Upload ${{ inputs.charm }} libs to charmhub
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Wait for integration tests to succeed
+        uses: lewagon/wait-on-check-action@v1.1.2
+        with:
+          ref: main
+          check-name: "Integration tests"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 20
+
+      - uses: canonical/charmhub-upload-action@0.2.1
+        with:
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          charm-path: ./orchestrator-bundle/${{ inputs.charm }}
+          upload-image: "false"
+
+      - name: Publish libs
+        env:
+          CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"
+        run: |
+          set -eux
+          for lib in ${{ inputs.libs }}; do
+            echo "Publishing ${lib}"
+            (cd ./orchestrator-bundle/${{ inputs.charm }} && charmcraft publish-lib ${lib})
+          done

--- a/orchestrator-bundle/orc8r-certifier-operator/metadata.yaml
+++ b/orchestrator-bundle/orc8r-certifier-operator/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: magma-orc8r-certifier


### PR DESCRIPTION
# Description

Adds `upload-libs` shared workflow.
Implements new workflow in orc8r-libs and magma-orc8r-certifier.
Updates charmhub upload logs path.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
