### PR TITLE
Fixes yarn command

### DIFF
--- a/nms-magmalte-operator/src/charm.py
+++ b/nms-magmalte-operator/src/charm.py
@@ -554,7 +554,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
         logger.info("Creating admin user for NMS")
         process = self._container.exec(
             [
-                "/usr/local/bin/yarn",
+                "yarn",
                 "setAdminPassword",
                 organization,
                 email,

--- a/nms-magmalte-operator/tests/unit/test_charm.py
+++ b/nms-magmalte-operator/tests/unit/test_charm.py
@@ -263,7 +263,7 @@ class TestCharm(unittest.TestCase):
         args, _ = mock_exec.call_args
         mock_exec.assert_called_once()
         call_command = [
-            "/usr/local/bin/yarn",
+            "yarn",
             "setAdminPassword",
             "test-org",
             "test@test.test",


### PR DESCRIPTION
# Description

Fixing yarn command location for `setAdminPassword` to work.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
