### PR TITLE
Uses juju secrets in cert admin operator

### DIFF
--- a/nms-magmalte-operator/lib/charms/magma_orc8r_certifier/v0/cert_admin_operator.py
+++ b/nms-magmalte-operator/lib/charms/magma_orc8r_certifier/v0/cert_admin_operator.py
@@ -36,7 +36,13 @@ class CertAdminOperatorRequires(Object):
 
 """
 
-from ops.charm import CharmBase, CharmEvents, RelationChangedEvent, RelationJoinedEvent, SecretEvent
+from ops.charm import(
+    CharmBase,
+    CharmEvents,
+    RelationChangedEvent,
+    RelationJoinedEvent,
+    SecretEvent
+    )
 from ops.framework import EventBase, EventSource, Object
 from ops.model import Secret
 from typing import Optional
@@ -75,6 +81,7 @@ class CertificateAvailableEvent(SecretEvent):
     """Dataclass for certificate available events."""
 
     def __init__(self, handle, id: str, label: Optional[str]):
+        """Sets secret id and secret label."""
         super().__init__(handle)
         self._id = id
         self._label = label
@@ -160,7 +167,6 @@ class CertAdminOperatorProvides(Object):
             None
         """
         self.on.certificate_request.emit(relation_id=event.relation.id)
-
 
 class CertAdminOperatorRequires(Object):
     """Class to be instantiated by requirer of admin operator certificates."""

--- a/nms-magmalte-operator/lib/charms/magma_orc8r_certifier/v0/cert_admin_operator.py
+++ b/nms-magmalte-operator/lib/charms/magma_orc8r_certifier/v0/cert_admin_operator.py
@@ -36,8 +36,10 @@ class CertAdminOperatorRequires(Object):
 
 """
 
-from ops.charm import CharmBase, CharmEvents, RelationChangedEvent, RelationJoinedEvent
+from ops.charm import CharmBase, CharmEvents, RelationChangedEvent, RelationJoinedEvent, SecretEvent
 from ops.framework import EventBase, EventSource, Object
+from ops.model import Secret
+from typing import Optional
 
 # The unique Charmhub library identifier, never change it
 LIBID = "6ca3a0b88afc4bebafbaa49514afb18f"
@@ -47,7 +49,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 class CertificateRequestEvent(EventBase):
@@ -69,23 +71,30 @@ class CertificateRequestEvent(EventBase):
         self.relation_id = snapshot["relation_id"]
 
 
-class CertificateAvailableEvent(EventBase):
+class CertificateAvailableEvent(SecretEvent):
     """Dataclass for certificate available events."""
 
-    def __init__(self, handle, certificate: str, private_key: str):
+    def __init__(self, handle, id: str, label: Optional[str]):
+        super().__init__(handle)
+        self._id = id
+        self._label = label
         """Sets certificate and private key."""
         super().__init__(handle)
-        self.certificate = certificate
-        self.private_key = private_key
+
+    @property
+    def secret(self) -> Secret:
+        """The secret instance this event refers to."""
+        backend = self.framework.model._backend
+        return Secret(backend=backend, id=self._id, label=self._label)
 
     def snapshot(self) -> dict:
         """Returns event data."""
-        return {"certificate": self.certificate, "private_key": self.private_key}
+        return {"certificate": self.certificate, "private-key": self.private_key}
 
     def restore(self, snapshot) -> None:
         """Restores event data."""
         self.certificate = snapshot["certificate"]
-        self.private_key = snapshot["private_key"]
+        self.private_key = snapshot["private-key"]
 
 
 class CertAdminOperatorProviderCharmEvents(CharmEvents):
@@ -120,7 +129,7 @@ class CertAdminOperatorProvides(Object):
         )
 
     def set_certificate(self, relation_id: int, certificate: str, private_key: str) -> None:
-        """Sets certificates in relation data.
+        """Sets certificates in relation data as a juju secret.
 
         Args:
             relation_id (str): Relation ID
@@ -130,11 +139,16 @@ class CertAdminOperatorProvides(Object):
         Returns:
             None
         """
