### PR TITLE
Unfixes ops version in certifier and certifier libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 *.idea
 .vscode/
+
+# Python
+**/venv/**
+*.pyc
+
+# Charmcraft
+*.charm

--- a/nms-magmalte-operator/lib/charms/magma_orc8r_certifier/v0/cert_admin_operator.py
+++ b/nms-magmalte-operator/lib/charms/magma_orc8r_certifier/v0/cert_admin_operator.py
@@ -47,7 +47,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 class CertificateRequestEvent(EventBase):
@@ -180,7 +180,7 @@ class CertAdminOperatorRequires(Object):
             None
         """
         relation_data = event.relation.data
-        certificate = relation_data[event.unit].get("certificate")
-        private_key = relation_data[event.unit].get("private_key")
+        certificate = relation_data[event.unit].get("certificate")  # type: ignore[index]
+        private_key = relation_data[event.unit].get("private_key")  # type: ignore[index]
         if certificate and private_key:
             self.on.certificate_available.emit(certificate=certificate, private_key=private_key)

--- a/nms-nginx-proxy-operator/lib/charms/magma_orc8r_certifier/v0/cert_controller.py
+++ b/nms-nginx-proxy-operator/lib/charms/magma_orc8r_certifier/v0/cert_controller.py
@@ -48,7 +48,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 class CertificateRequestEvent(EventBase):
@@ -181,7 +181,7 @@ class CertControllerRequires(Object):
             None
         """
         relation_data = event.relation.data
-        certificate = relation_data[event.unit].get("certificate")
-        private_key = relation_data[event.unit].get("private_key")
+        certificate = relation_data[event.unit].get("certificate")  # type: ignore[index]
+        private_key = relation_data[event.unit].get("private_key")  # type: ignore[index]
         if certificate and private_key:
             self.on.certificate_available.emit(certificate=certificate, private_key=private_key)

--- a/orc8r-bundle/tests/integration/test_integration.py
+++ b/orc8r-bundle/tests/integration/test_integration.py
@@ -68,7 +68,7 @@ async def run_get_load_balancer_services_action(ops_test: OpsTest) -> Tuple[str,
         action_name="get-load-balancer-services"
     )
     load_balancer_action_output = await ops_test.model.get_action_output(  # type: ignore[union-attr]  # noqa: E501
-        action_uuid=load_balancer_action.entity_id, wait=60
+        action_uuid=load_balancer_action.entity_id, wait=240
     )
     return (
         load_balancer_action_output["orc8r-bootstrap-nginx"],
@@ -92,7 +92,7 @@ async def run_get_pfx_password_action(ops_test: OpsTest) -> str:
         action_name="get-pfx-package-password"
     )
     pfx_password_action_output = await ops_test.model.get_action_output(  # type: ignore[union-attr]  # noqa: E501
-        action_uuid=pfx_password_action.entity_id, wait=60
+        action_uuid=pfx_password_action.entity_id, wait=240
     )
     return pfx_password_action_output["password"]
 

--- a/orc8r-certifier-operator/lib/charms/magma_orc8r_certifier/v0/cert_admin_operator.py
+++ b/orc8r-certifier-operator/lib/charms/magma_orc8r_certifier/v0/cert_admin_operator.py
@@ -180,7 +180,7 @@ class CertAdminOperatorRequires(Object):
             None
         """
         relation_data = event.relation.data
-        certificate = relation_data[event.unit].get("certificate")
-        private_key = relation_data[event.unit].get("private_key")
+        certificate = relation_data[event.unit].get("certificate")  # type: ignore[index]
+        private_key = relation_data[event.unit].get("private_key")  # type: ignore[index]
         if certificate and private_key:
             self.on.certificate_available.emit(certificate=certificate, private_key=private_key)

--- a/orc8r-certifier-operator/lib/charms/magma_orc8r_certifier/v0/cert_admin_operator.py
+++ b/orc8r-certifier-operator/lib/charms/magma_orc8r_certifier/v0/cert_admin_operator.py
@@ -47,7 +47,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 class CertificateRequestEvent(EventBase):

--- a/orc8r-certifier-operator/lib/charms/magma_orc8r_certifier/v0/cert_certifier.py
+++ b/orc8r-certifier-operator/lib/charms/magma_orc8r_certifier/v0/cert_certifier.py
@@ -177,6 +177,6 @@ class CertCertifierRequires(Object):
             None
         """
         relation_data = event.relation.data
-        certificate = relation_data[event.unit].get("certificate")
+        certificate = relation_data[event.unit].get("certificate")  # type: ignore[index]
         if certificate:
             self.on.certificate_available.emit(certificate=certificate)

--- a/orc8r-certifier-operator/lib/charms/magma_orc8r_certifier/v0/cert_certifier.py
+++ b/orc8r-certifier-operator/lib/charms/magma_orc8r_certifier/v0/cert_certifier.py
@@ -48,7 +48,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 
 class CertificateRequestEvent(EventBase):

--- a/orc8r-certifier-operator/lib/charms/magma_orc8r_certifier/v0/cert_controller.py
+++ b/orc8r-certifier-operator/lib/charms/magma_orc8r_certifier/v0/cert_controller.py
@@ -48,7 +48,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 class CertificateRequestEvent(EventBase):

--- a/orc8r-certifier-operator/lib/charms/magma_orc8r_certifier/v0/cert_controller.py
+++ b/orc8r-certifier-operator/lib/charms/magma_orc8r_certifier/v0/cert_controller.py
@@ -181,7 +181,7 @@ class CertControllerRequires(Object):
             None
         """
         relation_data = event.relation.data
-        certificate = relation_data[event.unit].get("certificate")
-        private_key = relation_data[event.unit].get("private_key")
+        certificate = relation_data[event.unit].get("certificate")  # type: ignore[index]
+        private_key = relation_data[event.unit].get("private_key")  # type: ignore[index]
         if certificate and private_key:
             self.on.certificate_available.emit(certificate=certificate, private_key=private_key)

--- a/orc8r-certifier-operator/lib/charms/magma_orc8r_certifier/v0/cert_root_ca.py
+++ b/orc8r-certifier-operator/lib/charms/magma_orc8r_certifier/v0/cert_root_ca.py
@@ -216,6 +216,6 @@ class CertRootCARequires(Object):
             None
         """
         relation_data = event.relation.data
-        certificate = relation_data[event.unit].get("certificate")
+        certificate = relation_data[event.unit].get("certificate")  # type: ignore[index]
         if certificate:
             self.on.certificate_available.emit(certificate=certificate)

--- a/orc8r-certifier-operator/lib/charms/magma_orc8r_certifier/v0/cert_root_ca.py
+++ b/orc8r-certifier-operator/lib/charms/magma_orc8r_certifier/v0/cert_root_ca.py
@@ -87,7 +87,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 class CertificateRequestEvent(EventBase):

--- a/orc8r-certifier-operator/requirements.txt
+++ b/orc8r-certifier-operator/requirements.txt
@@ -1,4 +1,4 @@
-ops==1.5.2
+ops
 ops-lib-pgsql
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube

--- a/orc8r-certifier-operator/src/charm.py
+++ b/orc8r-certifier-operator/src/charm.py
@@ -549,7 +549,7 @@ class MagmaOrc8rCertifierCharm(CharmBase):
             return
         event.set_results(
             {
-                "password": self._admin_operator_pfx_password,
+                "password": self._admin_operator_pfx_password,  # type: ignore[dict-item]
             }
         )
 

--- a/orc8r-nginx-operator/lib/charms/magma_orc8r_certifier/v0/cert_certifier.py
+++ b/orc8r-nginx-operator/lib/charms/magma_orc8r_certifier/v0/cert_certifier.py
@@ -48,7 +48,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 
 class CertificateRequestEvent(EventBase):
@@ -177,6 +177,6 @@ class CertCertifierRequires(Object):
             None
         """
         relation_data = event.relation.data
-        certificate = relation_data[event.unit].get("certificate")
+        certificate = relation_data[event.unit].get("certificate")  # type: ignore[index]
         if certificate:
             self.on.certificate_available.emit(certificate=certificate)

--- a/orc8r-nginx-operator/lib/charms/magma_orc8r_certifier/v0/cert_controller.py
+++ b/orc8r-nginx-operator/lib/charms/magma_orc8r_certifier/v0/cert_controller.py
@@ -48,7 +48,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 class CertificateRequestEvent(EventBase):
@@ -181,7 +181,7 @@ class CertControllerRequires(Object):
             None
         """
         relation_data = event.relation.data
-        certificate = relation_data[event.unit].get("certificate")
-        private_key = relation_data[event.unit].get("private_key")
+        certificate = relation_data[event.unit].get("certificate")  # type: ignore[index]
+        private_key = relation_data[event.unit].get("private_key")  # type: ignore[index]
         if certificate and private_key:
             self.on.certificate_available.emit(certificate=certificate, private_key=private_key)

--- a/orc8r-nginx-operator/lib/charms/magma_orc8r_certifier/v0/cert_root_ca.py
+++ b/orc8r-nginx-operator/lib/charms/magma_orc8r_certifier/v0/cert_root_ca.py
@@ -87,7 +87,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 class CertificateRequestEvent(EventBase):
@@ -216,6 +216,6 @@ class CertRootCARequires(Object):
             None
         """
         relation_data = event.relation.data
-        certificate = relation_data[event.unit].get("certificate")
+        certificate = relation_data[event.unit].get("certificate")  # type: ignore[index]
         if certificate:
             self.on.certificate_available.emit(certificate=certificate)

--- a/orc8r-orchestrator-operator/lib/charms/magma_orc8r_certifier/v0/cert_admin_operator.py
+++ b/orc8r-orchestrator-operator/lib/charms/magma_orc8r_certifier/v0/cert_admin_operator.py
@@ -47,7 +47,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 class CertificateRequestEvent(EventBase):
@@ -180,7 +180,7 @@ class CertAdminOperatorRequires(Object):
             None
         """
         relation_data = event.relation.data
-        certificate = relation_data[event.unit].get("certificate")
-        private_key = relation_data[event.unit].get("private_key")
+        certificate = relation_data[event.unit].get("certificate")  # type: ignore[index]
+        private_key = relation_data[event.unit].get("private_key")  # type: ignore[index]
         if certificate and private_key:
             self.on.certificate_available.emit(certificate=certificate, private_key=private_key)


### PR DESCRIPTION
# Description

The `ops` package version was fixed to `1.5.2`, which now points to the latest version. This change caused some static analysis issues that have been addressed.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
