### PR TITLE
Update nginx config file on config changed

### DIFF
--- a/orc8r-nginx-operator/src/charm.py
+++ b/orc8r-nginx-operator/src/charm.py
@@ -82,7 +82,7 @@ class MagmaOrc8rNginxCharm(CharmBase):
         )
 
         self.framework.observe(self.on.install, self._on_install)
-        self.framework.observe(self.on.config_changed, self._configure_magma_orc8r_nginx)
+        self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(
             self.on.magma_orc8r_nginx_pebble_ready, self._configure_magma_orc8r_nginx
         )
@@ -129,6 +129,21 @@ class MagmaOrc8rNginxCharm(CharmBase):
             return
         self._generate_nginx_config()
         self._create_additional_orc8r_nginx_services()
+
+    def _on_config_changed(self, event: ConfigChangedEvent) -> None:
+        """Triggered when configuration is changed.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        if not self._domain_config_is_valid:
+            self.unit.status = BlockedStatus("Domain config is not valid")
+            return
+        self._generate_nginx_config()
+        self._configure_magma_orc8r_nginx(event)
 
     def _configure_magma_orc8r_nginx(
         self,

--- a/orc8r-nginx-operator/src/charm.py
+++ b/orc8r-nginx-operator/src/charm.py
@@ -127,7 +127,6 @@ class MagmaOrc8rNginxCharm(CharmBase):
             logger.info("Can't connect to container - Deferring")
             event.defer()
             return
-        self._generate_nginx_config()
         self._create_additional_orc8r_nginx_services()
 
     def _on_config_changed(self, event: ConfigChangedEvent) -> None:
@@ -141,6 +140,10 @@ class MagmaOrc8rNginxCharm(CharmBase):
         """
         if not self._domain_config_is_valid:
             self.unit.status = BlockedStatus("Domain config is not valid")
+            return
+        if not self._container.can_connect():
+            logger.info("Can't connect to container - Deferring")
+            event.defer()
             return
         self._generate_nginx_config()
         self._configure_magma_orc8r_nginx(event)

--- a/orc8r-nginx-operator/tests/unit/test_charm.py
+++ b/orc8r-nginx-operator/tests/unit/test_charm.py
@@ -29,31 +29,6 @@ class TestCharm(unittest.TestCase):
         self.harness.begin()
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock())
-    @patch("lightkube.core.client.Client.create", new=Mock())
-    @patch("ops.model.Container.exec")
-    def test_given_domain_config_set_when_install_then_nginx_config_file_is_created(
-        self, patch_exec
-    ):
-        event = Mock()
-        domain = "whatever domain"
-        key_values = {"domain": domain}
-        self.harness.update_config(key_values=key_values)
-        container = self.harness.model.unit.get_container("magma-orc8r-nginx")
-        self.harness.set_can_connect(container=container, val=True)
-
-        self.harness.charm._on_install(event)
-
-        patch_exec.assert_called_with(
-            command=["/usr/local/bin/generate_nginx_configs.py"],
-            environment={
-                "PROXY_BACKENDS": f"{self.namespace}.svc.cluster.local",
-                "CONTROLLER_HOSTNAME": f"controller.{domain}",
-                "RESOLVER": "kube-dns.kube-system.svc.cluster.local valid=10s",
-                "SERVICE_REGISTRY_MODE": "k8s",
-            },
-        )
-
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock())
     @patch("lightkube.core.client.Client.get")
     @patch("lightkube.core.client.Client.create")
     @patch("ops.model.Container.exec", new=Mock())

--- a/orc8r-nginx-operator/tests/unit/test_charm.py
+++ b/orc8r-nginx-operator/tests/unit/test_charm.py
@@ -148,6 +148,7 @@ class TestCharm(unittest.TestCase):
 
         patch_create.assert_has_calls(calls=calls)
 
+    @patch("ops.model.Container.exec", Mock())
     def test_given_no_relations_created_when_pebble_ready_event_emitted_then_status_is_blocked(
         self,
     ):
@@ -164,6 +165,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Container.exists")
+    @patch("ops.model.Container.exec", Mock())
     def test_given_cert_certifier_relation_not_created_when_pebble_ready_event_emitted_then_status_is_blocked(  # noqa: E501
         self, patch_file_exists
     ):
@@ -187,6 +189,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Container.exists")
+    @patch("ops.model.Container.exec", Mock())
     def test_given_cert_controller_relation_not_created_when_pebble_ready_event_emitted_then_status_is_blocked(  # noqa: E501
         self, patch_file_exists
     ):
@@ -210,6 +213,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Container.exists")
+    @patch("ops.model.Container.exec", Mock())
     def test_given_magma_orc8r_bootstrapper_relation_not_created_when_pebble_ready_event_emitted_then_status_is_blocked(  # noqa: E501
         self, patch_file_exists
     ):
@@ -233,6 +237,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Container.exists")
+    @patch("ops.model.Container.exec", Mock())
     def test_given_magma_orc8r_obsidian_relation_not_created_when_pebble_ready_event_emitted_then_status_is_blocked(  # noqa: E501
         self, patch_file_exists
     ):
@@ -256,6 +261,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Container.exists")
+    @patch("ops.model.Container.exec", Mock())
     def test_given_pebble_ready_when_obsidian_relation_broken_then_status_is_blocked(  # noqa: E501
         self, patch_file_exists
     ):
@@ -274,6 +280,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Container.exists")
+    @patch("ops.model.Container.exec", Mock())
     def test_given_pebble_ready_when_bootstrapper_relation_broken_then_status_is_blocked(  # noqa: E501
         self, patch_file_exists
     ):
