### PR TITLE
[Bug Fix] Orc8r-nginx crashes when certifier certificates are ready before nginx.conf file is created

### DIFF
--- a/orc8r-nginx-operator/src/charm.py
+++ b/orc8r-nginx-operator/src/charm.py
@@ -176,6 +176,7 @@ class MagmaOrc8rNginxCharm(CharmBase):
             return
         if not self._nginx_config_is_generated:
             self.unit.status = WaitingStatus("Waiting for nginx config to be generated.")
+            event.defer()
             return
         self._configure_pebble_layer(event)
 

--- a/orc8r-nginx-operator/tests/unit/test_charm.py
+++ b/orc8r-nginx-operator/tests/unit/test_charm.py
@@ -513,7 +513,6 @@ class TestCharm(unittest.TestCase):
             self.harness.charm.unit.status,
         )
 
-    def _create_active_relation(self, relation_name: str, remote_app: str) -> int:
     @patch("ops.model.Container.restart")
     @patch("ops.model.Container.exists")
     def test_given_workload_container_with_pebble_layer_when_pebble_ready_then_nginx_service_is_reloaded(  # noqa: E501

--- a/orc8r-nginx-operator/tests/unit/test_charm.py
+++ b/orc8r-nginx-operator/tests/unit/test_charm.py
@@ -601,7 +601,6 @@ class TestCharm(unittest.TestCase):
         return relation_id
 
     def _create_all_relations(self) -> dict:
-
         bootstrapper_relation_id = self._create_active_relation(
             relation_name="magma-orc8r-bootstrapper", remote_app="magma-orc8r-bootstrapper"
         )

--- a/orc8r-nginx-operator/tests/unit/test_charm.py
+++ b/orc8r-nginx-operator/tests/unit/test_charm.py
@@ -28,35 +28,10 @@ class TestCharm(unittest.TestCase):
         self._container = self.harness.model.unit.get_container("magma-orc8r-nginx")
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock())
-    @patch("lightkube.core.client.Client.create", new=Mock())
-    @patch("ops.model.Container.exec", new_callable=Mock)
-    def test_given_domain_config_set_when_install_then_nginx_config_file_is_created(
-        self, patched_exec
-    ):
-        patched_exec.return_value = MockExec()
-        event = Mock()
-        domain = "whatever domain"
-        key_values = {"domain": domain}
-        self.harness.update_config(key_values=key_values)
-        self.harness.set_can_connect(container=self._container, val=True)
-
-        self.harness.charm._on_install(event)
-
-        patched_exec.assert_called_with(
-            command=["/usr/local/bin/generate_nginx_configs.py"],
-            environment={
-                "PROXY_BACKENDS": f"{self.namespace}.svc.cluster.local",
-                "CONTROLLER_HOSTNAME": f"controller.{domain}",
-                "RESOLVER": "kube-dns.kube-system.svc.cluster.local valid=10s",
-                "SERVICE_REGISTRY_MODE": "k8s",
-            },
-        )
-
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock())
     @patch("lightkube.core.client.Client.get")
     @patch("lightkube.core.client.Client.create")
     @patch("ops.model.Container.exec", new_callable=Mock)
-    def test_given_domain_config_set_when_install_then_additional_k8s_services_are_created(
+    def test_given_when_pebble_ready_then_additional_k8s_services_are_created(
         self, patched_exec, patch_create, patch_get
     ):
         patched_exec.return_value = MockExec()
@@ -493,7 +468,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Container.exec")
-    def test_given_valid_domain_config_set_when_config_changed_then_nginx_config_file_is_recreated(
+    def test_given_valid_domain_config_set_when_config_changed_then_nginx_config_file_is_created(
         self, patch_exec
     ):
         self.harness.set_can_connect(container=self._container, val=True)

--- a/orc8r-nginx-operator/tests/unit/test_charm.py
+++ b/orc8r-nginx-operator/tests/unit/test_charm.py
@@ -31,7 +31,7 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.Client.get")
     @patch("lightkube.core.client.Client.create")
     @patch("ops.model.Container.exec", new_callable=Mock)
-    def test_given_when_pebble_ready_then_additional_k8s_services_are_created(
+    def test_given_additional_k8s_services_not_created_when_on_install_then_additional_k8s_services_are_created(  # noqa: E501
         self, patched_exec, patch_create, patch_get
     ):
         patched_exec.return_value = MockExec()
@@ -41,7 +41,6 @@ class TestCharm(unittest.TestCase):
             request=Request(url="whatever", method="get"),
         )
         event = Mock()
-        self.harness.set_can_connect(container=self._container, val=True)
 
         self.harness.charm._on_install(event)
 

--- a/orc8r-nginx-operator/tests/unit/test_charm.py
+++ b/orc8r-nginx-operator/tests/unit/test_charm.py
@@ -31,7 +31,7 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.Client.get")
     @patch("lightkube.core.client.Client.create")
     @patch("ops.model.Container.exec", new_callable=Mock)
-    def test_given_additional_k8s_services_not_created_when_on_install_then_additional_k8s_services_are_created(  # noqa: E501
+    def test_given_additional_k8s_services_not_created_when_on_install_then_services_are_created(
         self, patched_exec, patch_create, patch_get
     ):
         patched_exec.return_value = MockExec()


### PR DESCRIPTION

# Description

Fixes bug where if certifier certificate was ready before the config file was created, the charm would crash

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
