### PR TITLE
Telco 309 upgrade integration tests proposal

### DIFF
--- a/orc8r-bootstrapper-operator/tests/integration/test_integration.py
+++ b/orc8r-bootstrapper-operator/tests/integration/test_integration.py
@@ -31,9 +31,8 @@ class TestOrc8rBootstrapper:
 
     @staticmethod
     def _find_charm(charm_dir: str, charm_file_name: str) -> Optional[str]:
-        if path := Path(charm_dir).rglob(charm_file_name):
-            return str(path[0])  # type: ignore[index]
-        return None
+        path = Path(charm_dir).rglob(charm_file_name)
+        return str(next(path, None))
 
     @staticmethod
     async def _deploy_postgresql(ops_test):

--- a/orc8r-tenants-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/orc8r-tenants-operator/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -55,7 +55,7 @@ provides:
 """
 
 import logging
-from typing import Union
+from typing import Optional, Union
 
 import ops.lib
 import psycopg2  # type: ignore[import]
@@ -64,6 +64,7 @@ from ops.charm import (
     PebbleReadyEvent,
     RelationBrokenEvent,
     RelationJoinedEvent,
+    UpgradeCharmEvent,
 )
 from ops.framework import Object
 from ops.model import (
@@ -118,7 +119,8 @@ class Orc8rBase(Object):
         relation_joined_event = getattr(
             self.charm.on, f"{provided_relation_name_with_underscores}_relation_joined"
         )
-        self.framework.observe(pebble_ready_event, self._on_magma_orc8r_pebble_ready)
+        self.framework.observe(pebble_ready_event, self._configure_workload)
+        self.framework.observe(self.charm.on.upgrade_charm, self._configure_workload)
 
         if additional_environment_variables:
             self.additional_environment_variables = additional_environment_variables
@@ -134,14 +136,12 @@ class Orc8rBase(Object):
         )
         self.framework.observe(relation_joined_event, self._on_relation_joined)
 
-    @property
-    def _db_relation_created(self) -> bool:
-        """Checks whether required relations are ready."""
-        if not self.model.get_relation("db"):
-            return False
-        return True
+    def _configure_workload(self, event: Union[PebbleReadyEvent, UpgradeCharmEvent]) -> None:
+        """If database relation is ready, configures workload.
 
-    def _on_magma_orc8r_pebble_ready(self, event: Union[PebbleReadyEvent, RelationJoinedEvent]):
+        Args:
+            event: Juju event (PebbleReadyEvent or UpgradeCharmEvent)
+        """
         if not self._db_relation_created:
             self.charm.unit.status = BlockedStatus("Waiting for db relation to be created")
             event.defer()
@@ -152,11 +152,54 @@ class Orc8rBase(Object):
             return
         self._configure_pebble(event)
 
-    def _configure_pebble(self, event: Union[PebbleReadyEvent, RelationJoinedEvent]):
-        """Adds layer to pebble config if the proposed config is different from the current one."""
+    def _on_relation_joined(self, event: RelationJoinedEvent) -> None:
+        """Triggered whenever a requirer charm joins the relation provided this charm.
+
+        When requirer charm joins the relation, the provider charm sets its workload service
+        status in the relation data bag. This allows the requirer charm to know if its
+        dependency is ready or not.
+
+        Args:
+            event: Juju event (RelationJoinedEvent)
+        """
+        if not self.charm.unit.is_leader():
+            return
+        self._update_relation_active_status(
+            relation=event.relation, is_active=self._service_is_running
+        )
+
+    def _on_database_relation_joined(self, event: RelationJoinedEvent) -> None:
+        """Event handler for database relation change.
+
+        - Sets the event.database field on the database joined event.
+        - Required because setting the database name is only possible
+          from inside the event handler per https://github.com/canonical/ops-lib-pgsql/issues/2
+        - Sets our database parameters based on what was provided
+          in the relation event.
+
+        Args:
+            event: Juju event (RelationJoinedEvent)
+        """
+        if self.charm.unit.is_leader():
+            event.database = self.DB_NAME  # type: ignore[attr-defined]
+
+    def _on_database_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Event handler for database relation broken.
+
+        Args:
+            event (RelationJoinedEvent): Juju event
+        """
+        self.charm.unit.status = BlockedStatus("Waiting for db relation to be created")
+
+    def _configure_pebble(self, event: Union[PebbleReadyEvent, UpgradeCharmEvent]) -> None:
+        """Adds layer to pebble config if the proposed config is different from the current one.
+
+        Args:
+            event: Juju event (PebbleReadyEvent or RelationJoinedEvent)
+        """
         if self.container.can_connect():
             self.charm.unit.status = MaintenanceStatus("Configuring pod")
-            pebble_layer = self._pebble_layer()
+            pebble_layer = self._pebble_layer
             plan = self.container.get_plan()
             if plan.services != pebble_layer.services:
                 self.container.add_layer(self.container_name, pebble_layer, combine=True)
@@ -168,52 +211,25 @@ class Orc8rBase(Object):
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()
 
