### PR TITLE
Removes waiting for db to be in active idle

### DIFF
--- a/orchestrator-bundle/orc8r-accessd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-accessd-operator/tests/integration/test_integration.py
@@ -20,7 +20,6 @@ class TestOrc8rAccessd:
     @pytest.mark.abort_on_fail
     async def setup(self, ops_test):
         await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
-        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
 
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail

--- a/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-certifier-operator/tests/integration/test_integration.py
@@ -22,7 +22,6 @@ class TestOrc8rCertifier:
     @pytest.mark.abort_on_fail
     async def setup(self, ops_test):
         await ops_test.model.deploy("postgresql-k8s", application_name=DB_APPLICATION_NAME)
-        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
         await self._deploy_tls_certificates_operator(ops_test)
 
     @staticmethod

--- a/orchestrator-bundle/orc8r-configurator-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-configurator-operator/tests/integration/test_integration.py
@@ -20,7 +20,6 @@ class TestOrc8rConfigurator:
     @pytest.mark.abort_on_fail
     async def setup(self, ops_test):
         await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
-        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
 
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail

--- a/orchestrator-bundle/orc8r-ctraced-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-ctraced-operator/tests/integration/test_integration.py
@@ -20,7 +20,6 @@ class TestOrc8rCtraced:
     @pytest.mark.abort_on_fail
     async def setup(self, ops_test):
         await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
-        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
 
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail

--- a/orchestrator-bundle/orc8r-device-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-device-operator/tests/integration/test_integration.py
@@ -20,7 +20,6 @@ class TestOrc8rDevice:
     @pytest.mark.abort_on_fail
     async def setup(self, ops_test):
         await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
-        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
 
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail

--- a/orchestrator-bundle/orc8r-directoryd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-directoryd-operator/tests/integration/test_integration.py
@@ -20,7 +20,6 @@ class TestOrc8rDirectoryd:
     @pytest.mark.abort_on_fail
     async def setup(self, ops_test):
         await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
-        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
 
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail

--- a/orchestrator-bundle/orc8r-lte-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-lte-operator/tests/integration/test_integration.py
@@ -20,7 +20,6 @@ class TestOrc8rLte:
     @pytest.mark.abort_on_fail
     async def setup(self, ops_test):
         await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
-        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
 
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail

--- a/orchestrator-bundle/orc8r-policydb-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-policydb-operator/tests/integration/test_integration.py
@@ -20,7 +20,6 @@ class TestOrc8rPolicyDB:
     @pytest.mark.abort_on_fail
     async def setup(self, ops_test):
         await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
-        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
 
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail

--- a/orchestrator-bundle/orc8r-smsd-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-smsd-operator/tests/integration/test_integration.py
@@ -20,7 +20,6 @@ class TestOrc8rSmsd:
     @pytest.mark.abort_on_fail
     async def setup(self, ops_test):
         await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
-        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
 
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail

--- a/orchestrator-bundle/orc8r-state-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-state-operator/tests/integration/test_integration.py
@@ -20,7 +20,6 @@ class TestOrc8rState:
     @pytest.mark.abort_on_fail
     async def setup(self, ops_test):
         await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
-        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
 
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail

--- a/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-subscriberdb-cache-operator/tests/integration/test_integration.py
@@ -20,7 +20,6 @@ class TestOrc8rSubscriberDBCache:
     @pytest.mark.abort_on_fail
     async def setup(self, ops_test):
         await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
-        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
 
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail

--- a/orchestrator-bundle/orc8r-subscriberdb-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-subscriberdb-operator/tests/integration/test_integration.py
@@ -20,7 +20,6 @@ class TestOrc8rSubscriberDB:
     @pytest.mark.abort_on_fail
     async def setup(self, ops_test):
         await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
-        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
 
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail

--- a/orchestrator-bundle/orc8r-tenants-operator/tests/integration/test_integration.py
+++ b/orchestrator-bundle/orc8r-tenants-operator/tests/integration/test_integration.py
@@ -20,7 +20,6 @@ class TestOrc8rTenants:
     @pytest.mark.abort_on_fail
     async def setup(self, ops_test):
         await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
-        await ops_test.model.wait_for_idle(apps=["postgresql-k8s"], status="active", timeout=1000)
 
     @pytest.fixture(scope="module")
     @pytest.mark.abort_on_fail


### PR DESCRIPTION
# Description

In reality when we deploy magma-orc8r bundle we don't wait for the db to be in active idle, this change removes the await statements from the integration tests that wait for the db to be active.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
