### PR TITLE
Fixes the ops version to 1.5.2 to avoid static analysis errors.

### DIFF
--- a/orchestrator-bundle/nms-magmalte-operator/requirements.txt
+++ b/orchestrator-bundle/nms-magmalte-operator/requirements.txt
@@ -1,4 +1,4 @@
-ops
+ops==1.5.2
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/nms-nginx-proxy-operator/requirements.txt
+++ b/orchestrator-bundle/nms-nginx-proxy-operator/requirements.txt
@@ -1,4 +1,4 @@
-ops
+ops==1.5.2
 lightkube
 lightkube-models
 jinja2

--- a/orchestrator-bundle/orc8r-analytics-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-analytics-operator/requirements.txt
@@ -1,3 +1,3 @@
-ops
+ops==1.5.2
 lightkube
 lightkube-models

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/requirements.txt
@@ -1,4 +1,4 @@
-ops
+ops==1.5.2
 lightkube
 lightkube-models
 cryptography

--- a/orchestrator-bundle/orc8r-certifier-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-certifier-operator/requirements.txt
@@ -1,4 +1,4 @@
-ops
+ops==1.5.2
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/orc8r-eventd-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-eventd-operator/requirements.txt
@@ -1,3 +1,3 @@
-ops
+ops==1.5.2
 lightkube
 lightkube-models

--- a/orchestrator-bundle/orc8r-feg-relay-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-feg-relay-operator/requirements.txt
@@ -1,3 +1,3 @@
-ops
+ops==1.5.2
 lightkube >= 0.8.1
 lightkube-models >= 1.22.0.4

--- a/orchestrator-bundle/orc8r-libs/requirements.txt
+++ b/orchestrator-bundle/orc8r-libs/requirements.txt
@@ -1,4 +1,4 @@
-ops
+ops==1.5.2
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/orc8r-lte-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-lte-operator/requirements.txt
@@ -1,4 +1,4 @@
-ops
+ops==1.5.2
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orchestrator-bundle/orc8r-metricsd-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-metricsd-operator/requirements.txt
@@ -1,3 +1,3 @@
-ops
+ops==1.5.2
 lightkube
 lightkube-models

--- a/orchestrator-bundle/orc8r-nginx-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-nginx-operator/requirements.txt
@@ -1,3 +1,3 @@
-ops
+ops==1.5.2
 lightkube
 lightkube-models

--- a/orchestrator-bundle/orc8r-orchestrator-operator/requirements.txt
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/requirements.txt
@@ -1,3 +1,3 @@
-ops
+ops==1.5.2
 lightkube
 lightkube-models


### PR DESCRIPTION
# Description

Fixes the ops version to 1.5.2 to avoid static analysis errors.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
