### PR TITLE
Bug fix: Specifies charm name without assuming it ends with "-operator"

### DIFF
--- a/.github/workflows/orchestrator.accessd.yml
+++ b/.github/workflows/orchestrator.accessd.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-accessd
+      charm: orc8r-accessd-operator

--- a/.github/workflows/orchestrator.analytics.yml
+++ b/.github/workflows/orchestrator.analytics.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-analytics
+      charm: orc8r-analytics-operator

--- a/.github/workflows/orchestrator.baseacct.yml
+++ b/.github/workflows/orchestrator.baseacct.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-base-acct
+      charm: orc8r-base-acct-operator

--- a/.github/workflows/orchestrator.bootstrapper.yml
+++ b/.github/workflows/orchestrator.bootstrapper.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-bootstrapper
+      charm: orc8r-bootstrapper-operator

--- a/.github/workflows/orchestrator.certifier.yml
+++ b/.github/workflows/orchestrator.certifier.yml
@@ -31,7 +31,7 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-certifier
+      charm: orc8r-certifier-operator
 
   orc8r-certifier-libs-charmhub-upload:
     if: github.ref_name == 'main'

--- a/.github/workflows/orchestrator.configurator.yml
+++ b/.github/workflows/orchestrator.configurator.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-configurator
+      charm: orc8r-configurator-operator

--- a/.github/workflows/orchestrator.ctraced.yml
+++ b/.github/workflows/orchestrator.ctraced.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-ctraced
+      charm: orc8r-ctraced-operator

--- a/.github/workflows/orchestrator.device.yml
+++ b/.github/workflows/orchestrator.device.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-device
+      charm: orc8r-device-operator

--- a/.github/workflows/orchestrator.directoryd.yml
+++ b/.github/workflows/orchestrator.directoryd.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-directoryd
+      charm: orc8r-directoryd-operator

--- a/.github/workflows/orchestrator.dispatcher.yml
+++ b/.github/workflows/orchestrator.dispatcher.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-dispatcher
+      charm: orc8r-dispatcher-operator

--- a/.github/workflows/orchestrator.eventd.yml
+++ b/.github/workflows/orchestrator.eventd.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-eventd
+      charm: orc8r-eventd-operator

--- a/.github/workflows/orchestrator.feg.yml
+++ b/.github/workflows/orchestrator.feg.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-feg
+      charm: orc8r-feg-operator

--- a/.github/workflows/orchestrator.fegrelay.yml
+++ b/.github/workflows/orchestrator.fegrelay.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-feg-relay
+      charm: orc8r-feg-relay-operator

--- a/.github/workflows/orchestrator.ha.yml
+++ b/.github/workflows/orchestrator.ha.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-ha
+      charm: orc8r-ha-operator

--- a/.github/workflows/orchestrator.health.yml
+++ b/.github/workflows/orchestrator.health.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-health
+      charm: orc8r-health-operator

--- a/.github/workflows/orchestrator.lte.yml
+++ b/.github/workflows/orchestrator.lte.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-lte
+      charm: orc8r-lte-operator

--- a/.github/workflows/orchestrator.metricsd.yml
+++ b/.github/workflows/orchestrator.metricsd.yml
@@ -100,4 +100,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-metricsd
+      charm: orc8r-metricsd-operator

--- a/.github/workflows/orchestrator.nginx.yml
+++ b/.github/workflows/orchestrator.nginx.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-nginx
+      charm: orc8r-nginx-operator

--- a/.github/workflows/orchestrator.nms.magmalte.yml
+++ b/.github/workflows/orchestrator.nms.magmalte.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: nms-magmalte
+      charm: nms-magmalte-operator

--- a/.github/workflows/orchestrator.nms.nginx.proxy.yml
+++ b/.github/workflows/orchestrator.nms.nginx.proxy.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: nms-nginx-proxy
+      charm: nms-nginx-proxy-operator

--- a/.github/workflows/orchestrator.obsidian.yml
+++ b/.github/workflows/orchestrator.obsidian.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-obsidian
+      charm: orc8r-obsidian-operator

--- a/.github/workflows/orchestrator.orchestrator.yml
+++ b/.github/workflows/orchestrator.orchestrator.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-orchestrator
+      charm: orc8r-orchestrator-operator

--- a/.github/workflows/orchestrator.policydb.yml
+++ b/.github/workflows/orchestrator.policydb.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-policydb
+      charm: orc8r-policydb-operator

--- a/.github/workflows/orchestrator.service.registry.yml
+++ b/.github/workflows/orchestrator.service.registry.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-service-registry
+      charm: orc8r-service-registry-operator

--- a/.github/workflows/orchestrator.smsd.yml
+++ b/.github/workflows/orchestrator.smsd.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-smsd
+      charm: orc8r-smsd-operator

--- a/.github/workflows/orchestrator.state.yml
+++ b/.github/workflows/orchestrator.state.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-state
+      charm: orc8r-state-operator

--- a/.github/workflows/orchestrator.streamer.yml
+++ b/.github/workflows/orchestrator.streamer.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-streamer
+      charm: orc8r-streamer-operator

--- a/.github/workflows/orchestrator.subscriberdb.cache.yml
+++ b/.github/workflows/orchestrator.subscriberdb.cache.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-subscriberdb-cache
+      charm: orc8r-subscriberdb-cache-operator

--- a/.github/workflows/orchestrator.subscriberdb.yml
+++ b/.github/workflows/orchestrator.subscriberdb.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-subscriberdb
+      charm: orc8r-subscriberdb-operator

--- a/.github/workflows/orchestrator.tenants.yml
+++ b/.github/workflows/orchestrator.tenants.yml
@@ -31,4 +31,4 @@ jobs:
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
     with:
-      charm: orc8r-tenants
+      charm: orc8r-tenants-operator

--- a/.github/workflows/upload-charm.yml
+++ b/.github/workflows/upload-charm.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   charmhub-upload:
     runs-on: ubuntu-20.04
-    name: Charmhub upload ${{ inputs.charm }}-operator
+    name: Charmhub upload ${{ inputs.charm }}
     steps:
       - uses: actions/checkout@v2
 
@@ -27,7 +27,7 @@ jobs:
         with:
           credentials: ${{ secrets.CHARMCRAFT_AUTH }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          charm-path: ./orchestrator-bundle/${{ inputs.charm }}-operator
+          charm-path: ./orchestrator-bundle/${{ inputs.charm }}
 
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.0.0-rc
@@ -41,7 +41,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           upload-image: "false"
           channel: "${{ steps.channel.outputs.name }}"
-          charm-path: ./orchestrator-bundle/${{ inputs.charm }}-operator
+          charm-path: ./orchestrator-bundle/${{ inputs.charm }}
           tag-prefix: magma-${{ inputs.charm }}
 
       - name: Chmod charmcraft logs


### PR DESCRIPTION
# Description

Specifies charm name without assuming it ends with "-operator". This fixes an issue where the orc8r-libs charm wouldn't be uploaded to charmhub because it didn't end with `operator`. An example of this issue can be seen [here](https://github.com/canonical/charmed-magma/actions/runs/3283021943/jobs/5407206500).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
