### PR TITLE
Uses the stable release of juju in tox

### DIFF
--- a/orchestrator-bundle/nms-magmalte-operator/tox.ini
+++ b/orchestrator-bundle/nms-magmalte-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/nms-nginx-proxy-operator/tox.ini
+++ b/orchestrator-bundle/nms-nginx-proxy-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-accessd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-accessd-operator/tox.ini
@@ -78,7 +78,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     pytest-operator
     git+https://github.com/charmed-kubernetes/pytest-operator.git

--- a/orchestrator-bundle/orc8r-analytics-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-analytics-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-base-acct-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-base-acct-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-bootstrapper-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-bootstrapper-operator/tox.ini
@@ -78,7 +78,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-bundle/tox.ini
+++ b/orchestrator-bundle/orc8r-bundle/tox.ini
@@ -80,7 +80,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
 commands =

--- a/orchestrator-bundle/orc8r-certifier-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-certifier-operator/tox.ini
@@ -82,7 +82,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-configurator-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-configurator-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-ctraced-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-ctraced-operator/tox.ini
@@ -78,7 +78,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-device-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-device-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-directoryd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-directoryd-operator/tox.ini
@@ -78,7 +78,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-dispatcher-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-dispatcher-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-eventd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-eventd-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-feg-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-feg-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-feg-relay-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-feg-relay-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-ha-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-ha-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-health-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-health-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-lte-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-lte-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-metricsd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-metricsd-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-nginx-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-nginx-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-obsidian-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-obsidian-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-orchestrator-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-orchestrator-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-policydb-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-policydb-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-service-registry-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-service-registry-operator/tox.ini
@@ -78,7 +78,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-smsd-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-smsd-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-state-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-state-operator/tox.ini
@@ -78,7 +78,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-streamer-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-streamer-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-tenants-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-tenants-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
# Description

Use the latest stable version of juju instead of depending on development versions.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
