### PR TITLE
Fixes orc8r-certifier integration tests

### DIFF
--- a/orchestrator-bundle/nms-magmalte-operator/tox.ini
+++ b/orchestrator-bundle/nms-magmalte-operator/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt

--- a/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
@@ -72,7 +72,7 @@ class TestOrc8rCertifier:
         )
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
 
-    async def test_redeploy_db(self, ops_test, setup, build_and_deploy_charm):
+    async def test_redeploy_db(self, ops_test, setup, build_and_deploy):
         await ops_test.model.deploy("postgresql-k8s", application_name=DB_APPLICATION_NAME)
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"

--- a/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
@@ -66,16 +66,25 @@ class TestOrc8rCertifier:
         )
         await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
 
+    async def test_remove_db_application(self, ops_test, setup, build_and_deploy):
+        await ops_test.model.remove_application(
+            DB_APPLICATION_NAME, block_until_done=True, force=True
+        )
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
+
+    async def test_redeploy_db(self, ops_test, setup, build_and_deploy_charm):
+        await ops_test.model.deploy("postgresql-k8s", application_name=DB_APPLICATION_NAME)
+        await ops_test.model.add_relation(
+            relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
+        )
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+
     async def test_build_and_deploy_and_scale_up(self, ops_test, setup, build_and_deploy):
         await ops_test.model.applications[APPLICATION_NAME].scale(2)
 
         await ops_test.model.wait_for_idle(
             apps=[APPLICATION_NAME], status="active", timeout=1000, wait_for_exact_units=2
         )
-
-    async def test_remove_db_application(self, ops_test, setup, build_and_deploy):
-        await ops_test.model.applications[DB_APPLICATION_NAME].remove(force=True)
-        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
 
     @pytest.mark.xfail(reason="Bug in Juju: https://bugs.launchpad.net/juju/+bug/1977582")
     async def test_build_and_deploy_and_scale_down(self, ops_test, setup, build_and_deploy):

--- a/orchestrator-bundle/orc8r-certifier-operator/tox.ini
+++ b/orchestrator-bundle/orc8r-certifier-operator/tox.ini
@@ -82,7 +82,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
# Description

A test case was missing from orc8r-certifier.
Fixes tox to use stable version of juju.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
