### PR TITLE
Use nginx rock for orc8r-nginx service

### DIFF
--- a/orc8r-nginx-operator/README.md
+++ b/orc8r-nginx-operator/README.md
@@ -2,8 +2,8 @@
 
 ## Description
 
-magma-orc8r-nginx deploys an **nginx** web server that proxies communication between NMS and 
-Orchestrator. Visit [Magma Architecture Overview](https://docs.magmacore.org/docs/orc8r/architecture_overview) to 
+magma-orc8r-nginx deploys an **nginx** web server that proxies communication between NMS and
+Orchestrator. Visit [Magma Architecture Overview](https://docs.magmacore.org/docs/orc8r/architecture_overview) to
 learn more.
 
 This charm is part of [Charmed Magma Orchestrator](https://charmhub.io/magma-orc8r/) and should
@@ -35,5 +35,4 @@ juju relate orc8r-nginx:cert-controller orc8r-certifier:cert-controller
 
 ## OCI Images
 
-Default: linuxfoundation.jfrog.io/magma-docker/nginx:1.8.0
-
+Default: ghcr.io/canonical/nginx:1.23.3

--- a/orc8r-nginx-operator/charmcraft.yaml
+++ b/orc8r-nginx-operator/charmcraft.yaml
@@ -6,3 +6,7 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "22.04"
+
+parts:
+  charm:
+    charm-python-packages: [setuptools]

--- a/orc8r-nginx-operator/metadata.yaml
+++ b/orc8r-nginx-operator/metadata.yaml
@@ -20,8 +20,8 @@ containers:
 resources:
   magma-orc8r-nginx-image:
     type: oci-image
-    description: OCI image for magma-orc8r-nginx (linuxfoundation.jfrog.io/magma-docker/nginx:1.8.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/nginx:1.8.0
+    description: OCI image for magma-orc8r-nginx
+    upstream-source: ghcr.io/canonical/nginx:1.23.3
 
 storage:
   certs:

--- a/orc8r-nginx-operator/requirements.txt
+++ b/orc8r-nginx-operator/requirements.txt
@@ -1,3 +1,4 @@
+Jinja2
 jsonschema
 ops
 lightkube

--- a/orc8r-nginx-operator/src/charm.py
+++ b/orc8r-nginx-operator/src/charm.py
@@ -59,6 +59,9 @@ class MagmaOrc8rNginxCharm(CharmBase):
     CONFIG_PATH = "/etc/nginx"
     REQUIRED_RELATIONS = ["cert-certifier", "cert-controller"]
     REQUIRED_MAGMA_SERVICES_RELATIONS = ["magma-orc8r-bootstrapper", "magma-orc8r-obsidian"]
+    CLIENTCERT_PORT = 8443
+    OPEN_PORT = 8444
+    API_PORT = 9443
 
     def __init__(self, *args):
         """Initializes all event that need to be observed."""
@@ -73,9 +76,9 @@ class MagmaOrc8rNginxCharm(CharmBase):
             charm=self,
             ports=[
                 ServicePort(name="health", port=80),
-                ServicePort(name="clientcert", port=8443),
-                ServicePort(name="open", port=8444),
-                ServicePort(name="api", port=443, targetPort=9443),
+                ServicePort(name="clientcert", port=self.CLIENTCERT_PORT),
+                ServicePort(name="open", port=self.OPEN_PORT),
+                ServicePort(name="api", port=443, targetPort=self.API_PORT),
             ],
             service_type="LoadBalancer",
             service_name="orc8r-nginx-proxy",
@@ -327,6 +330,9 @@ class MagmaOrc8rNginxCharm(CharmBase):
             "backend": f"{self._namespace}.svc.cluster.local",
             "controller_hostname": f"controller.{domain_name}",
             "resolver": "kube-dns.kube-system.svc.cluster.local valid=10s",
+            "open_port": self.OPEN_PORT,
+            "clientcert_port": self.CLIENTCERT_PORT,
+            "api_port": self.API_PORT,
         }
         env = Environment(loader=FileSystemLoader(pathlib.Path(__file__).parent), autoescape=False)
         template = env.get_template("nginx.conf.j2")
@@ -456,12 +462,12 @@ class MagmaOrc8rNginxCharm(CharmBase):
                         ServicePort(
                             name="open-legacy",
                             port=443,
-                            targetPort=8444,
+                            targetPort=self.OPEN_PORT,
                         ),
                         ServicePort(
                             name="open",
-                            port=8444,
-                            targetPort=8444,
+                            port=self.OPEN_PORT,
+                            targetPort=self.OPEN_PORT,
                         ),
                     ],
                     type="LoadBalancer",
@@ -489,12 +495,12 @@ class MagmaOrc8rNginxCharm(CharmBase):
                         ServicePort(
                             name="clientcert-legacy",
                             port=443,
-                            targetPort=8443,
+                            targetPort=self.CLIENTCERT_PORT,
                         ),
                         ServicePort(
                             name="clientcert",
-                            port=8443,
-                            targetPort=8443,
+                            port=self.CLIENTCERT_PORT,
+                            targetPort=self.CLIENTCERT_PORT,
                         ),
                     ],
                     type="LoadBalancer",

--- a/orc8r-nginx-operator/src/nginx.conf.j2
+++ b/orc8r-nginx-operator/src/nginx.conf.j2
@@ -1,0 +1,141 @@
+user root;
+worker_processes auto;
+pid /run/nginx.pid;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  # Custom JSON-formatted log
+  log_format json_custom escape=json
+    '{'
+      '"nginx.time_local": "$time_local",'
+      '"nginx.remote_addr": "$remote_addr",'
+      '"nginx.request": "$request",'
+      '"nginx.request_method": "$request_method",'
+      '"nginx.request_uri": "$request_uri",'
+      '"nginx.status": $status,'
+      '"nginx.body_bytes_sent": $body_bytes_sent,'
+      '"nginx.request_length": $request_length,'
+      '"nginx.request_time": $request_time,'
+      '"nginx.server_name": "$server_name",'
+      '"nginx.client_serial": "$ssl_client_serial",'
+      '"nginx.client_cn": "$ssl_client_s_dn_cn"'
+    '}';
+
+  ## Fix - [emerg]: could not build the map_hash, you should increase
+  map_hash_bucket_size 64;
+
+  # See https://kubernetes.github.io/ingress-nginx/examples/grpc/#notes-on-using-responserequest-streams
+  grpc_send_timeout 1200s;
+  grpc_read_timeout 1200s;
+  client_body_timeout 1200s;
+
+  # Use a regex to pull the client cert common name out of the DN
+  # The DN will look something like "CN=foobar,OU=,O=,C=US"
+  map $ssl_client_s_dn $ssl_client_s_dn_cn {
+    default "";
+    ~CN=(?<CN>[^/,]+) $CN;
+  }
+
+  # Server block for controller
+  server {
+    listen              8443 ssl http2;
+    server_name         ~^(?<srv>.+)-{{ controller_hostname }}$;
+
+    error_log  /var/log/nginx/error.log info;
+    access_log /var/log/nginx/access.log json_custom;
+
+    ssl_certificate     {{ base_certs_path }}/controller.crt;
+    ssl_certificate_key {{ base_certs_path }}/controller.key;
+    ssl_verify_client on;
+    ssl_client_certificate {{ base_certs_path }}/certifier.pem;
+
+    # Max allowed size for client requests body
+    client_max_body_size 50M;
+
+    location / {
+      resolver {{ resolver }};
+
+      # certifier is internal only service
+      if ($srv = "certifier") {
+        return 403;
+      }
+      # Helm services don't allow for underscores. Magma convention is
+      # to use underscores in service names, so convert any hyphens in the
+      # k8s service name.
+      set $k8s_svc $srv;
+      if ($k8s_svc ~* "(\w+)[_](\w+)") {
+        set $k8s_svc "$1-$2";
+      }
+      grpc_pass grpc://orc8r-$k8s_svc.{{ backend }}:9180;
+      grpc_set_header Host $srv-orc8r-$k8s_svc.{{ backend }}:9180;
+
+      grpc_set_header x-magma-client-cert-cn $ssl_client_s_dn_cn;
+      grpc_set_header x-magma-client-cert-serial $ssl_client_serial;
+    }
+  }
+
+  # Server block for bootstrapper and any other non-clientcert services
+  server {
+    listen 8444 ssl http2;
+    server_name         ~^(?<srv>.+)-{{ controller_hostname }}$;
+
+    error_log  /var/log/nginx/error.log info;
+    access_log /var/log/nginx/access.log json_custom;
+
+    ssl_certificate     {{ base_certs_path }}/controller.crt;
+    ssl_certificate_key {{ base_certs_path }}/controller.key;
+
+    location / {
+      resolver {{ resolver }};
+
+      # Convert underscore to hypen in service name
+      if ($srv ~* "(\w+)[_](\w+)") {
+        set $srv "$1-$2";
+      }
+      grpc_pass grpc://orc8r-bootstrapper.{{ backend }}:9180;
+    }
+  }
+
+  # Catch-all server block for REST HTTP/1.1 requests from browsers
+  server {
+    listen 9443 ssl default_server;
+    server_name _;
+
+    # Automatically upgrade HTTP requests to HTTPS
+    # Ref: https://ma.ttias.be/force-redirect-http-https-custom-port-nginx/#forcing-https-redirects-on-non-standard-ports
+    error_page 497 https://$host:9443$request_uri;
+
+    error_log  /var/log/nginx/error.log info;
+    access_log /var/log/nginx/access.log json_custom;
+
+    ssl_certificate     {{ base_certs_path }}/controller.crt;
+    ssl_certificate_key {{ base_certs_path }}/controller.key;
+    ssl_verify_client on;
+    ssl_client_certificate {{ base_certs_path }}/certifier.pem;
+
+    # Max allowed size for client requests body
+    client_max_body_size 50M;
+
+    location / {
+      resolver {{ resolver }};
+
+      proxy_pass http://orc8r-obsidian.{{ backend }}:8080;
+
+      proxy_set_header x-magma-client-cert-cn $ssl_client_s_dn_cn;
+      proxy_set_header x-magma-client-cert-serial $ssl_client_serial;
+    }
+  }
+
+  # Open port 80 for k8s liveness check. Just returns a 200.
+  server {
+    listen 80;
+    server_name _;
+
+    location / {
+      return 200;
+    }
+  }
+}

