### PR TITLE
Fixes bug where Juju logs were filled with RuntimeErrors

### DIFF
--- a/orc8r-certifier-operator/src/charm.py
+++ b/orc8r-certifier-operator/src/charm.py
@@ -501,7 +501,9 @@ class MagmaOrc8rCertifierCharm(CharmBase):
             event (CertificateCreationRequestEvent): Custom Juju event for certificate request
         """
         if not self._application_private_key:
-            raise RuntimeError("Application private key not available")
+            self.unit.status = WaitingStatus("Waiting for application private key")
+            event.defer()
+            return
         if not event.certificate_signing_request:
             self.unit.status = BlockedStatus("Fluentd CSR not available in the relation data")
             return

--- a/orc8r-certifier-operator/tests/unit/test_charm.py
+++ b/orc8r-certifier-operator/tests/unit/test_charm.py
@@ -1248,22 +1248,25 @@ class TestCharm(unittest.TestCase):
         patch_certificate_request.assert_not_called()
         patch_certificate_renewal.assert_not_called()
 
-    def test_given_application_key_not_available_when_fluentd_certificate_creation_request_then_runtime_error_is_raised(  # noqa: E501
+    def test_given_application_key_not_available_when_fluentd_certificate_creation_request_then_status_is_waiting(  # noqa: E501
         self,
     ):
         fluentd_relation_id = self.harness.add_relation("fluentd-certs", "fluentd-app")
         self.harness.add_relation_unit(fluentd_relation_id, "fluentd-app/0")
 
-        with self.assertRaises(RuntimeError):
-            self.harness.update_relation_data(
-                relation_id=fluentd_relation_id,
-                app_or_unit="fluentd-app/0",
-                key_values={
-                    "certificate_signing_requests": json.dumps(
-                        [{"certificate_signing_request": "whatever"}]
-                    )
-                },
-            )
+        self.harness.update_relation_data(
+            relation_id=fluentd_relation_id,
+            app_or_unit="fluentd-app/0",
+            key_values={
+                "certificate_signing_requests": json.dumps(
+                    [{"certificate_signing_request": "whatever"}]
+                )
+            },
+        )
+
+        assert self.harness.charm.unit.status == WaitingStatus(
+            "Waiting for application private key"
+        )
 
     @patch("charm.generate_certificate")
     def test_given_fluentd_csr_not_present_in_relation_data_when_fluentd_certificate_creation_request_then_fluentd_cert_is_not_generated(  # noqa: E501


### PR DESCRIPTION
# Description

Fixes bug where Juju logs were filled with those errors: `RuntimeError: Application private key not available`. I observed this pattern in the logs provided in [this](https://github.com/canonical/charmed-magma/issues/22) bug.

```
unit-orc8r-subscriberdb-0: 10:16:14 INFO juju.worker.uniter.operation ran "db-relation-created" hook (via hook dispatching script: dispatch)
unit-orc8r-certifier-0: 10:16:15 INFO unit.orc8r-certifier/0.juju-log fluentd-certs:9: Container not yet available
unit-orc8r-certifier-0: 10:16:15 INFO unit.orc8r-certifier/0.juju-log fluentd-certs:9: Container not yet available
unit-orc8r-certifier-0: 10:16:15 INFO unit.orc8r-certifier/0.juju-log fluentd-certs:9: Container not yet available
unit-orc8r-certifier-0: 10:16:15 INFO unit.orc8r-certifier/0.juju-log fluentd-certs:9: Container not yet available
unit-orc8r-certifier-0: 10:16:15 INFO unit.orc8r-certifier/0.juju-log fluentd-certs:9: Container not yet available
unit-orc8r-certifier-0: 10:16:15 ERROR unit.orc8r-certifier/0.juju-log fluentd-certs:9: Uncaught exception while in charm code:
Traceback (most recent call last):
  File "./src/charm.py", line 1417, in <module>
    main(MagmaOrc8rCertifierCharm)
  File "/var/lib/juju/agents/unit-orc8r-certifier-0/charm/venv/ops/main.py", line 435, in main
    _emit_charm_event(charm, dispatcher.event_name)
  File "/var/lib/juju/agents/unit-orc8r-certifier-0/charm/venv/ops/main.py", line 144, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-orc8r-certifier-0/charm/venv/ops/framework.py", line 355, in emit
    framework._emit(event)  # noqa
  File "/var/lib/juju/agents/unit-orc8r-certifier-0/charm/venv/ops/framework.py", line 824, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-orc8r-certifier-0/charm/venv/ops/framework.py", line 899, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-orc8r-certifier-0/charm/lib/charms/tls_certificates_interface/v1/tls_certificates.py", line 1057, in _on_relation_changed
    self.on.certificate_creation_request.emit(
  File "/var/lib/juju/agents/unit-orc8r-certifier-0/charm/venv/ops/framework.py", line 355, in emit
    framework._emit(event)  # noqa
  File "/var/lib/juju/agents/unit-orc8r-certifier-0/charm/venv/ops/framework.py", line 824, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-orc8r-certifier-0/charm/venv/ops/framework.py", line 899, in _reemit
    custom_handler(event)
  File "./src/charm.py", line 494, in _on_fluentd_certificate_creation_request
    raise RuntimeError("Application private key not available")
RuntimeError: Application private key not available
unit-orc8r-subscriberdb-0: 10:16:15 INFO juju.worker.uniter found queued "leader-elected" hook
```

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
