### PR TITLE
Restart nginx regardless of pebble layer change

### DIFF
--- a/orc8r-nginx-operator/src/charm.py
+++ b/orc8r-nginx-operator/src/charm.py
@@ -375,8 +375,8 @@ class MagmaOrc8rNginxCharm(CharmBase):
                     f"Configuring pebble layer for {self._service_name}"
                 )
                 self._container.add_layer(self._container_name, layer, combine=True)
-                self._container.restart(self._service_name)
-                logger.info(f"Restarted service {self._service_name}")
+            self._container.restart(self._service_name)
+            logger.info(f"Restarted service {self._service_name}")
             self._update_relations()
             self.unit.status = ActiveStatus()
         else:


### PR DESCRIPTION
# Description

Ensures `nginx` service is restarted regardless of pebble layer change. 
If restart only happens on layer change, `nginx` will not be restarted when the certs or the charm config changes. As a result, `nginx` will not fetch the new configuration.

NOTE:
This was already implemented before, but got accidentally reverted by [this PR](https://github.com/canonical/charmed-magma-orchestrator/pull/155/files#diff-00900f79f9d9f3e59fcb73978d0d8b64cbe7fb1bc6f62c86642d8891ddcdce5c).

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