--- a/orc8r-nginx-operator/src/nginx.conf.j2
+++ b/orc8r-nginx-operator/src/nginx.conf.j2
@@ -41,7 +41,7 @@ http {
 
   # Server block for controller
   server {
-    listen              8443 ssl http2;
+    listen              {{ clientcert_port }} ssl http2;
     server_name         ~^(?<srv>.+)-{{ controller_hostname }}$;
 
     error_log  /var/log/nginx/error.log info;
@@ -79,7 +79,7 @@ http {
 
   # Server block for bootstrapper and any other non-clientcert services
   server {
-    listen 8444 ssl http2;
+    listen {{ open_port }} ssl http2;
     server_name         ~^(?<srv>.+)-{{ controller_hostname }}$;
 
     error_log  /var/log/nginx/error.log info;
@@ -101,7 +101,7 @@ http {
 
   # Catch-all server block for REST HTTP/1.1 requests from browsers
   server {
-    listen 9443 ssl default_server;
+    listen {{ api_port }} ssl default_server;
     server_name _;
 
     # Automatically upgrade HTTP requests to HTTPS

--- a/orc8r-nginx-operator/tests/unit/nginx.conf
+++ b/orc8r-nginx-operator/tests/unit/nginx.conf
@@ -1,0 +1,141 @@
+user root;
+worker_processes auto;
+pid /run/nginx.pid;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  # Custom JSON-formatted log
+  log_format json_custom escape=json
+    '{'
+      '"nginx.time_local": "$time_local",'
+      '"nginx.remote_addr": "$remote_addr",'
+      '"nginx.request": "$request",'
+      '"nginx.request_method": "$request_method",'
+      '"nginx.request_uri": "$request_uri",'
+      '"nginx.status": $status,'
+      '"nginx.body_bytes_sent": $body_bytes_sent,'
+      '"nginx.request_length": $request_length,'
+      '"nginx.request_time": $request_time,'
+      '"nginx.server_name": "$server_name",'
+      '"nginx.client_serial": "$ssl_client_serial",'
+      '"nginx.client_cn": "$ssl_client_s_dn_cn"'
+    '}';
+
+  ## Fix - [emerg]: could not build the map_hash, you should increase
+  map_hash_bucket_size 64;
+
+  # See https://kubernetes.github.io/ingress-nginx/examples/grpc/#notes-on-using-responserequest-streams
+  grpc_send_timeout 1200s;
+  grpc_read_timeout 1200s;
+  client_body_timeout 1200s;
+
+  # Use a regex to pull the client cert common name out of the DN
+  # The DN will look something like "CN=foobar,OU=,O=,C=US"
+  map $ssl_client_s_dn $ssl_client_s_dn_cn {
+    default "";
+    ~CN=(?<CN>[^/,]+) $CN;
+  }
+
+  # Server block for controller
+  server {
+    listen              8443 ssl http2;
+    server_name         ~^(?<srv>.+)-controller.whateverdomain.com$;
+
+    error_log  /var/log/nginx/error.log info;
+    access_log /var/log/nginx/access.log json_custom;
+
+    ssl_certificate     /var/opt/magma/certs/controller.crt;
+    ssl_certificate_key /var/opt/magma/certs/controller.key;
+    ssl_verify_client on;
+    ssl_client_certificate /var/opt/magma/certs/certifier.pem;
+
+    # Max allowed size for client requests body
+    client_max_body_size 50M;
+
+    location / {
+      resolver kube-dns.kube-system.svc.cluster.local valid=10s;
+
+      # certifier is internal only service
+      if ($srv = "certifier") {
+        return 403;
+      }
+      # Helm services don't allow for underscores. Magma convention is
+      # to use underscores in service names, so convert any hyphens in the
+      # k8s service name.
+      set $k8s_svc $srv;
+      if ($k8s_svc ~* "(\w+)[_](\w+)") {
+        set $k8s_svc "$1-$2";
+      }
+      grpc_pass grpc://orc8r-$k8s_svc.whatever.svc.cluster.local:9180;
+      grpc_set_header Host $srv-orc8r-$k8s_svc.whatever.svc.cluster.local:9180;
+
+      grpc_set_header x-magma-client-cert-cn $ssl_client_s_dn_cn;
+      grpc_set_header x-magma-client-cert-serial $ssl_client_serial;
+    }
+  }
+
+  # Server block for bootstrapper and any other non-clientcert services
+  server {
+    listen 8444 ssl http2;
+    server_name         ~^(?<srv>.+)-controller.whateverdomain.com$;
+
+    error_log  /var/log/nginx/error.log info;
+    access_log /var/log/nginx/access.log json_custom;
+
+    ssl_certificate     /var/opt/magma/certs/controller.crt;
+    ssl_certificate_key /var/opt/magma/certs/controller.key;
+
+    location / {
+      resolver kube-dns.kube-system.svc.cluster.local valid=10s;
+
+      # Convert underscore to hypen in service name
+      if ($srv ~* "(\w+)[_](\w+)") {
+        set $srv "$1-$2";
+      }
+      grpc_pass grpc://orc8r-bootstrapper.whatever.svc.cluster.local:9180;
+    }
+  }
+
+  # Catch-all server block for REST HTTP/1.1 requests from browsers
+  server {
+    listen 9443 ssl default_server;
+    server_name _;
+
+    # Automatically upgrade HTTP requests to HTTPS
+    # Ref: https://ma.ttias.be/force-redirect-http-https-custom-port-nginx/#forcing-https-redirects-on-non-standard-ports
+    error_page 497 https://$host:9443$request_uri;
+
+    error_log  /var/log/nginx/error.log info;
+    access_log /var/log/nginx/access.log json_custom;
+
+    ssl_certificate     /var/opt/magma/certs/controller.crt;
+    ssl_certificate_key /var/opt/magma/certs/controller.key;
+    ssl_verify_client on;
+    ssl_client_certificate /var/opt/magma/certs/certifier.pem;
+
+    # Max allowed size for client requests body
+    client_max_body_size 50M;
+
+    location / {
+      resolver kube-dns.kube-system.svc.cluster.local valid=10s;
+
+      proxy_pass http://orc8r-obsidian.whatever.svc.cluster.local:8080;
+
+      proxy_set_header x-magma-client-cert-cn $ssl_client_s_dn_cn;
+      proxy_set_header x-magma-client-cert-serial $ssl_client_serial;
+    }
+  }
+
+  # Open port 80 for k8s liveness check. Just returns a 200.
+  server {
+    listen 80;
+    server_name _;
+
+    location / {
+      return 200;
+    }
+  }
+}

--- a/orc8r-nginx-operator/tests/unit/test_charm.py
+++ b/orc8r-nginx-operator/tests/unit/test_charm.py
@@ -461,7 +461,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Container.push")
-    def test_given_valid_domain_config_set_when_config_changed_then_nginx_config_file_is_created(
+    def test_given_valid_domain_config_set_when_config_changed_then_nginx_config_file_is_pushed(
         self, patched_push
     ):
         self.harness.set_can_connect(container=self._container, val=True)

--- a/orc8r-nginx-operator/tests/unit/test_orchestator_relation.py
+++ b/orc8r-nginx-operator/tests/unit/test_orchestator_relation.py
@@ -42,7 +42,7 @@ class TestOrchestratorRelation(unittest.TestCase):
             {},
         )
 
-    @patch("ops.model.Container.exec", Mock())
+    @patch("ops.model.Container.exec", new=Mock)
     def test_given_invalid_domain_when_orchestrator_relation_joined_then_charm_goes_to_blocked_status(  # noqa: E501
         self,
     ):
@@ -53,7 +53,7 @@ class TestOrchestratorRelation(unittest.TestCase):
 
         assert self.harness.charm.unit.status == BlockedStatus("Domain config is not valid")
 
-    @patch("ops.model.Container.exec", Mock())
+    @patch("ops.model.Container.exec", new=Mock)
     def test_given_magma_orc8r_nginx_service_not_running_when_orchestrator_relation_joined_then_charm_goes_to_waiting_status(  # noqa: E501
         self,
     ):
@@ -66,8 +66,8 @@ class TestOrchestratorRelation(unittest.TestCase):
             "Waiting for magma-orc8r-nginx service to become active"
         )
 
-    @patch("ops.model.Container.get_service", new=Mock())
-    @patch("ops.model.Container.exec", Mock())
+    @patch("ops.model.Container.get_service", new=Mock)
+    @patch("ops.model.Container.push", new=Mock)
     def test_given_magma_orc8r_nginx_service_active_but_rootca_not_stored_when_orchestrator_relation_joined_then_charm_goes_to_waiting_status(  # noqa: E501
         self,
     ):
@@ -82,8 +82,8 @@ class TestOrchestratorRelation(unittest.TestCase):
         )
 
     @patch("ops.model.Container.exists")
-    @patch("ops.model.Container.get_service", new=Mock())
-    @patch("ops.model.Container.exec", Mock())
+    @patch("ops.model.Container.get_service", new=Mock)
+    @patch("ops.model.Container.push", new=Mock)
     def test_given_magma_orc8r_nginx_service_active_but_certifier_pem_not_stored_when_orchestrator_relation_joined_then_charm_goes_to_waiting_status(  # noqa: E501
         self, patch_exists
     ):
@@ -100,8 +100,8 @@ class TestOrchestratorRelation(unittest.TestCase):
 
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
-    @patch("ops.model.Container.get_service", new=Mock())
-    @patch("ops.model.Container.exec", Mock())
+    @patch("ops.model.Container.get_service", new=Mock)
+    @patch("ops.model.Container.exec", new=Mock)
     def test_given_path_error_when_orchestrator_relation_joined_then_pulling_rootca_from_container_fails_and_charm_goes_to_blocked_status(  # noqa: E501
         self, patched_exists, patched_pull
     ):
@@ -119,8 +119,8 @@ class TestOrchestratorRelation(unittest.TestCase):
 
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
-    @patch("ops.model.Container.get_service", new=Mock())
-    @patch("ops.model.Container.exec", Mock())
+    @patch("ops.model.Container.get_service", new=Mock)
+    @patch("ops.model.Container.exec", new=Mock)
     def test_given_protocol_error_when_pulling_rootca_when_orchestrator_relation_joined_then_pulling_rootca_from_container_fails_and_relevant_message_is_logged(  # noqa: E501
         self, patched_exists, patched_pull
     ):
@@ -138,8 +138,8 @@ class TestOrchestratorRelation(unittest.TestCase):
 
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
-    @patch("ops.model.Container.get_service", new=Mock())
-    @patch("ops.model.Container.exec", Mock())
+    @patch("ops.model.Container.get_service", new=Mock)
+    @patch("ops.model.Container.exec", new=Mock)
     def test_given_all_checks_passed_when_orchestrator_relation_joined_then_relation_data_bag_is_updated(  # noqa: E501
         self, patched_exists, patched_pull
     ):
@@ -160,8 +160,8 @@ class TestOrchestratorRelation(unittest.TestCase):
 
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
-    @patch("ops.model.Container.get_service", new=Mock())
-    @patch("ops.model.Container.exec", Mock())
+    @patch("ops.model.Container.get_service", new=Mock)
+    @patch("ops.model.Container.push", new=Mock)
     def test_given_orchestrator_relation_created_and_orchestrator_details_in_the_relation_data_bag_when_domain_changes_then_relation_data_bag_is_updated(  # noqa: E501
         self, patched_exists, patched_pull
     ):
@@ -195,9 +195,9 @@ class TestOrchestratorRelation(unittest.TestCase):
 
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
-    @patch("ops.model.Container.get_service", new=Mock())
-    @patch("ops.model.Container.exec", Mock())
-    @patch("ops.model.Container.push", Mock())
+    @patch("ops.model.Container.get_service", new=Mock)
+    @patch("ops.model.Container.exec", new=Mock)
+    @patch("ops.model.Container.push", new=Mock)
     def test_given_orchestrator_relation_created_and_orchestrator_details_in_the_relation_data_bag_when_root_ca_certificate_updated_then_relation_data_bag_is_updated(  # noqa: E501
         self, patched_exists, patched_pull
     ):
@@ -234,9 +234,9 @@ class TestOrchestratorRelation(unittest.TestCase):
 
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
-    @patch("ops.model.Container.get_service", new=Mock())
-    @patch("ops.model.Container.exec", Mock())
-    @patch("ops.model.Container.push", Mock())
+    @patch("ops.model.Container.get_service", new=Mock)
+    @patch("ops.model.Container.exec", new=Mock)
+    @patch("ops.model.Container.push", new=Mock)
     def test_given_orchestrator_relation_created_and_orchestrator_details_in_the_relation_data_bag_when_certifier_pem_certificate_updated_then_relation_data_bag_is_updated(  # noqa: E501
         self, patched_exists, patched_pull
     ):


### PR DESCRIPTION
# Description

Use nginx rock for orc8r-nginx service. This also change the generation of the configuration file, as upstream Magma container has a script to generate it from a template already inside the container image.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