-    def _pebble_layer(self) -> Layer:
-        """Returns pebble layer for the charm."""
-        return Layer(
-            {
-                "summary": f"{self.service_name} layer",
-                "description": f"pebble config layer for {self.service_name}",
-                "services": {
-                    self.service_name: {
-                        "override": "replace",
-                        "summary": self.service_name,
-                        "startup": "enabled",
-                        "command": self.startup_command,
-                        "environment": self._environment_variables,
-                    }
-                },
-            }
-        )
-
-    def _on_database_relation_joined(self, event: RelationJoinedEvent):
-        """Event handler for database relation change.
-
-        - Sets the event.database field on the database joined event.
-        - Required because setting the database name is only possible
-          from inside the event handler per https://github.com/canonical/ops-lib-pgsql/issues/2
-        - Sets our database parameters based on what was provided
-          in the relation event.
-        """
-        if self.charm.unit.is_leader():
-            event.database = self.DB_NAME  # type: ignore[attr-defined]
-
-    def _on_database_relation_broken(self, event: RelationBrokenEvent):
-        """Event handler for database relation broken.
-
-        Args:
-            event (RelationJoinedEvent): Juju event
-        Returns:
-            None
-        """
-        self.charm.unit.status = BlockedStatus("Waiting for db relation to be created")
+    def _update_relations(self) -> None:
+        """Updates relation provided by the charm with the workload service status."""
+        if not self.charm.unit.is_leader():
+            return
+        relations = self.charm.model.relations[self.charm.meta.name]
+        for relation in relations:
+            self._update_relation_active_status(
+                relation=relation, is_active=self._service_is_running
+            )
 
     @property
     def _db_relation_ready(self) -> bool:
         """Validates that database relation is ready.
 
         Validates that there is a relation, credentials have been passed and the database can be
-         connected to.
+        connected to.
+
+        Returns:
+            bool: Whether a database relation is ready
         """
         db_connection_string = self._get_db_connection_string
         if not db_connection_string:
@@ -230,13 +246,79 @@ class Orc8rBase(Object):
             return False
 
     @property
-    def _get_db_connection_string(self):
-        """Returns DB connection string provided by the DB relation."""
+    def _get_db_connection_string(self) -> Optional[ConnectionString]:
+        """Returns DB connection string provided by the DB relation.
+
+        Returns:
+            ConnectionString: DB connection string
+        """
         try:
             db_relation = self.model.get_relation("db")
             return ConnectionString(db_relation.data[db_relation.app]["master"])  # type: ignore[index, union-attr]  # noqa: E501
         except (AttributeError, KeyError):
             return None
+
+    @property
+    def _db_relation_created(self) -> bool:
+        """Checks whether required relations are ready.
+
+        Returns:
+            bool: Whether required relations are ready
+        """
+        if not self.model.get_relation("db"):
+            return False
+        return True
+
+    @property
+    def _service_is_running(self) -> bool:
+        """Retrieves the workload service and returns whether it is running.
+
+        Returns:
+            bool: Whether service is running
+        """
+        if self.container.can_connect():
+            try:
+                self.container.get_service(self.service_name)
+                return True
+            except ModelError:
+                pass
+        return False
+
+    def _update_relation_active_status(self, relation: Relation, is_active: bool) -> None:
+        """Updates service status in the relation data bag.
+
+        Args:
+            relation: Juju Relation object to update
+            is_active: Workload service status
+        """
+        relation.data[self.charm.unit].update(
+            {
+                "active": str(is_active),
+            }
+        )
+
+    @property
+    def _pebble_layer(self) -> Layer:
+        """Returns pebble layer for the charm.
+
+        Returns:
+            Layer: Pebble Layer
+        """
+        return Layer(
+            {
+                "summary": f"{self.service_name} layer",
+                "description": f"pebble config layer for {self.service_name}",
+                "services": {
+                    self.service_name: {
+                        "override": "replace",
+                        "summary": self.service_name,
+                        "startup": "enabled",
+                        "command": self.startup_command,
+                        "environment": self._environment_variables,
+                    }
+                },
+            }
+        )
 
     @property
     def _environment_variables(self):