+        content = {
+            'certificate': certificate,
+            'private-key': private_key,
+        }
+        secret = self.model.unit.add_secret(content)
         relation = self.model.get_relation(
             relation_name=self.relationship_name, relation_id=relation_id
         )
-        relation.data[self.model.unit]["certificate"] = certificate  # type: ignore[union-attr]
-        relation.data[self.model.unit]["private_key"] = private_key  # type: ignore[union-attr]
+        secret.grant(relation)
+        relation.data[self.model.unit]['secret-id'] = secret.id
 
     def _on_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Triggered whenever a requirer charm joins the relation.
@@ -180,7 +194,11 @@ class CertAdminOperatorRequires(Object):
             None
         """
         relation_data = event.relation.data
-        certificate = relation_data[event.unit].get("certificate")  # type: ignore[index]
-        private_key = relation_data[event.unit].get("private_key")  # type: ignore[index]
+        secret_id = relation_data[event.unit]['secret-id']
+        secret = self.model.get_secret(id=secret_id)
+        content = secret.get_content()
+        certificate = content["certificate"]  # type: ignore[index]
+        private_key = content["private-key"]  # type: ignore[index]
         if certificate and private_key:
-            self.on.certificate_available.emit(certificate=certificate, private_key=private_key)
+            self.on.certificate_available.emit(
+                id=secret_id, label="cert_admin_operator")

--- a/nms-magmalte-operator/src/charm.py
+++ b/nms-magmalte-operator/src/charm.py
@@ -301,7 +301,6 @@ class MagmaNmsMagmalteCharm(CharmBase):
             event.defer()
             return
         content = event.secret.get_content()  # type: ignore[attr-defined]
-        print(content["certificate"])
         self._container.push(
             path=f"{self.BASE_CERTS_PATH}/admin_operator.pem", source=content["certificate"]
         )

--- a/nms-magmalte-operator/src/charm.py
+++ b/nms-magmalte-operator/src/charm.py
@@ -300,11 +300,13 @@ class MagmaNmsMagmalteCharm(CharmBase):
             logger.info("Can't connect to container - Deferring")
             event.defer()
             return
+        content = event.secret.get_content()  # type: ignore[attr-defined]
+        print(content["certificate"])
         self._container.push(
-            path=f"{self.BASE_CERTS_PATH}/admin_operator.pem", source=event.certificate
+            path=f"{self.BASE_CERTS_PATH}/admin_operator.pem", source=content["certificate"]
         )
         self._container.push(
-            path=f"{self.BASE_CERTS_PATH}/admin_operator.key.pem", source=event.private_key
+            path=f"{self.BASE_CERTS_PATH}/admin_operator.key.pem", source=content["private_key"]
         )
         self._on_magma_nms_magmalte_pebble_ready(event)
 

--- a/nms-magmalte-operator/src/charm.py
+++ b/nms-magmalte-operator/src/charm.py
@@ -300,7 +300,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
             logger.info("Can't connect to container - Deferring")
             event.defer()
             return
-        content = event.secret.get_content()  # type: ignore[attr-defined]
+        content = event.secret.get_content()
         self._container.push(
             path=f"{self.BASE_CERTS_PATH}/admin_operator.pem", source=content["certificate"]
         )

--- a/nms-magmalte-operator/tests/unit/test_charm.py
+++ b/nms-magmalte-operator/tests/unit/test_charm.py
@@ -350,7 +350,6 @@ class TestCharm(unittest.TestCase):
     def test_given_workload_service_is_running_and_peer_relation_not_created_when_get_admin_credentials_action_then_get_admin_credentials_fail(  # noqa: E501
         self, action_event
     ):
-
         self.harness.remove_relation(self.peer_relation_id)
         self.harness.charm._on_get_master_admin_credentials(action_event)
 
@@ -397,15 +396,18 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Container.push")
+    @patch("ops.model.Secret")
     def test_given_pebble_ready_when_certificate_available_then_certs_are_pushed_to_container(
-        self, patch_push
+        self, patched_secret, patch_push
     ):
         certificate = "whatever certificate"
         private_key = "whatever private key"
         event = Mock()
-        event.certificate = certificate
-        event.private_key = private_key
-
+        patched_secret.get_content.return_value = {
+            "certificate": certificate,
+            "private_key": private_key,
+        }
+        event.secret = patched_secret
         container = self.harness.model.unit.get_container("magma-nms-magmalte")
         self.harness.set_can_connect(container=container, val=True)
 

--- a/orc8r-certifier-operator/tests/unit/lib/charms/magma_orc8r_certifier/v0/test_cert_admin_operator.py
+++ b/orc8r-certifier-operator/tests/unit/lib/charms/magma_orc8r_certifier/v0/test_cert_admin_operator.py
@@ -26,8 +26,7 @@ class TestCertAdminOperatorProvides(unittest.TestCase):
             relation_name=self.relationship_name, remote_app=app_name
         )
 
-
-        self.harness.add_relation_unit(relation_id, f"{app_name}/0")
+        self.harness.add_relation_unit(relation_id, "whatever-app/0")
         self.harness.charm.admin_operator.set_certificate(
             certificate=certificate, private_key=private_key, relation_id=relation_id
         )
@@ -35,7 +34,7 @@ class TestCertAdminOperatorProvides(unittest.TestCase):
         relation_data = self.harness.get_relation_data(
             relation_id=relation_id, app_or_unit=self.harness.charm.unit
         )
-        secret_id = relation_data['secret-id']
+        secret_id = relation_data["secret-id"]
         secret = self.harness.model.get_secret(id=secret_id)
         content = secret.get_content()
         self.assertEqual(certificate, content["certificate"])

--- a/orc8r-certifier-operator/tests/unit/lib/charms/magma_orc8r_certifier/v0/test_cert_admin_operator.py
+++ b/orc8r-certifier-operator/tests/unit/lib/charms/magma_orc8r_certifier/v0/test_cert_admin_operator.py
@@ -21,15 +21,22 @@ class TestCertAdminOperatorProvides(unittest.TestCase):
     ):
         certificate = "whatever cert"
         private_key = "whatever private key"
+        app_name = "whatever app"
         relation_id = self.harness.add_relation(
-            relation_name=self.relationship_name, remote_app="whatever app"
+            relation_name=self.relationship_name, remote_app=app_name
         )
 
+
+        self.harness.add_relation_unit(relation_id, f"{app_name}/0")
         self.harness.charm.admin_operator.set_certificate(
             certificate=certificate, private_key=private_key, relation_id=relation_id
         )
 
         relation_data = self.harness.get_relation_data(
-            relation_id=relation_id, app_or_unit=self.harness.charm.unit.name
+            relation_id=relation_id, app_or_unit=self.harness.charm.unit
         )
-        self.assertEqual(certificate, relation_data["certificate"])
+        secret_id = relation_data['secret-id']
+        secret = self.harness.model.get_secret(id=secret_id)
+        content = secret.get_content()
+        self.assertEqual(certificate, content["certificate"])
+        self.assertEqual(private_key, content["private-key"])

--- a/orc8r-certifier-operator/tests/unit/test_charm.py
+++ b/orc8r-certifier-operator/tests/unit/test_charm.py
@@ -27,7 +27,6 @@ from charm import MagmaOrc8rCertifierCharm
 
 
 class TestCharm(unittest.TestCase):
-
     TEST_DB_NAME = MagmaOrc8rCertifierCharm.DB_NAME
     TEST_DB_PORT = "1234"
     TEST_DB_CONNECTION_STRING = ConnectionString(


### PR DESCRIPTION
# Description

Uses juju secret in `cert-admin-operator` library and leverages the changes in `nms-magmalte` 

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
