### PR TITLE
Removes `1.6/` prefix from bundle.yaml.j2

### DIFF
--- a/orc8r-bundle/bundle.yaml.j2
+++ b/orc8r-bundle/bundle.yaml.j2
@@ -22,7 +22,7 @@ applications:
       magma-nms-magmalte-image: linuxfoundation.jfrog.io/magma-docker/magmalte:1.6.0
     {%- else %}
     charm: magma-nms-magmalte
-    channel: 1.6/{{ channel|default("stable") }}
+    channel: {{ channel|default("stable") }}
     {%- endif %}
     scale: 1
     trust: true
@@ -33,7 +33,7 @@ applications:
       magma-nms-nginx-proxy-image: ghcr.io/canonical/nginx:1.23.3
     {%- else %}
     charm: magma-nms-nginx-proxy
-    channel: 1.6/{{ channel|default("stable") }}
+    channel: {{ channel|default("stable") }}
     {%- endif %}
     scale: 1
     trust: true
@@ -44,7 +44,7 @@ applications:
       magma-orc8r-accessd-image: linuxfoundation.jfrog.io/magma-docker/controller:1.6.0
     {%- else %}
     charm: magma-orc8r-accessd
-    channel: 1.6/{{ channel|default("stable") }}
+    channel: {{ channel|default("stable") }}
     {%- endif %}
     scale: 1
     trust: true


### PR DESCRIPTION
# Description

Removes `1.6/` prefix from bundle.yaml.j2

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
