### PR TITLE
Telco 384 update fluentd pem when certifier pem changes

### DIFF
--- a/fluentd-elasticsearch-operator/src/charm.py
+++ b/fluentd-elasticsearch-operator/src/charm.py
@@ -38,7 +38,6 @@ logger = logging.getLogger(__name__)
 
 
 class FluentdElasticsearchCharm(CharmBase):
-
     CERTIFICATES_DIRECTORY = "/certs"
     CONFIG_SOURCE_DIRECTORY = os.path.join(
         os.path.abspath(os.path.dirname(__file__)),

--- a/nms-magmalte-operator/tests/unit/test_charm.py
+++ b/nms-magmalte-operator/tests/unit/test_charm.py
@@ -350,7 +350,6 @@ class TestCharm(unittest.TestCase):
     def test_given_workload_service_is_running_and_peer_relation_not_created_when_get_admin_credentials_action_then_get_admin_credentials_fail(  # noqa: E501
         self, action_event
     ):
-
         self.harness.remove_relation(self.peer_relation_id)
         self.harness.charm._on_get_master_admin_credentials(action_event)
 

--- a/orc8r-bundle/tests/unit/test_render_bundle.py
+++ b/orc8r-bundle/tests/unit/test_render_bundle.py
@@ -7,7 +7,6 @@ from render_bundle import render_bundle
 
 
 def test_given_channel_is_not_provided_and_local_not_set_when_render_bundle_then_valueerror_is_raised():  # noqa: E501
-
     with pytest.raises(ValueError) as e:
         render_bundle(
             template="bundle.yaml.j2",
@@ -18,7 +17,6 @@ def test_given_channel_is_not_provided_and_local_not_set_when_render_bundle_then
 
 
 def test_given_channel_is_provided_and_local_set_to_true_when_render_bundle_then_valueerror_is_raised():  # noqa: E501
-
     with pytest.raises(ValueError) as e:
         render_bundle(
             channel="edge",

--- a/orc8r-certifier-operator/src/charm.py
+++ b/orc8r-certifier-operator/src/charm.py
@@ -1363,11 +1363,11 @@ class MagmaOrc8rCertifierCharm(CharmBase):
             certificate_signing_request = yaml.safe_load(csr_relation_data)[0][
                 "certificate_signing_request"
             ]
-            return certificate_signing_request
         except KeyError:
             logger.info(f"Fluentd CSR not found for relation {relation.id}. Skipping...")
         except StopIteration:
             logger.info(f"Units not found for relation {relation.id}. Skipping...")
+        return certificate_signing_request
 
     @property
     def _namespace(self) -> str:

--- a/orc8r-certifier-operator/tests/unit/test_charm.py
+++ b/orc8r-certifier-operator/tests/unit/test_charm.py
@@ -27,7 +27,6 @@ from charm import MagmaOrc8rCertifierCharm
 
 
 class TestCharm(unittest.TestCase):
-
     TEST_DB_NAME = MagmaOrc8rCertifierCharm.DB_NAME
     TEST_DB_PORT = "1234"
     TEST_DB_CONNECTION_STRING = ConnectionString(

--- a/orc8r-certifier-operator/tests/unit/test_charm.py
+++ b/orc8r-certifier-operator/tests/unit/test_charm.py
@@ -1256,9 +1256,7 @@ class TestCharm(unittest.TestCase):
             relation_id=fluentd_relation_id,
             app_or_unit="fluentd-app/0",
             key_values={
-                "certificate_signing_requests": json.dumps(
-                    [{"certificate_signing_request": ""}]
-                )
+                "certificate_signing_requests": json.dumps([{"certificate_signing_request": ""}])
             },
         )
 

--- a/orc8r-certifier-operator/tests/unit/test_charm.py
+++ b/orc8r-certifier-operator/tests/unit/test_charm.py
@@ -1366,10 +1366,6 @@ class TestCharm(unittest.TestCase):
 
     @patch("charm.generate_certificate")
     @patch("charm.generate_pfx_package")
-    @patch(
-        "charms.tls_certificates_interface.v1.tls_certificates.TLSCertificatesRequiresV1.request_certificate_renewal",  # noqa: E501,W505
-        new=Mock(),
-    )
     @patch("charm.TLSCertificatesProvidesV1.set_relation_certificate", Mock())
     @patch("charm.pgsql.PostgreSQLClient._mirror_appdata", new=Mock())
     @patch("ops.model.Container.push", Mock())

--- a/orc8r-certifier-operator/tests/unit/test_charm.py
+++ b/orc8r-certifier-operator/tests/unit/test_charm.py
@@ -867,10 +867,10 @@ class TestCharm(unittest.TestCase):
         )
 
         certificates_relation_id = self.harness.add_relation(
-            relation_name="certificates", remote_app="whatever app"
+            relation_name="certificates", remote_app="whatever_app"
         )
         self.harness.add_relation_unit(
-            relation_id=certificates_relation_id, remote_unit_name="whatever unit name"
+            relation_id=certificates_relation_id, remote_unit_name="whatever_app/0"
         )
 
         patch_request_certificates.assert_called_with(
@@ -886,12 +886,12 @@ class TestCharm(unittest.TestCase):
     ):
         self.harness.set_leader(is_leader=True)
         certificates_relation_id = self.harness.add_relation(
-            relation_name="certificates", remote_app="whatever app"
+            relation_name="certificates", remote_app="whatever_app"
         )
         self.create_peer_relation_with_certificates(domain_config="whatever")
 
         self.harness.add_relation_unit(
-            relation_id=certificates_relation_id, remote_unit_name="whatever unit name"
+            relation_id=certificates_relation_id, remote_unit_name="whatever_app/0"
         )
 
         self.assertEqual(0, patch_request_certificates.call_count)
@@ -905,7 +905,7 @@ class TestCharm(unittest.TestCase):
     ):
         self.harness.set_leader(is_leader=False)
         certificates_relation_id = self.harness.add_relation(
-            relation_name="certificates", remote_app="whatever app"
+            relation_name="certificates", remote_app="whatever_app"
         )
         self.create_peer_relation_with_certificates(
             domain_config="whatever",
@@ -914,7 +914,7 @@ class TestCharm(unittest.TestCase):
         )
 
         self.harness.add_relation_unit(
-            relation_id=certificates_relation_id, remote_unit_name="whatever unit name"
+            relation_id=certificates_relation_id, remote_unit_name="whatever_app/0"
         )
 
         patch_request_certificates.assert_not_called()
@@ -1243,25 +1243,31 @@ class TestCharm(unittest.TestCase):
                 },
             )
 
