### PR TITLE
Fixing charm path in publish libs action

### DIFF
--- a/.github/workflows/orchestrator.certifier.yml
+++ b/.github/workflows/orchestrator.certifier.yml
@@ -38,7 +38,7 @@ jobs:
     uses: ./.github/workflows/upload-libs.yml
     secrets: inherit
     with:
-      charm: orc8r-certifier
+      charm: orc8r-certifier-operator
       libs: "charms.magma_orc8r_certifier.v0.cert_admin_operator
       charms.magma_orc8r_certifier.v0.cert_certifier 
       charms.magma_orc8r_certifier.v0.cert_controller 


### PR DESCRIPTION
# Description

Fixes charm path in certifier's publish libs action

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