@@ -292,6 +299,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Container.exists")
+    @patch("ops.model.Container.exec", Mock())
     def test_given_magma_orc8r_obsidian_relation_not_ready_when_pebble_ready_event_emitted_then_status_is_waiting(  # noqa: E501
         self, patch_file_exists
     ):
@@ -319,6 +327,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Container.exists")
+    @patch("ops.model.Container.exec", Mock())
     def test_given_magma_orc8r_bootstrapper_relation_not_ready_when_pebble_ready_event_emitted_then_status_is_waiting(  # noqa: E501
         self, patch_file_exists
     ):
@@ -346,6 +355,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Container.exists")
+    @patch("ops.model.Container.exec", Mock())
     def test_given_all_relations_created_and_ready_and_nginx_services_are_created_when_pebble_ready_event_emitted_then_pebble_layer_is_configured(  # noqa: E501
         self, patch_file_exists
     ):
@@ -372,6 +382,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(expected_plan, updated_plan)
 
     @patch("ops.model.Container.exists")
+    @patch("ops.model.Container.exec", Mock())
     def test_given_all_relations_created_and_ready_and_nginx_services_are_created_when_pebble_ready_event_emitted_then_status_is_active(  # noqa: E501
         self, patch_file_exists
     ):
@@ -396,6 +407,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("ops.model.Container.exists")
     @patch("ops.model.Container.push", Mock())
+    @patch("ops.model.Container.exec", Mock())
     def test_given_metricsd_service_running_when_metricsd_relation_joined_then_service_active_status_in_the_relation_data_bag_is_true(  # noqa: E501
         self, patch_file_exists
     ):
@@ -412,6 +424,27 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(
             self.harness.get_relation_data(relation_id, "magma-orc8r-nginx/0"),
             {"active": "True"},
+        )
+
+    @patch("ops.model.Container.exec")
+    def test_given_valid_domain_config_set_when_config_changed_then_nginx_config_file_is_recreated(
+        self, patch_exec
+    ):
+        container = self.harness.model.unit.get_container("magma-orc8r-nginx")
+        self.harness.set_can_connect(container=container, val=True)
+
+        domain = "whateverdomain.com"
+        key_values = {"domain": domain}
+        self.harness.update_config(key_values=key_values)
+
+        patch_exec.assert_called_with(
+            command=["/usr/local/bin/generate_nginx_configs.py"],
+            environment={
+                "PROXY_BACKENDS": f"{self.namespace}.svc.cluster.local",
+                "CONTROLLER_HOSTNAME": f"controller.{domain}",
+                "RESOLVER": "kube-dns.kube-system.svc.cluster.local valid=10s",
+                "SERVICE_REGISTRY_MODE": "k8s",
+            },
         )
 
     def _create_active_relation(self, relation_name: str, remote_app: str):

--- a/orc8r-nginx-operator/tests/unit/test_orchestator_relation.py
+++ b/orc8r-nginx-operator/tests/unit/test_orchestator_relation.py
@@ -40,6 +40,7 @@ class TestOrchestratorRelation(unittest.TestCase):
             {},
         )
 
+    @patch("ops.model.Container.exec", Mock())
     def test_given_invalid_domain_when_orchestrator_relation_joined_then_charm_goes_to_blocked_status(  # noqa: E501
         self,
     ):
@@ -50,6 +51,7 @@ class TestOrchestratorRelation(unittest.TestCase):
 
         assert self.harness.charm.unit.status == BlockedStatus("Domain config is not valid")
 
+    @patch("ops.model.Container.exec", Mock())
     def test_given_magma_orc8r_nginx_service_not_running_when_orchestrator_relation_joined_then_charm_goes_to_waiting_status(  # noqa: E501
         self,
     ):
@@ -63,6 +65,7 @@ class TestOrchestratorRelation(unittest.TestCase):
         )
 
     @patch("ops.model.Container.get_service", new=Mock())
+    @patch("ops.model.Container.exec", Mock())
     def test_given_magma_orc8r_nginx_service_active_but_rootca_not_stored_when_orchestrator_relation_joined_then_charm_goes_to_waiting_status(  # noqa: E501
         self,
     ):
@@ -79,6 +82,7 @@ class TestOrchestratorRelation(unittest.TestCase):
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
     @patch("ops.model.Container.get_service", new=Mock())
+    @patch("ops.model.Container.exec", Mock())
     def test_given_path_error_when_orchestrator_relation_joined_then_pulling_rootca_from_container_fails_and_charm_goes_to_blocked_status(  # noqa: E501
         self, patched_exists, patched_pull
     ):
@@ -97,6 +101,7 @@ class TestOrchestratorRelation(unittest.TestCase):
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
     @patch("ops.model.Container.get_service", new=Mock())
+    @patch("ops.model.Container.exec", Mock())
     def test_given_protocol_error_when_pulling_rootca_when_orchestrator_relation_joined_then_pulling_rootca_from_container_fails_and_relevant_message_is_logged(  # noqa: E501
         self, patched_exists, patched_pull
     ):
@@ -115,6 +120,7 @@ class TestOrchestratorRelation(unittest.TestCase):
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
     @patch("ops.model.Container.get_service", new=Mock())
+    @patch("ops.model.Container.exec", Mock())
     def test_given_all_checks_passed_when_orchestrator_relation_joined_then_relation_data_bag_is_updated(  # noqa: E501
         self, patched_exists, patched_pull
     ):


### PR DESCRIPTION
# Description

Previously, the nginx configuration file was only generated `on_install`. This changes recreates the file `on_config_changed` before restarting the service.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