-    def test_given_fluentd_csr_not_present_in_relation_data_when_fluentd_certificate_creation_request_then_status_is_blocked(  # noqa: E501
-        self,
+    @patch("charm.generate_certificate")
+    def test_given_fluentd_csr_not_present_in_relation_data_when_fluentd_certificate_creation_request_then_fluentd_cert_is_not_generated_and_relevant_message_is_logged(  # noqa: E501
+        self, patched_generate_certificate
     ):
         self.create_peer_relation_with_certificates(
-            domain_config="some.com", application_private_key=True
+            domain_config="some.com", application_private_key=True, application_certificate=True
         )
         fluentd_relation_id = self.harness.add_relation("fluentd-certs", "fluentd-app")
         self.harness.add_relation_unit(fluentd_relation_id, "fluentd-app/0")
 
-        self.harness.update_relation_data(
-            relation_id=fluentd_relation_id,
-            app_or_unit="fluentd-app/0",
-            key_values={
-                "certificate_signing_requests": json.dumps([{"certificate_signing_request": ""}])
-            },
-        )
+        with self.assertLogs() as captured:
+            self.harness.update_relation_data(
+                relation_id=fluentd_relation_id,
+                app_or_unit="fluentd-app/0",
+                key_values={
+                    "certificate_signing_requests": json.dumps(
+                        [{"certificate_signing_request": ""}]
+                    )
+                },
+            )
 
-        assert self.harness.charm.unit.status == BlockedStatus(
-            "Fluentd CSR not available in the relation data"
+        patched_generate_certificate.assert_not_called()
+        self.assertEqual(
+            f"Fluentd CSR not found for relation {fluentd_relation_id}. Skipping...",
+            captured.records[0].getMessage(),
         )
 
     def test_given_valid_fluentd_csr_but_application_cert_not_available_when_fluentd_certificate_creation_request_then_status_is_waiting(  # noqa: E501
@@ -1290,7 +1296,7 @@ class TestCharm(unittest.TestCase):
     @patch("charm.generate_certificate")
     @patch("charm.TLSCertificatesProvidesV1.set_relation_certificate", Mock())
     @patch("charm.pgsql.PostgreSQLClient._mirror_appdata", new=Mock())
-    def test_given_aplication_key_and_cert_available_and_valid_fluentd_csr_in_the_relation_data_when_fluentd_certificate_creation_request_then_fluentd_cert_is_generated(  # noqa: E501
+    def test_given_application_key_and_cert_available_and_valid_fluentd_csr_in_the_relation_data_when_fluentd_certificate_creation_request_then_fluentd_cert_is_generated(  # noqa: E501
         self, patched_generate_certificate
     ):
         self.harness.set_leader(is_leader=True)
@@ -1323,7 +1329,7 @@ class TestCharm(unittest.TestCase):
     @patch("charm.TLSCertificatesProvidesV1.set_relation_certificate")
     @patch("charm.generate_certificate")
     @patch("charm.pgsql.PostgreSQLClient._mirror_appdata", new=Mock())
-    def test_given_aplication_key_and_cert_available_and_valid_fluentd_csr_in_the_relation_data_when_fluentd_certificate_creation_request_then_fluentd_cert_is_set_in_the_relation(  # noqa: E501
+    def test_given_application_key_and_cert_available_and_valid_fluentd_csr_in_the_relation_data_when_fluentd_certificate_creation_request_then_fluentd_cert_is_set_in_the_relation(  # noqa: E501
         self, patched_generate_certificate, patched_set_relation_certificate
     ):
         test_fluentd_cert = b"whatever"
@@ -1357,3 +1363,62 @@ class TestCharm(unittest.TestCase):
             chain=[test_fluentd_cert.decode(), certs["application_certificate"]],
             relation_id=fluentd_relation_id,
         )
+
+    @patch("charm.generate_certificate")
+    @patch("charm.generate_pfx_package")
+    @patch(
+        "charms.tls_certificates_interface.v1.tls_certificates.TLSCertificatesRequiresV1.request_certificate_renewal",  # noqa: E501,W505
+        new=Mock(),
+    )
+    @patch("charm.TLSCertificatesProvidesV1.set_relation_certificate", Mock())
+    @patch("charm.pgsql.PostgreSQLClient._mirror_appdata", new=Mock())
+    @patch("ops.model.Container.push", Mock())
+    def test_given_application_key_and_cert_available_and_valid_fluentd_csr_in_the_relation_data_when_new_certifier_pem_then_fluentd_cert_is_generated(  # noqa: E501
+        self, patched_generate_pfx_package, patched_generate_certificate
+    ):
+        self.harness.set_leader(is_leader=True)
+        self.harness.set_can_connect(container="magma-orc8r-certifier", val=True)
+        patched_generate_certificate.return_value = b"some cert"
+        patched_generate_pfx_package.return_value = b"some pfx"
+        test_csr = "whatever"
+        _, certs = self.create_peer_relation_with_certificates(
+            domain_config="some.com",
+            root_csr=True,
+            root_private_key=True,
+            admin_operator_private_key=True,
+            application_private_key=True,
+            application_certificate=True,
+        )
+        fluentd_relation_id = self.harness.add_relation("fluentd-certs", "fluentd-app")
+        self.harness.add_relation_unit(fluentd_relation_id, "fluentd-app/0")
+        self.harness.update_relation_data(
+            relation_id=fluentd_relation_id,
+            app_or_unit="fluentd-app/0",
+            key_values={
+                "certificate_signing_requests": json.dumps(
+                    [{"certificate_signing_request": test_csr}]
+                )
+            },
+        )
+
+        self.harness.update_config(key_values={"domain": "new-domain.com"})
+
+        expected_calls = [
+            call(
+                csr=test_csr.encode(),
+                ca=certs["application_certificate"].encode(),
+                ca_key=certs["application_private_key"].encode(),
+            ),
+            call(
+                csr=test_csr.encode(),
+                ca=self.harness.model.get_relation("replicas")  # type: ignore[union-attr]
+                .data[self.harness.charm.app]["application_certificate"]
+                .encode(),
+                ca_key=certs["application_private_key"].encode(),
+            ),
+        ]
+        actual_calls = patched_generate_certificate.mock_calls
+
+        self.assertEqual(actual_calls[0], expected_calls[0])
+        # Second actual_call is made to generate new certifier.pem and is irrelevant for this test.
+        self.assertEqual(actual_calls[2], expected_calls[1])

--- a/orc8r-certifier-operator/tests/unit/test_charm.py
+++ b/orc8r-certifier-operator/tests/unit/test_charm.py
@@ -1243,7 +1243,7 @@ class TestCharm(unittest.TestCase):
             )
 
     @patch("charm.generate_certificate")
-    def test_given_fluentd_csr_not_present_in_relation_data_when_fluentd_certificate_creation_request_then_fluentd_cert_is_not_generated_and_relevant_message_is_logged(  # noqa: E501
+    def test_given_fluentd_csr_not_present_in_relation_data_when_fluentd_certificate_creation_request_then_fluentd_cert_is_not_generated(  # noqa: E501
         self, patched_generate_certificate
     ):
         self.create_peer_relation_with_certificates(
@@ -1252,22 +1252,17 @@ class TestCharm(unittest.TestCase):
         fluentd_relation_id = self.harness.add_relation("fluentd-certs", "fluentd-app")
         self.harness.add_relation_unit(fluentd_relation_id, "fluentd-app/0")
 
-        with self.assertLogs() as captured:
-            self.harness.update_relation_data(
-                relation_id=fluentd_relation_id,
-                app_or_unit="fluentd-app/0",
-                key_values={
-                    "certificate_signing_requests": json.dumps(
-                        [{"certificate_signing_request": ""}]
-                    )
-                },
-            )
+        self.harness.update_relation_data(
+            relation_id=fluentd_relation_id,
+            app_or_unit="fluentd-app/0",
+            key_values={
+                "certificate_signing_requests": json.dumps(
+                    [{"certificate_signing_request": ""}]
+                )
+            },
+        )
 
         patched_generate_certificate.assert_not_called()
-        self.assertEqual(
-            f"Fluentd CSR not found for relation {fluentd_relation_id}. Skipping...",
-            captured.records[0].getMessage(),
-        )
 
     def test_given_valid_fluentd_csr_but_application_cert_not_available_when_fluentd_certificate_creation_request_then_status_is_waiting(  # noqa: E501
         self,


### PR DESCRIPTION
# Description

Updates `fluentd.pem` whenever `certifier.pem` changes.
`certifier.pem` is a CA signing the `fluentd.pem`.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
