### PR TITLE
Bumps orc8r base library

### DIFF
--- a/orc8r-accessd-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orc8r-accessd-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -85,7 +85,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        additional_environment_variables: dict = None,
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -163,7 +163,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-analytics-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
+++ b/orc8r-analytics-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
@@ -67,7 +67,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -80,8 +80,8 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        required_relations: list = None,
-        additional_environment_variables: dict = None,
+        required_relations: list = None,  # type: ignore[assignment]
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -131,7 +131,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-base-acct-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
+++ b/orc8r-base-acct-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
@@ -67,7 +67,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -80,8 +80,8 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        required_relations: list = None,
-        additional_environment_variables: dict = None,
+        required_relations: list = None,  # type: ignore[assignment]
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -131,7 +131,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-configurator-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orc8r-configurator-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -85,7 +85,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        additional_environment_variables: dict = None,
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -163,7 +163,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-ctraced-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orc8r-ctraced-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -85,7 +85,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        additional_environment_variables: dict = None,
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -163,7 +163,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-device-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orc8r-device-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -85,7 +85,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        additional_environment_variables: dict = None,
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -163,7 +163,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-directoryd-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orc8r-directoryd-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -85,7 +85,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        additional_environment_variables: dict = None,
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -163,7 +163,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-dispatcher-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
+++ b/orc8r-dispatcher-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
@@ -67,7 +67,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -80,8 +80,8 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        required_relations: list = None,
-        additional_environment_variables: dict = None,
+        required_relations: list = None,  # type: ignore[assignment]
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -131,7 +131,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-eventd-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
+++ b/orc8r-eventd-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
@@ -67,7 +67,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -80,8 +80,8 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        required_relations: list = None,
-        additional_environment_variables: dict = None,
+        required_relations: list = None,  # type: ignore[assignment]
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -131,7 +131,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-feg-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
+++ b/orc8r-feg-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
@@ -67,7 +67,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -80,8 +80,8 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        required_relations: list = None,
-        additional_environment_variables: dict = None,
+        required_relations: list = None,  # type: ignore[assignment]
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -131,7 +131,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-feg-relay-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
+++ b/orc8r-feg-relay-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
@@ -67,7 +67,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -80,8 +80,8 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        required_relations: list = None,
-        additional_environment_variables: dict = None,
+        required_relations: list = None,  # type: ignore[assignment]
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -131,7 +131,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-ha-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
+++ b/orc8r-ha-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
@@ -67,7 +67,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -80,8 +80,8 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        required_relations: list = None,
-        additional_environment_variables: dict = None,
+        required_relations: list = None,  # type: ignore[assignment]
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -131,7 +131,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-health-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orc8r-health-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -85,7 +85,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        additional_environment_variables: dict = None,
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -163,7 +163,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-lte-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orc8r-lte-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -85,7 +85,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        additional_environment_variables: dict = None,
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -163,7 +163,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-obsidian-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
+++ b/orc8r-obsidian-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
@@ -67,7 +67,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -80,8 +80,8 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        required_relations: list = None,
-        additional_environment_variables: dict = None,
+        required_relations: list = None,  # type: ignore[assignment]
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -131,7 +131,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-policydb-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orc8r-policydb-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -85,7 +85,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        additional_environment_variables: dict = None,
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -163,7 +163,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-service-registry-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
+++ b/orc8r-service-registry-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
@@ -67,7 +67,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -80,8 +80,8 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        required_relations: list = None,
-        additional_environment_variables: dict = None,
+        required_relations: list = None,  # type: ignore[assignment]
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -131,7 +131,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-smsd-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orc8r-smsd-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -85,7 +85,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        additional_environment_variables: dict = None,
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -163,7 +163,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-state-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orc8r-state-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -85,7 +85,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        additional_environment_variables: dict = None,
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -163,7 +163,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-streamer-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
+++ b/orc8r-streamer-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
@@ -67,7 +67,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -80,8 +80,8 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        required_relations: list = None,
-        additional_environment_variables: dict = None,
+        required_relations: list = None,  # type: ignore[assignment]
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -131,7 +131,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-subscriberdb-cache-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orc8r-subscriberdb-cache-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -85,7 +85,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        additional_environment_variables: dict = None,
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -163,7 +163,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-subscriberdb-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orc8r-subscriberdb-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -85,7 +85,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        additional_environment_variables: dict = None,
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -163,7 +163,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/orc8r-tenants-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orc8r-tenants-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -85,7 +85,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ class Orc8rBase(Object):
         self,
         charm: CharmBase,
         startup_command: str,
-        additional_environment_variables: dict = None,
+        additional_environment_variables: dict = None,  # type: ignore[assignment]
     ):
         """Observes common events for all Orchestrator charms."""
         super().__init__(charm, "orc8r-base")
@@ -163,7 +163,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()


### PR DESCRIPTION
# Description

Bumps orc8r base library. This will address a [bug](https://github.com/canonical/charmed-magma/issues/22) where some charms would go to maintenancestatus after pods get restarted.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
