### PR TITLE
Uses the magma-orc8r-controller rockcraft built rock

### DIFF
--- a/orc8r-accessd-operator/metadata.yaml
+++ b/orc8r-accessd-operator/metadata.yaml
@@ -17,7 +17,7 @@ resources:
   magma-orc8r-accessd-image:
     type: oci-image
     description: OCI image for magma-orc8r-accessd
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-accessd:

--- a/orc8r-accessd-operator/metadata.yaml
+++ b/orc8r-accessd-operator/metadata.yaml
@@ -17,7 +17,7 @@ resources:
   magma-orc8r-accessd-image:
     type: oci-image
     description: OCI image for magma-orc8r-accessd
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-accessd:

--- a/orc8r-accessd-operator/src/charm.py
+++ b/orc8r-accessd-operator/src/charm.py
@@ -24,13 +24,7 @@ class MagmaOrc8rAccessdCharm(CharmBase):
             ports=[ServicePort(name="grpc", port=9180, targetPort=9091)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
-        startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/accessd "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "accessd -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-analytics-operator/metadata.yaml
+++ b/orc8r-analytics-operator/metadata.yaml
@@ -21,7 +21,7 @@ resources:
   magma-orc8r-analytics-image:
     type: oci-image
     description: OCI image for magma-orc8r-analytics
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-analytics:

--- a/orc8r-analytics-operator/metadata.yaml
+++ b/orc8r-analytics-operator/metadata.yaml
@@ -20,8 +20,8 @@ containers:
 resources:
   magma-orc8r-analytics-image:
     type: oci-image
-    description: OCI image for magma-orc8r-analytics (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    description: OCI image for magma-orc8r-analytics
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-analytics:

--- a/orc8r-analytics-operator/src/charm.py
+++ b/orc8r-analytics-operator/src/charm.py
@@ -30,13 +30,7 @@ class MagmaOrc8rAnalyticsCharm(CharmBase):
             ports=[ServicePort(name="grpc", port=9180, targetPort=9200)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
-        startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/analytics "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "analytics -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
         self.framework.observe(self.on.install, self._on_install)
 

--- a/orc8r-bootstrapper-operator/metadata.yaml
+++ b/orc8r-bootstrapper-operator/metadata.yaml
@@ -20,8 +20,8 @@ containers:
 resources:
   magma-orc8r-bootstrapper-image:
     type: oci-image
-    description: OCI image for magma-orc8r-bootstrapper (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    description: OCI image for magma-orc8r-bootstrapper
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
 
 storage:
   certs:

--- a/orc8r-bootstrapper-operator/metadata.yaml
+++ b/orc8r-bootstrapper-operator/metadata.yaml
@@ -21,7 +21,7 @@ resources:
   magma-orc8r-bootstrapper-image:
     type: oci-image
     description: OCI image for magma-orc8r-bootstrapper
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 storage:
   certs:

--- a/orc8r-bootstrapper-operator/src/charm.py
+++ b/orc8r-bootstrapper-operator/src/charm.py
@@ -56,9 +56,7 @@ class MagmaOrc8rBootstrapperCharm(CharmBase):
                     self._service_name: {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": "/usr/bin/envdir "
-                        "/var/opt/magma/envdir "
-                        "/var/opt/magma/bin/bootstrapper "
+                        "command": "bootstrapper "
                         "-cak=/var/opt/magma/certs/bootstrapper.key "
                         "-logtostderr=true "
                         "-v=0",

--- a/orc8r-bootstrapper-operator/tests/unit/test_charm.py
+++ b/orc8r-bootstrapper-operator/tests/unit/test_charm.py
@@ -106,9 +106,7 @@ class TestCharm(unittest.TestCase):
                 "magma-orc8r-bootstrapper": {
                     "override": "replace",
                     "startup": "enabled",
-                    "command": "/usr/bin/envdir "
-                    "/var/opt/magma/envdir "
-                    "/var/opt/magma/bin/bootstrapper "
+                    "command": "bootstrapper "
                     "-cak=/var/opt/magma/certs/bootstrapper.key "
                     "-logtostderr=true "
                     "-v=0",

--- a/orc8r-bundle/bundle.yaml.j2
+++ b/orc8r-bundle/bundle.yaml.j2
@@ -282,7 +282,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-smsd_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-smsd-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-smsd-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
     {%- else %}
     charm: magma-orc8r-smsd
     channel: {{ channel|default("edge") }}

--- a/orc8r-bundle/bundle.yaml.j2
+++ b/orc8r-bundle/bundle.yaml.j2
@@ -47,7 +47,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-accessd_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-accessd-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-accessd-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-accessd
     channel: {{ channel|default("edge") }}
@@ -70,7 +70,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-analytics_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-analytics-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-analytics-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-analytics
     channel: {{ channel|default("edge") }}
@@ -81,7 +81,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-bootstrapper_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-bootstrapper-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-bootstrapper-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-bootstrapper
     channel: {{ channel|default("edge") }}
@@ -92,7 +92,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-certifier_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-certifier-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-certifier-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-certifier
     channel: {{ channel|default("edge") }}
@@ -105,7 +105,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-configurator_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-configurator-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-configurator-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-configurator
     channel: {{ channel|default("edge") }}
@@ -116,7 +116,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-ctraced_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-ctraced-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-ctraced-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-ctraced
     channel: {{ channel|default("edge") }}
@@ -127,7 +127,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-device_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-device-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-device-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-device
     channel: {{ channel|default("edge") }}
@@ -138,7 +138,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-directoryd_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-directoryd-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-directoryd-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-directoryd
     channel: {{ channel|default("edge") }}
@@ -149,7 +149,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-dispatcher_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-dispatcher-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-dispatcher-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-dispatcher
     channel: {{ channel|default("edge") }}
@@ -160,7 +160,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-eventd_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-eventd-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-eventd-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-eventd
     channel: {{ channel|default("edge") }}
@@ -195,7 +195,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-metricsd_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-metricsd-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-metricsd-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-metricsd
     channel: {{ channel|default("edge") }}
@@ -217,7 +217,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-obsidian_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-obsidian-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-obsidian-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-obsidian
     channel: {{ channel|default("edge") }}
@@ -228,7 +228,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-orchestrator_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-orchestrator-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-orchestrator-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-orchestrator
     channel: {{ channel|default("edge") }}
@@ -271,7 +271,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-service-registry_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-service-registry-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-service-registry-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-service-registry
     channel: {{ channel|default("edge") }}
@@ -282,7 +282,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-smsd_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-smsd-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-smsd-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-smsd
     channel: {{ channel|default("edge") }}
@@ -293,7 +293,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-state_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-state-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-state-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-state
     channel: {{ channel|default("edge") }}
@@ -304,7 +304,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-streamer_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-streamer-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-streamer-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-streamer
     channel: {{ channel|default("edge") }}
@@ -337,7 +337,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-tenants_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-tenants-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+      magma-orc8r-tenants-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-tenants
     channel: {{ channel|default("edge") }}

--- a/orc8r-bundle/bundle.yaml.j2
+++ b/orc8r-bundle/bundle.yaml.j2
@@ -47,7 +47,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-accessd_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-accessd-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-accessd-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-accessd
     channel: {{ channel|default("edge") }}
@@ -70,7 +70,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-analytics_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-analytics-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-analytics-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-analytics
     channel: {{ channel|default("edge") }}
@@ -81,7 +81,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-bootstrapper_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-bootstrapper-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-bootstrapper-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-bootstrapper
     channel: {{ channel|default("edge") }}
@@ -92,7 +92,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-certifier_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-certifier-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-certifier-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-certifier
     channel: {{ channel|default("edge") }}
@@ -105,7 +105,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-configurator_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-configurator-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-configurator-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-configurator
     channel: {{ channel|default("edge") }}
@@ -116,7 +116,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-ctraced_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-ctraced-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-ctraced-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-ctraced
     channel: {{ channel|default("edge") }}
@@ -127,7 +127,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-device_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-device-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-device-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-device
     channel: {{ channel|default("edge") }}
@@ -138,7 +138,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-directoryd_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-directoryd-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-directoryd-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-directoryd
     channel: {{ channel|default("edge") }}
@@ -149,7 +149,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-dispatcher_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-dispatcher-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-dispatcher-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-dispatcher
     channel: {{ channel|default("edge") }}
@@ -160,7 +160,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-eventd_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-eventd-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-eventd-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-eventd
     channel: {{ channel|default("edge") }}
@@ -195,7 +195,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-metricsd_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-metricsd-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-metricsd-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-metricsd
     channel: {{ channel|default("edge") }}
@@ -217,7 +217,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-obsidian_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-obsidian-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-obsidian-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-obsidian
     channel: {{ channel|default("edge") }}
@@ -228,7 +228,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-orchestrator_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-orchestrator-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-orchestrator-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-orchestrator
     channel: {{ channel|default("edge") }}
@@ -271,7 +271,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-service-registry_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-service-registry-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-service-registry-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-service-registry
     channel: {{ channel|default("edge") }}
@@ -293,7 +293,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-state_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-state-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-state-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-state
     channel: {{ channel|default("edge") }}
@@ -304,7 +304,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-streamer_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-streamer-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-streamer-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-streamer
     channel: {{ channel|default("edge") }}
@@ -337,7 +337,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-tenants_ubuntu-20.04-amd64.charm
     resources:
-      magma-orc8r-tenants-image: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+      magma-orc8r-tenants-image: ghcr.io/canonical/magma-orc8r-controller:1.6.1
     {%- else %}
     charm: magma-orc8r-tenants
     channel: {{ channel|default("edge") }}

--- a/orc8r-certifier-operator/metadata.yaml
+++ b/orc8r-certifier-operator/metadata.yaml
@@ -22,8 +22,8 @@ containers:
 resources:
   magma-orc8r-certifier-image:
     type: oci-image
-    description: OCI image for magma-orc8r-certifier (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    description: OCI image for magma-orc8r-certifier
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
 
 storage:
   config:

--- a/orc8r-certifier-operator/metadata.yaml
+++ b/orc8r-certifier-operator/metadata.yaml
@@ -23,7 +23,7 @@ resources:
   magma-orc8r-certifier-image:
     type: oci-image
     description: OCI image for magma-orc8r-certifier
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 storage:
   config:

--- a/orc8r-certifier-operator/src/charm.py
+++ b/orc8r-certifier-operator/src/charm.py
@@ -1278,9 +1278,7 @@ class MagmaOrc8rCertifierCharm(CharmBase):
                     self._service_name: {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": "/usr/bin/envdir "
-                        "/var/opt/magma/envdir "
-                        "/var/opt/magma/bin/certifier "
+                        "command": "certifier "
                         f"-cac={self.BASE_CERTIFICATES_PATH}/certifier.pem "
                         f"-cak={self.BASE_CERTIFICATES_PATH}/certifier.key "
                         f"-vpnc={self.BASE_CERTIFICATES_PATH}/vpn_ca.crt "

--- a/orc8r-certifier-operator/tests/unit/test_charm.py
+++ b/orc8r-certifier-operator/tests/unit/test_charm.py
@@ -27,7 +27,6 @@ from charm import MagmaOrc8rCertifierCharm
 
 
 class TestCharm(unittest.TestCase):
-
     TEST_DB_NAME = MagmaOrc8rCertifierCharm.DB_NAME
     TEST_DB_PORT = "1234"
     TEST_DB_CONNECTION_STRING = ConnectionString(
@@ -764,9 +763,7 @@ class TestCharm(unittest.TestCase):
                 "magma-orc8r-certifier": {
                     "override": "replace",
                     "startup": "enabled",
-                    "command": "/usr/bin/envdir "
-                    "/var/opt/magma/envdir "
-                    "/var/opt/magma/bin/certifier "
+                    "command": "certifier "
                     "-cac=/var/opt/magma/certs/certifier.pem "
                     "-cak=/var/opt/magma/certs/certifier.key "
                     "-vpnc=/var/opt/magma/certs/vpn_ca.crt "

--- a/orc8r-configurator-operator/metadata.yaml
+++ b/orc8r-configurator-operator/metadata.yaml
@@ -17,7 +17,7 @@ containers:
 resources:
   magma-orc8r-configurator-image:
     type: oci-image
-    description: OCI image for magma-orc8r-configurator (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
+    description: OCI image for magma-orc8r-configurator
     upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
 
 provides:

--- a/orc8r-configurator-operator/metadata.yaml
+++ b/orc8r-configurator-operator/metadata.yaml
@@ -18,7 +18,7 @@ resources:
   magma-orc8r-configurator-image:
     type: oci-image
     description: OCI image for magma-orc8r-configurator
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-configurator:

--- a/orc8r-configurator-operator/src/charm.py
+++ b/orc8r-configurator-operator/src/charm.py
@@ -24,13 +24,7 @@ class MagmaOrc8rConfiguratorCharm(CharmBase):
             ports=[ServicePort(name="grpc", port=9180, targetPort=9108)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
-        startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/configurator "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "configurator -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-ctraced-operator/metadata.yaml
+++ b/orc8r-ctraced-operator/metadata.yaml
@@ -15,8 +15,8 @@ containers:
 resources:
   magma-orc8r-ctraced-image:
     type: oci-image
-    description: OCI image for magma-orc8r-ctraced (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    description: OCI image for magma-orc8r-ctraced
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-ctraced:

--- a/orc8r-ctraced-operator/metadata.yaml
+++ b/orc8r-ctraced-operator/metadata.yaml
@@ -16,7 +16,7 @@ resources:
   magma-orc8r-ctraced-image:
     type: oci-image
     description: OCI image for magma-orc8r-ctraced
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-ctraced:

--- a/orc8r-ctraced-operator/src/charm.py
+++ b/orc8r-ctraced-operator/src/charm.py
@@ -34,14 +34,7 @@ class MagmaOrc8rCtracedCharm(CharmBase):
                 "orc8r.io/obsidian_handlers_path_prefixes": "/magma/v1/networks/:network_id/tracing,"  # noqa: E501
             },
         )
-        startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/ctraced "
-            "-run_echo_server=true "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "ctraced -run_echo_server=true -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-device-operator/metadata.yaml
+++ b/orc8r-device-operator/metadata.yaml
@@ -16,7 +16,7 @@ resources:
   magma-orc8r-device-image:
     type: oci-image
     description: OCI image for magma-orc8r-device
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-device:

--- a/orc8r-device-operator/metadata.yaml
+++ b/orc8r-device-operator/metadata.yaml
@@ -15,8 +15,8 @@ containers:
 resources:
   magma-orc8r-device-image:
     type: oci-image
-    description: OCI image for magma-orc8r-device (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    description: OCI image for magma-orc8r-device
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-device:

--- a/orc8r-device-operator/src/charm.py
+++ b/orc8r-device-operator/src/charm.py
@@ -24,13 +24,7 @@ class MagmaOrc8rDeviceCharm(CharmBase):
             ports=[ServicePort(name="grpc", port=9180, targetPort=9106)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
-        startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/device "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "device -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-directoryd-operator/metadata.yaml
+++ b/orc8r-directoryd-operator/metadata.yaml
@@ -16,8 +16,8 @@ containers:
 resources:
   magma-orc8r-directoryd-image:
     type: oci-image
-    description: OCI image for magma-orc8r-directoryd (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    description: OCI image for magma-orc8r-directoryd
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-directoryd:

--- a/orc8r-directoryd-operator/metadata.yaml
+++ b/orc8r-directoryd-operator/metadata.yaml
@@ -17,7 +17,7 @@ resources:
   magma-orc8r-directoryd-image:
     type: oci-image
     description: OCI image for magma-orc8r-directoryd
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-directoryd:

--- a/orc8r-directoryd-operator/src/charm.py
+++ b/orc8r-directoryd-operator/src/charm.py
@@ -24,13 +24,7 @@ class MagmaOrc8rDirectorydCharm(CharmBase):
             ports=[ServicePort(name="grpc", port=9180, targetPort=9100)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
-        startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/directoryd "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "directoryd -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-dispatcher-operator/metadata.yaml
+++ b/orc8r-dispatcher-operator/metadata.yaml
@@ -15,8 +15,8 @@ containers:
 resources:
   magma-orc8r-dispatcher-image:
     type: oci-image
-    description: OCI image for magma-orc8r-dispatcher (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    description: OCI image for magma-orc8r-dispatcher
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.10
 
 provides:
   magma-orc8r-dispatcher:

--- a/orc8r-dispatcher-operator/metadata.yaml
+++ b/orc8r-dispatcher-operator/metadata.yaml
@@ -16,7 +16,7 @@ resources:
   magma-orc8r-dispatcher-image:
     type: oci-image
     description: OCI image for magma-orc8r-dispatcher
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.10
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-dispatcher:

--- a/orc8r-dispatcher-operator/src/charm.py
+++ b/orc8r-dispatcher-operator/src/charm.py
@@ -24,13 +24,7 @@ class MagmaOrc8rDispatcherCharm(CharmBase):
             ports=[ServicePort(name="grpc", port=9180, targetPort=9096)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
-        startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/dispatcher "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "dispatcher -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-eventd-operator/metadata.yaml
+++ b/orc8r-eventd-operator/metadata.yaml
@@ -24,8 +24,8 @@ containers:
 resources:
   magma-orc8r-eventd-image:
     type: oci-image
-    description: OCI image for magma-orc8r-eventd (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    description: OCI image for magma-orc8r-eventd
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-eventd:

--- a/orc8r-eventd-operator/metadata.yaml
+++ b/orc8r-eventd-operator/metadata.yaml
@@ -25,7 +25,7 @@ resources:
   magma-orc8r-eventd-image:
     type: oci-image
     description: OCI image for magma-orc8r-eventd
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-eventd:

--- a/orc8r-eventd-operator/src/charm.py
+++ b/orc8r-eventd-operator/src/charm.py
@@ -44,14 +44,7 @@ class MagmaOrc8rEventdCharm(CharmBase):
                 "/magma/v1/events,"
             },
         )
-        startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/eventd "
-            "-run_echo_server=true "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "eventd -run_echo_server=true -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
         self.framework.observe(self.on.config_changed, self._on_elasticsearch_url_config_changed)
 

--- a/orc8r-metricsd-operator/metadata.yaml
+++ b/orc8r-metricsd-operator/metadata.yaml
@@ -19,7 +19,7 @@ resources:
   magma-orc8r-metricsd-image:
     type: oci-image
     description: OCI image for magma-orc8r-metricsd
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-metricsd:

--- a/orc8r-metricsd-operator/metadata.yaml
+++ b/orc8r-metricsd-operator/metadata.yaml
@@ -18,8 +18,8 @@ containers:
 resources:
   magma-orc8r-metricsd-image:
     type: oci-image
-    description: OCI image for magma-orc8r-metricsd (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    description: OCI image for magma-orc8r-metricsd
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-metricsd:

--- a/orc8r-metricsd-operator/src/charm.py
+++ b/orc8r-metricsd-operator/src/charm.py
@@ -200,12 +200,7 @@ class MagmaOrc8rMetricsdCharm(CharmBase):
                         "override": "replace",
                         "summary": self._service_name,
                         "startup": "enabled",
-                        "command": "/usr/bin/envdir "
-                        "/var/opt/magma/envdir "
-                        "/var/opt/magma/bin/metricsd "
-                        "-run_echo_server=true "
-                        "-logtostderr=true "
-                        "-v=0",
+                        "command": "metricsd -run_echo_server=true -logtostderr=true -v=0",
                         "environment": self._environment_variables,
                     }
                 },

--- a/orc8r-metricsd-operator/tests/unit/test_charm.py
+++ b/orc8r-metricsd-operator/tests/unit/test_charm.py
@@ -206,12 +206,7 @@ class TestCharm(unittest.TestCase):
                     "override": "replace",
                     "summary": "magma-orc8r-metricsd",
                     "startup": "enabled",
-                    "command": "/usr/bin/envdir "
-                    "/var/opt/magma/envdir "
-                    "/var/opt/magma/bin/metricsd "
-                    "-run_echo_server=true "
-                    "-logtostderr=true "
-                    "-v=0",
+                    "command": "metricsd -run_echo_server=true -logtostderr=true -v=0",
                     "environment": {
                         "SERVICE_HOSTNAME": "magma-orc8r-metricsd",
                         "SERVICE_REGISTRY_MODE": "k8s",

--- a/orc8r-obsidian-operator/metadata.yaml
+++ b/orc8r-obsidian-operator/metadata.yaml
@@ -17,8 +17,8 @@ containers:
 resources:
   magma-orc8r-obsidian-image:
     type: oci-image
-    description: OCI image for magma-orc8r-nginx (linuxfoundation.jfrog.io/magma-docker/nginx:1.6.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    description: OCI image for magma-orc8r-nginx
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-obsidian:

--- a/orc8r-obsidian-operator/metadata.yaml
+++ b/orc8r-obsidian-operator/metadata.yaml
@@ -18,7 +18,7 @@ resources:
   magma-orc8r-obsidian-image:
     type: oci-image
     description: OCI image for magma-orc8r-nginx
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-obsidian:

--- a/orc8r-obsidian-operator/src/charm.py
+++ b/orc8r-obsidian-operator/src/charm.py
@@ -27,13 +27,7 @@ class MagmaOrc8rObsidianCharm(CharmBase):
             ],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
-        startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/obsidian "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "obsidian -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-orchestrator-operator/metadata.yaml
+++ b/orc8r-orchestrator-operator/metadata.yaml
@@ -23,8 +23,8 @@ containers:
 resources:
   magma-orc8r-orchestrator-image:
     type: oci-image
-    description: OCI image for magma-orc8r-orchestrator (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    description: OCI image for magma-orc8r-orchestrator
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-orchestrator:

--- a/orc8r-orchestrator-operator/metadata.yaml
+++ b/orc8r-orchestrator-operator/metadata.yaml
@@ -24,7 +24,7 @@ resources:
   magma-orc8r-orchestrator-image:
     type: oci-image
     description: OCI image for magma-orc8r-orchestrator
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-orchestrator:

--- a/orc8r-orchestrator-operator/src/charm.py
+++ b/orc8r-orchestrator-operator/src/charm.py
@@ -153,12 +153,7 @@ class MagmaOrc8rOrchestratorCharm(CharmBase):
                     self._service_name: {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": "/usr/bin/envdir "
-                        "/var/opt/magma/envdir "
-                        "/var/opt/magma/bin/orchestrator "
-                        "-run_echo_server=true "
-                        "-logtostderr=true "
-                        "-v=0",
+                        "command": "orchestrator -run_echo_server=true -logtostderr=true -v=0",
                         "environment": self._environment_variables,
                     }
                 },

--- a/orc8r-orchestrator-operator/src/charm.py
+++ b/orc8r-orchestrator-operator/src/charm.py
@@ -427,7 +427,7 @@ class MagmaOrc8rOrchestratorCharm(CharmBase):
     def _create_orchestrator_admin_user(self):
         process = self._container.exec(
             [
-                "/var/opt/magma/bin/accessc",
+                "accessc",
                 "add-existing",
                 "-admin",
                 "-cert",

--- a/orc8r-orchestrator-operator/tests/unit/test_charm.py
+++ b/orc8r-orchestrator-operator/tests/unit/test_charm.py
@@ -153,7 +153,7 @@ class TestCharm(unittest.TestCase):
         args, _ = patch_exec.call_args
         patch_exec.assert_called_once()
         call_command = [
-            "/var/opt/magma/bin/accessc",
+            "accessc",
             "add-existing",
             "-admin",
             "-cert",

--- a/orc8r-orchestrator-operator/tests/unit/test_charm.py
+++ b/orc8r-orchestrator-operator/tests/unit/test_charm.py
@@ -72,11 +72,7 @@ class TestCharm(unittest.TestCase):
                 "magma-orc8r-orchestrator": {
                     "startup": "enabled",
                     "override": "replace",
-                    "command": "/usr/bin/envdir "
-                    "/var/opt/magma/envdir "
-                    "/var/opt/magma/bin/orchestrator "
-                    "-run_echo_server=true "
-                    "-logtostderr=true -v=0",
+                    "command": "orchestrator -run_echo_server=true -logtostderr=true -v=0",
                     "environment": {
                         "SERVICE_HOSTNAME": "magma-orc8r-orchestrator",
                         "SERVICE_REGISTRY_MODE": "k8s",

--- a/orc8r-policydb-operator/metadata.yaml
+++ b/orc8r-policydb-operator/metadata.yaml
@@ -17,7 +17,7 @@ containers:
 resources:
   magma-orc8r-policydb-image:
     type: oci-image
-    description: OCI image for magma-orc8r-policydb (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
+    description: OCI image for magma-orc8r-policydb
     upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
 
 provides:

--- a/orc8r-service-registry-operator/metadata.yaml
+++ b/orc8r-service-registry-operator/metadata.yaml
@@ -16,8 +16,8 @@ containers:
 resources:
   magma-orc8r-service-registry-image:
     type: oci-image
-    description: OCI image for magma-orc8r-service-registry (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    description: OCI image for magma-orc8r-service-registry
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-service-registry:

--- a/orc8r-service-registry-operator/metadata.yaml
+++ b/orc8r-service-registry-operator/metadata.yaml
@@ -17,7 +17,7 @@ resources:
   magma-orc8r-service-registry-image:
     type: oci-image
     description: OCI image for magma-orc8r-service-registry
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-service-registry:

--- a/orc8r-service-registry-operator/src/charm.py
+++ b/orc8r-service-registry-operator/src/charm.py
@@ -24,13 +24,7 @@ class MagmaOrc8rServiceRegistry(CharmBase):
             ports=[ServicePort(name="grpc", port=9180)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
-        startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/service_registry "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "service_registry -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-smsd-operator/metadata.yaml
+++ b/orc8r-smsd-operator/metadata.yaml
@@ -16,7 +16,7 @@ resources:
   magma-orc8r-smsd-image:
     type: oci-image
     description: OCI image for magma-orc8r-smsd
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
 
 provides:
   magma-orc8r-smsd:

--- a/orc8r-smsd-operator/metadata.yaml
+++ b/orc8r-smsd-operator/metadata.yaml
@@ -15,8 +15,8 @@ containers:
 resources:
   magma-orc8r-smsd-image:
     type: oci-image
-    description: OCI image for magma-orc8r-smsd (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    description: OCI image for magma-orc8r-smsd
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-smsd:

--- a/orc8r-smsd-operator/src/charm.py
+++ b/orc8r-smsd-operator/src/charm.py
@@ -34,7 +34,14 @@ class MagmaOrc8rSmsdCharm(CharmBase):
                 "orc8r.io/obsidian_handlers_path_prefixes": "/magma/v1/lte/:network_id/sms"
             },
         )
-        startup_command = "smsd -logtostderr=true -run_echo_server=true -v=0"
+        startup_command = (
+            "/usr/bin/envdir "
+            "/var/opt/magma/envdir "
+            "/var/opt/magma/bin/smsd "
+            "-logtostderr=true "
+            "-run_echo_server=true "
+            "-v=0"
+        )
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-smsd-operator/src/charm.py
+++ b/orc8r-smsd-operator/src/charm.py
@@ -34,14 +34,7 @@ class MagmaOrc8rSmsdCharm(CharmBase):
                 "orc8r.io/obsidian_handlers_path_prefixes": "/magma/v1/lte/:network_id/sms"
             },
         )
-        startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/smsd "
-            "-logtostderr=true "
-            "-run_echo_server=true "
-            "-v=0"
-        )
+        startup_command = "smsd -logtostderr=true -run_echo_server=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-state-operator/metadata.yaml
+++ b/orc8r-state-operator/metadata.yaml
@@ -15,8 +15,8 @@ containers:
 resources:
   magma-orc8r-state-image:
     type: oci-image
-    description: OCI image for magma-orc8r-state (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    description: OCI image for magma-orc8r-state
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-state:

--- a/orc8r-state-operator/metadata.yaml
+++ b/orc8r-state-operator/metadata.yaml
@@ -16,7 +16,7 @@ resources:
   magma-orc8r-state-image:
     type: oci-image
     description: OCI image for magma-orc8r-state
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-state:

--- a/orc8r-state-operator/src/charm.py
+++ b/orc8r-state-operator/src/charm.py
@@ -24,13 +24,7 @@ class MagmaOrc8rStateCharm(CharmBase):
             ports=[ServicePort(name="grpc", port=9180, targetPort=9105)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
-        startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/state "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "state -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-streamer-operator/metadata.yaml
+++ b/orc8r-streamer-operator/metadata.yaml
@@ -18,7 +18,7 @@ resources:
   magma-orc8r-streamer-image:
     type: oci-image
     description: OCI image for magma-orc8r-streamer
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-streamer:

--- a/orc8r-streamer-operator/metadata.yaml
+++ b/orc8r-streamer-operator/metadata.yaml
@@ -17,8 +17,8 @@ containers:
 resources:
   magma-orc8r-streamer-image:
     type: oci-image
-    description: OCI image for magma-orc8r-streamer (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    description: OCI image for magma-orc8r-streamer
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-streamer:

--- a/orc8r-streamer-operator/src/charm.py
+++ b/orc8r-streamer-operator/src/charm.py
@@ -24,13 +24,7 @@ class MagmaOrc8rStreamer(CharmBase):
             ports=[ServicePort(name="grpc", port=9180, targetPort=9082)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
-        startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/streamer "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "streamer -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-tenants-operator/metadata.yaml
+++ b/orc8r-tenants-operator/metadata.yaml
@@ -15,8 +15,8 @@ containers:
 resources:
   magma-orc8r-tenants-image:
     type: oci-image
-    description: OCI image for magma-orc8r-tenants (linuxfoundation.jfrog.io/magma-docker/controller:1.6.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
+    description: OCI image for magma-orc8r-tenants
+    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-tenants:

--- a/orc8r-tenants-operator/metadata.yaml
+++ b/orc8r-tenants-operator/metadata.yaml
@@ -16,7 +16,7 @@ resources:
   magma-orc8r-tenants-image:
     type: oci-image
     description: OCI image for magma-orc8r-tenants
-    upstream-source: ghcr.io/gruyaume/magma-orc8r-controller:1.6.1
+    upstream-source: ghcr.io/canonical/magma-orc8r-controller:1.6.1
 
 provides:
   magma-orc8r-tenants:

--- a/orc8r-tenants-operator/src/charm.py
+++ b/orc8r-tenants-operator/src/charm.py
@@ -35,14 +35,7 @@ class MagmaOrc8rTenantsCharm(CharmBase):
                 "/magma/v1/tenants/:tenants_id,"
             },
         )
-        startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/tenants "
-            "-run_echo_server=true "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "tenants -run_echo_server=true -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 


### PR DESCRIPTION
# Description

This PR replaces the use of the upstream container image with the rockcraft built rock for the `orc8r-controller` container image. This image was used in most of the services. Here we only replace it in the orc8r images that are not `lte`:
- accessd
- analytics
- bootstrapper
- certifier
- configurator
- ctraced
- device
- directoryd
- dispatcher
- eventd
- metricsd
- obsidian
- orchestrator
- service-registry
- state
- streamer
- tenants

A different rock will be created specifically for the `lte` services:
- ha
- lte
- policydb
- smsd
- subscriberdb
- subscriberdb-cache

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