@@ -249,7 +331,7 @@ class Orc8rBase(Object):
         environment_variables.update(self.additional_environment_variables)
         environment_variables.update(default_environment_variables)
         sql_environment_variables = {
-            "DATABASE_SOURCE": f"dbname={self.DB_NAME} "
+            "DATABASE_SOURCE": f"dbname={self.DB_NAME} "  # type: ignore[union-attr]
             f"user={self._get_db_connection_string.user} "
             f"password={self._get_db_connection_string.password} "
             f"host={self._get_db_connection_string.host} "
@@ -263,38 +345,9 @@ class Orc8rBase(Object):
 
     @property
     def namespace(self) -> str:
-        """Returns Kubernetes namespace."""
+        """Returns Kubernetes namespace.
+
+        Returns:
+            str: Kubernetes namespace
+        """
         return self.charm.model.name
-
-    def _update_relations(self):
-        if not self.charm.unit.is_leader():
-            return
-        relations = self.charm.model.relations[self.charm.meta.name]
-        for relation in relations:
-            self._update_relation_active_status(
-                relation=relation, is_active=self._service_is_running
-            )
-
-    def _on_relation_joined(self, event: RelationJoinedEvent):
-        if not self.charm.unit.is_leader():
-            return
-        self._update_relation_active_status(
-            relation=event.relation, is_active=self._service_is_running
-        )
-
-    @property
-    def _service_is_running(self) -> bool:
-        if self.container.can_connect():
-            try:
-                self.container.get_service(self.service_name)
-                return True
-            except ModelError:
-                pass
-        return False
-
-    def _update_relation_active_status(self, relation: Relation, is_active: bool):
-        relation.data[self.charm.unit].update(
-            {
-                "active": str(is_active),
-            }
-        )

--- a/orc8r-tenants-operator/tests/integration/test_upgrade.py
+++ b/orc8r-tenants-operator/tests/integration/test_upgrade.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+
+logger = logging.getLogger(__name__)
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+APPLICATION_NAME = "orc8r-tenants"
+CHARM_NAME = "magma-orc8r-tenants"
+CHARM_RESOURCES = {
+    f"{CHARM_NAME}-image": METADATA["resources"][f"{CHARM_NAME}-image"]["upstream-source"],
+}
+
+
+class TestOrc8rTenants:
+    @pytest.fixture(scope="module")
+    @pytest.mark.abort_on_fail
+    async def setup(self, ops_test):
+        await self._deploy_postgresql(ops_test)
+        await self._deploy_orc8r_tenants_from_latest_stable_channel(ops_test)
+        await self._relate_orc8r_tenants_and_postgresql(ops_test)
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=600)
+
+    @pytest.mark.abort_on_fail
+    async def test_workload_container_image_comes_from_charmhub(self, ops_test, setup):
+        image = await self._get_container_image(ops_test, APPLICATION_NAME)
+        assert "registry.jujucharms.com" in image
+
+    @pytest.fixture(scope="module")
+    @pytest.mark.abort_on_fail
+    async def build_and_refresh(self, ops_test, setup):
+        charm = await ops_test.build_charm(".")
+
+        await ops_test.model.applications[APPLICATION_NAME].refresh(
+            path=charm, resources=CHARM_RESOURCES
+        )
+
+    @pytest.mark.abort_on_fail
+    async def test_wait_for_active_idle_after_refresh(self, ops_test, setup, build_and_refresh):
+        await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=180)
+
+    @pytest.mark.abort_on_fail
+    async def test_workload_container_image_updated_with_metadata_oci_image(
+        self, ops_test, setup, build_and_refresh
+    ):
+        image = await self._get_container_image(ops_test, APPLICATION_NAME)
+        assert image == CHARM_RESOURCES[f"{CHARM_NAME}-image"]
+
+    @staticmethod
+    async def _deploy_postgresql(ops_test):
+        await ops_test.model.deploy("postgresql-k8s", application_name="postgresql-k8s")
+
+    @staticmethod
+    async def _deploy_orc8r_tenants_from_latest_stable_channel(ops_test):
+        await ops_test.model.deploy(
+            "magma-orc8r-tenants",
+            application_name="orc8r-tenants",
+            channel="latest/stable",
+            trust=True,
+        )
+
+    @staticmethod
+    async def _relate_orc8r_tenants_and_postgresql(ops_test):
+        await ops_test.model.add_relation(
+            relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
+        )
+
+    @staticmethod
+    async def _get_container_image(ops_test, app_name):
+        cmd = [
+            "sg",
+            "microk8s",
+            "-c",
+            " ".join(
+                [
+                    "microk8s.kubectl",
+                    "get",
+                    "pods",
+                    "-n",
+                    ops_test.model_name,
+                    "-o",
+                    "jsonpath='{.items[*].spec.containers[1].image}'",
+                    "-l",
+                    f"app.kubernetes.io/name={app_name}",
+                ]
+            )
+        ]
+        _, image, __ = await ops_test.run(*cmd)
+        return image


### PR DESCRIPTION
# Description

Drafts itests for the upgrade procedure.

Context:
The approach used in this draft leverages the fact, that the charm installed directly from charmhub uses a container image uploaded to charmhub's container registry, whereas charm installed from a local file uses a container image specified in the `metadata.yaml`. This fact can be used to check whether the charm under test was actually upgraded.
The test scenario deploys the charm from charmhub and validates that the workload container's image actually comes from charmhub. Next, charm under test is built from sources and upgrade/refresh is triggered. Once operation is completed (Juju application is in active/idle again), test validates that the workload container's image has changed to the one specified in charm's `metadata.yaml`.
The advantage of this approach is that it'll work across all the future releases. 
The disadvantage is that it's just a super basic test, which definitely isn't enough to ensure that the upgrade works as expected.

Alternatively we could be testing specific changes between the releases (like configs, startup commands, ports, etc.), but that approach would require maintenance between the releases.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
