### PR TITLE
Save Juju crashdump as artifacts on integration tests failure

### DIFF
--- a/.github/workflows/integration-tests-self-hosted.yml
+++ b/.github/workflows/integration-tests-self-hosted.yml
@@ -43,6 +43,13 @@ jobs:
             /usr/bin/sudo snap refresh juju --classic --channel=$JUJU_VERSION
           fi
 
+          echo "# Install juju-crashdump"
+          if ! command -v juju-crashdump &> /dev/null; then
+            /usr/bin/sudo snap install juju-crashdump --classic --channel=latest
+          else
+            /usr/bin/sudo snap refresh juju-crashdump --classic --channel=latest
+          fi
+
           echo "# Install charmcraft"
           /usr/bin/sudo snap install charmcraft --classic --channel=latest/stable
 
@@ -73,6 +80,12 @@ jobs:
         with:
           name: charmcraft-logs
           path: /home/ubuntu/.local/state/charmcraft/log/*.log
+      - name: Archive juju crashdump
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: juju-crashdump
+          path: ${{ inputs.charm_dir }}/juju-crashdump-*.tar.xz
 
       - name: Clean up
         if: always()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,6 +23,7 @@ jobs:
           provider: microk8s
           channel: ${{ env.MICROK8S_VERSION }}
           juju-channel: ${{ env.JUJU_VERSION }}
+          juju-crashdump-channel: latest/stable
       - name: Run integration tests
         run: cd ${{ inputs.charm_dir }} && tox -e integration
       - name: Archive charmcraft logs
@@ -31,3 +32,9 @@ jobs:
         with:
           name: charmcraft-logs
           path: /home/runner/.local/state/charmcraft/log/*.log
+      - name: Archive juju crashdump
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: juju-crashdump
+          path: ${{ inputs.charm_dir }}/juju-crashdump-*.tar.xz

--- a/orc8r-bootstrapper-operator/charmcraft.yaml
+++ b/orc8r-bootstrapper-operator/charmcraft.yaml
@@ -14,5 +14,6 @@ parts:
       - libssl-dev
       - rustc
       - cargo
+      - pkg-config
     charm-binary-python-packages:
       - psycopg2-binary

--- a/orc8r-certifier-operator/charmcraft.yaml
+++ b/orc8r-certifier-operator/charmcraft.yaml
@@ -14,6 +14,7 @@ parts:
       - libssl-dev
       - rustc
       - cargo
+      - pkg-config
     charm-binary-python-packages:
       - psycopg2-binary
     charm-python-packages:


### PR DESCRIPTION
# Description

Save Juju crashdump as artifacts on integration tests failure. This will help investigate failures in more details.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
