### PR TITLE
Update workflows to 22.04

### DIFF
--- a/.github/workflows/bundle.upload.edge.yml
+++ b/.github/workflows/bundle.upload.edge.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   orc8r-bundle-charmhub-upload:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint-report:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Install tox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   orchestrator-lint-report:
     name: Lint report
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Install tox
@@ -26,7 +26,7 @@ jobs:
 
   orchestrator-static-analysis:
     name: Static analysis
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Install tox
@@ -41,7 +41,7 @@ jobs:
 
   orchestrator-unit-tests-with-coverage:
     name: Unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Install tox

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   static-analysis:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Install tox

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Install tox

--- a/.github/workflows/upload-charm.yml
+++ b/.github/workflows/upload-charm.yml
@@ -13,7 +13,7 @@ on:
       runner-version:
         required: false
         type: string
-        default: "ubuntu-20.04"
+        default: "ubuntu-22.04"
 
 jobs:
   charmhub-upload:

--- a/.github/workflows/upload-libs.yml
+++ b/.github/workflows/upload-libs.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   libs-charmhub-upload:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Upload ${{ inputs.charm }} libs to charmhub
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# Description

Update workflows to 22.04. This will probably fix the issue with the Upload action not working after updating the charm bases to 22.04.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
