### PR TITLE
Doesn't force choice of channel to support more complex channels (main)

### DIFF
--- a/orc8r-bundle/render_bundle.py
+++ b/orc8r-bundle/render_bundle.py
@@ -42,7 +42,6 @@ def parse_args() -> Tuple[str, str, bool, str]:
         "--channel",
         type=str,
         help="channel for the charms in the bundle",
-        choices=["edge", "beta", "candidate", "stable"],
         required=False,
     )
     bundle_args, _ = parser.parse_known_args()


### PR DESCRIPTION
# Description

Doesn't force choice of channel to support more complex channels (ex. 1.6/stable)

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
