### PR TITLE
Remove wait-on-check-action

### DIFF
--- a/.github/workflows/accessd.yml
+++ b/.github/workflows/accessd.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-accessd-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-accessd-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-analytics-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-analytics-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/baseacct.yml
+++ b/.github/workflows/baseacct.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-base-acct-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-base-acct-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/bootstrapper.yml
+++ b/.github/workflows/bootstrapper.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-bootstrapper-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-bootstrapper-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/certifier.yml
+++ b/.github/workflows/certifier.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-certifier-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-certifier-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit
@@ -40,6 +42,8 @@ jobs:
 
   orc8r-certifier-libs-charmhub-upload:
     name: Libs upload
+    needs:
+      - orc8r-certifier-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-libs.yml
     secrets: inherit

--- a/.github/workflows/configurator.yml
+++ b/.github/workflows/configurator.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-configurator-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-configurator-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/ctraced.yml
+++ b/.github/workflows/ctraced.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-ctraced-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-ctraced-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/device.yml
+++ b/.github/workflows/device.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-device-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-device-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/directoryd.yml
+++ b/.github/workflows/directoryd.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-directoryd-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-directoryd-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-dispatcher-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-dispatcher-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/eventd.yml
+++ b/.github/workflows/eventd.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-eventd-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-eventd-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/feg.yml
+++ b/.github/workflows/feg.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-feg-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-feg-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/fegrelay.yml
+++ b/.github/workflows/fegrelay.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-feg-relay-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-feg-relay-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/ha.yml
+++ b/.github/workflows/ha.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-ha-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-ha-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-health-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-health-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/lte.yml
+++ b/.github/workflows/lte.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-lte-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-lte-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/metricsd.yml
+++ b/.github/workflows/metricsd.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-metricsd-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-metricsd-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-nginx-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-nginx-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/nms-magmalte.yml
+++ b/.github/workflows/nms-magmalte.yml
@@ -32,6 +32,8 @@ jobs:
 
   nms-magmalte-charmhub-upload:
     name: Charm upload
+    needs:
+      - nms-magmalte-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/nms-nginx-proxy.yml
+++ b/.github/workflows/nms-nginx-proxy.yml
@@ -32,6 +32,8 @@ jobs:
 
   nms-nginx-proxy-charmhub-upload:
     name: Charm upload
+    needs:
+      - nms-nginx-proxy-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/obsidian.yml
+++ b/.github/workflows/obsidian.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-obsidian-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-obsidian-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-orchestrator-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-orchestrator-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/policydb.yml
+++ b/.github/workflows/policydb.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-policydb-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-policydb-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/service.registry.yml
+++ b/.github/workflows/service.registry.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-service-registry-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-service-registry-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/smsd.yml
+++ b/.github/workflows/smsd.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-smsd-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-smsd-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/state.yml
+++ b/.github/workflows/state.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-state-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-state-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/streamer.yml
+++ b/.github/workflows/streamer.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-streamer-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-streamer-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/subscriberdb.cache.yml
+++ b/.github/workflows/subscriberdb.cache.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-subscriberdb-cache-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-subscriberdb-cache-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/subscriberdb.yml
+++ b/.github/workflows/subscriberdb.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-subscriberdb-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-subscriberdb-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/tenants.yml
+++ b/.github/workflows/tenants.yml
@@ -32,6 +32,8 @@ jobs:
 
   orc8r-tenants-charmhub-upload:
     name: Charm upload
+    needs:
+      - orc8r-tenants-integration-test
     if: github.ref_name == 'main'
     uses: ./.github/workflows/upload-charm.yml
     secrets: inherit

--- a/.github/workflows/upload-charm.yml
+++ b/.github/workflows/upload-charm.yml
@@ -22,14 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Wait for integration tests to succeed
-        uses: lewagon/wait-on-check-action@v1.1.2
-        with:
-          ref: main
-          check-name: "Integration tests / integration-tests"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 60
-
       - name: Check libraries
         uses: canonical/charming-actions/check-libraries@2.2.2
         with:

--- a/.github/workflows/upload-libs.yml
+++ b/.github/workflows/upload-libs.yml
@@ -17,14 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Wait for integration tests to succeed
-        uses: lewagon/wait-on-check-action@v1.1.2
-        with:
-          ref: main
-          check-name: "Integration tests / integration-tests"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 60
-
       - name: Check libraries
         uses: canonical/charming-actions/check-libraries@2.0.0-rc
         with:


### PR DESCRIPTION
Using `wait-on-check-action` wastes GitHub runner time
![wait](https://user-images.githubusercontent.com/115640263/219679214-9e2fb738-ecac-4f6b-811d-5ed14faeb17f.png)

From: https://github.com/canonical/charmed-magma-orchestrator/actions/runs/4202800608/jobs/7291411955


The `canonical organization` is currently reaching the maximum concurrent GitHub runner limit: https://chat.canonical.com/canonical/pl/p7qq3g4se7brjchzszyoiqfxqr