### PR TITLE
Fixing missing charmcraft command in libs upload workflow

### DIFF
--- a/.github/workflows/upload-libs.yml
+++ b/.github/workflows/upload-libs.yml
@@ -25,6 +25,13 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 20
 
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@2.0.0-rc
+        with:
+          credentials: ${{ secrets.CHARMCRAFT_AUTH }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          charm-path: ./orchestrator-bundle/${{ inputs.charm }}
+
       - name: Publish libs
         env:
           CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"

--- a/orchestrator-bundle/orc8r-certifier-operator/README.md
+++ b/orchestrator-bundle/orc8r-certifier-operator/README.md
@@ -48,6 +48,7 @@ The pfx package can now be loaded in your browser.
 - **cert-bootstrapper**: Relation that provides the bootstrapper private key.
 - **cert-controller**: Relation that provides the controller certificates.
 - **cert-certifier**: Relation that provides the certifier certificates.
+- **cert-root-ca**: Relation that provides the rootCA certificates.
 
 ### Requires
 


### PR DESCRIPTION
# Description

Adds a step adding `charmcraft` command to publish-libs workflow

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
