### PR TITLE
Uses 1.8.0 LTE rock

### DIFF
--- a/orc8r-bundle/bundle.yaml.j2
+++ b/orc8r-bundle/bundle.yaml.j2
@@ -167,7 +167,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-ha_ubuntu-22.04-amd64.charm
     resources:
-      magma-orc8r-ha-image: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+      magma-orc8r-ha-image: ghcr.io/canonical/magma-lte-controller:1.8.0
     {%- else %}
     charm: magma-orc8r-ha
     channel: {{ channel|default("edge") }}
@@ -178,7 +178,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-lte_ubuntu-22.04-amd64.charm
     resources:
-      magma-orc8r-lte-image: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+      magma-orc8r-lte-image: ghcr.io/canonical/magma-lte-controller:1.8.0
     {%- else %}
     charm: magma-orc8r-lte
     channel: {{ channel|default("edge") }}
@@ -235,7 +235,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-policydb_ubuntu-22.04-amd64.charm
     resources:
-      magma-orc8r-policydb-image: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+      magma-orc8r-policydb-image: ghcr.io/canonical/magma-lte-controller:1.8.0
     {%- else %}
     charm: magma-orc8r-policydb
     channel: {{ channel|default("edge") }}
@@ -276,7 +276,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-smsd_ubuntu-22.04-amd64.charm
     resources:
-      magma-orc8r-smsd-image: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+      magma-orc8r-smsd-image: ghcr.io/canonical/magma-lte-controller:1.8.0
     {%- else %}
     charm: magma-orc8r-smsd
     channel: {{ channel|default("edge") }}
@@ -309,7 +309,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-subscriberdb_ubuntu-22.04-amd64.charm
     resources:
-      magma-orc8r-subscriberdb-image: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+      magma-orc8r-subscriberdb-image: ghcr.io/canonical/magma-lte-controller:1.8.0
     {%- else %}
     charm: magma-orc8r-subscriberdb
     channel: {{ channel|default("edge") }}
@@ -320,7 +320,7 @@ applications:
     {%- if local == true %}
     charm: ./magma-orc8r-subscriberdb-cache_ubuntu-22.04-amd64.charm
     resources:
-      magma-orc8r-subscriberdb-cache-image: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+      magma-orc8r-subscriberdb-cache-image: ghcr.io/canonical/magma-lte-controller:1.8.0
     {%- else %}
     charm: magma-orc8r-subscriberdb-cache
     channel: {{ channel|default("edge") }}

--- a/orc8r-bundle/tests/unit/expected_bundles/local.yaml
+++ b/orc8r-bundle/tests/unit/expected_bundles/local.yaml
@@ -106,13 +106,13 @@ applications:
   orc8r-ha:
     charm: ./magma-orc8r-ha_ubuntu-22.04-amd64.charm
     resources:
-      magma-orc8r-ha-image: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+      magma-orc8r-ha-image: ghcr.io/canonical/magma-lte-controller:1.8.0
     scale: 1
     trust: true
   orc8r-lte:
     charm: ./magma-orc8r-lte_ubuntu-22.04-amd64.charm
     resources:
-      magma-orc8r-lte-image: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+      magma-orc8r-lte-image: ghcr.io/canonical/magma-lte-controller:1.8.0
     scale: 1
     trust: true
   orc8r-metricsd:
@@ -144,7 +144,7 @@ applications:
   orc8r-policydb:
     charm: ./magma-orc8r-policydb_ubuntu-22.04-amd64.charm
     resources:
-      magma-orc8r-policydb-image: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+      magma-orc8r-policydb-image: ghcr.io/canonical/magma-lte-controller:1.8.0
     scale: 1
     trust: true
   orc8r-prometheus:
@@ -175,7 +175,7 @@ applications:
   orc8r-smsd:
     charm: ./magma-orc8r-smsd_ubuntu-22.04-amd64.charm
     resources:
-      magma-orc8r-smsd-image: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+      magma-orc8r-smsd-image: ghcr.io/canonical/magma-lte-controller:1.8.0
     scale: 1
     trust: true
   orc8r-state:
@@ -193,13 +193,13 @@ applications:
   orc8r-subscriberdb:
     charm: ./magma-orc8r-subscriberdb_ubuntu-22.04-amd64.charm
     resources:
-      magma-orc8r-subscriberdb-image: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+      magma-orc8r-subscriberdb-image: ghcr.io/canonical/magma-lte-controller:1.8.0
     scale: 1
     trust: true
   orc8r-subscriberdb-cache:
     charm: ./magma-orc8r-subscriberdb-cache_ubuntu-22.04-amd64.charm
     resources:
-      magma-orc8r-subscriberdb-cache-image: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+      magma-orc8r-subscriberdb-cache-image: ghcr.io/canonical/magma-lte-controller:1.8.0
     scale: 1
     trust: true
   orc8r-tenants:

--- a/orc8r-ha-operator/README.md
+++ b/orc8r-ha-operator/README.md
@@ -13,4 +13,4 @@ juju deploy magma-orc8r-ha orc8r-ha
 
 ## OCI Images
 
-Default: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+Default: ghcr.io/canonical/magma-lte-controller:1.8.0

--- a/orc8r-ha-operator/metadata.yaml
+++ b/orc8r-ha-operator/metadata.yaml
@@ -17,7 +17,7 @@ containers:
 resources:
   magma-orc8r-ha-image:
     type: oci-image
-    description: OCI image for magma-orc8r-ha (ghcr.io/canonical/magma-lte-controller:1.8.0)
+    description: OCI image for magma-orc8r-ha
     upstream-source: ghcr.io/canonical/magma-lte-controller:1.8.0
 
 provides:

--- a/orc8r-ha-operator/metadata.yaml
+++ b/orc8r-ha-operator/metadata.yaml
@@ -17,8 +17,8 @@ containers:
 resources:
   magma-orc8r-ha-image:
     type: oci-image
-    description: OCI image for magma-orc8r-ha (linuxfoundation.jfrog.io/magma-docker/controller:1.8.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+    description: OCI image for magma-orc8r-ha (ghcr.io/canonical/magma-lte-controller:1.8.0)
+    upstream-source: ghcr.io/canonical/magma-lte-controller:1.8.0
 
 provides:
   magma-orc8r-ha:

--- a/orc8r-ha-operator/src/charm.py
+++ b/orc8r-ha-operator/src/charm.py
@@ -24,11 +24,7 @@ class MagmaOrc8rHACharm(CharmBase):
             ports=[ServicePort(name="grpc", port=9180, targetPort=9119)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
-        startup_command = (
-            "ha "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "ha " "-logtostderr=true " "-v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-ha-operator/src/charm.py
+++ b/orc8r-ha-operator/src/charm.py
@@ -25,9 +25,7 @@ class MagmaOrc8rHACharm(CharmBase):
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
         startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/ha "
+            "ha "
             "-logtostderr=true "
             "-v=0"
         )

--- a/orc8r-ha-operator/src/charm.py
+++ b/orc8r-ha-operator/src/charm.py
@@ -24,7 +24,7 @@ class MagmaOrc8rHACharm(CharmBase):
             ports=[ServicePort(name="grpc", port=9180, targetPort=9119)],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
-        startup_command = "ha " "-logtostderr=true " "-v=0"
+        startup_command = "ha -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-lte-operator/README.md
+++ b/orc8r-lte-operator/README.md
@@ -23,4 +23,4 @@ The current setup has only been tested with relation to the `postgresql-k8s` cha
 
 ## OCI Images
 
-Default: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+Default: ghcr.io/canonical/magma-lte-controller:1.8.0

--- a/orc8r-lte-operator/metadata.yaml
+++ b/orc8r-lte-operator/metadata.yaml
@@ -21,8 +21,8 @@ containers:
 resources:
   magma-orc8r-lte-image:
     type: oci-image
-    description: OCI image for magma-orc8r-lte (linuxfoundation.jfrog.io/magma-docker/controller:1.8.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+    description: OCI image for magma-orc8r-lte (ghcr.io/canonical/magma-lte-controller:1.8.0)
+    upstream-source: ghcr.io/canonical/magma-lte-controller:1.8.0
 provides:
   magma-orc8r-lte:
     interface: magma-orc8r-lte

--- a/orc8r-lte-operator/metadata.yaml
+++ b/orc8r-lte-operator/metadata.yaml
@@ -21,7 +21,7 @@ containers:
 resources:
   magma-orc8r-lte-image:
     type: oci-image
-    description: OCI image for magma-orc8r-lte (ghcr.io/canonical/magma-lte-controller:1.8.0)
+    description: OCI image for magma-orc8r-lte
     upstream-source: ghcr.io/canonical/magma-lte-controller:1.8.0
 provides:
   magma-orc8r-lte:

--- a/orc8r-lte-operator/src/charm.py
+++ b/orc8r-lte-operator/src/charm.py
@@ -55,9 +55,7 @@ class MagmaOrc8rLteCharm(CharmBase):
             },
         )
         startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/lte "
+            "lte "
             "-run_echo_server=true "
             "-logtostderr=true "
             "-v=0"

--- a/orc8r-lte-operator/src/charm.py
+++ b/orc8r-lte-operator/src/charm.py
@@ -54,7 +54,7 @@ class MagmaOrc8rLteCharm(CharmBase):
                 "subscriberdb,",
             },
         )
-        startup_command = "lte " "-run_echo_server=true " "-logtostderr=true " "-v=0"
+        startup_command = "lte -run_echo_server=true -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
         self.framework.observe(self.on.install, self._on_install)
 

--- a/orc8r-lte-operator/src/charm.py
+++ b/orc8r-lte-operator/src/charm.py
@@ -54,12 +54,7 @@ class MagmaOrc8rLteCharm(CharmBase):
                 "subscriberdb,",
             },
         )
-        startup_command = (
-            "lte "
-            "-run_echo_server=true "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "lte " "-run_echo_server=true " "-logtostderr=true " "-v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
         self.framework.observe(self.on.install, self._on_install)
 

--- a/orc8r-policydb-operator/README.md
+++ b/orc8r-policydb-operator/README.md
@@ -17,4 +17,4 @@ juju relate orc8r-policydb postgresql-k8s:db
 
 ## OCI Images
 
-Default: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+Default: ghcr.io/canonical/magma-lte-controller:1.8.0

--- a/orc8r-policydb-operator/metadata.yaml
+++ b/orc8r-policydb-operator/metadata.yaml
@@ -17,8 +17,8 @@ containers:
 resources:
   magma-orc8r-policydb-image:
     type: oci-image
-    description: OCI image for magma-orc8r-policydb
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+    description: OCI image for magma-orc8r-policydb (ghcr.io/canonical/magma-lte-controller:1.8.0)
+    upstream-source: ghcr.io/canonical/magma-lte-controller:1.8.0
 
 provides:
   magma-orc8r-policydb:

--- a/orc8r-policydb-operator/metadata.yaml
+++ b/orc8r-policydb-operator/metadata.yaml
@@ -17,7 +17,7 @@ containers:
 resources:
   magma-orc8r-policydb-image:
     type: oci-image
-    description: OCI image for magma-orc8r-policydb (ghcr.io/canonical/magma-lte-controller:1.8.0)
+    description: OCI image for magma-orc8r-policydb
     upstream-source: ghcr.io/canonical/magma-lte-controller:1.8.0
 
 provides:

--- a/orc8r-policydb-operator/src/charm.py
+++ b/orc8r-policydb-operator/src/charm.py
@@ -37,7 +37,7 @@ class MagmaOrc8rPolicydbCharm(CharmBase):
                 "/magma/v1/networks/:network_id/rating_groups"
             },
         )
-        startup_command = "policydb " "-run_echo_server=true " "-logtostderr=true " "-v=0"
+        startup_command = "policydb -run_echo_server=true -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-policydb-operator/src/charm.py
+++ b/orc8r-policydb-operator/src/charm.py
@@ -37,12 +37,7 @@ class MagmaOrc8rPolicydbCharm(CharmBase):
                 "/magma/v1/networks/:network_id/rating_groups"
             },
         )
-        startup_command = (
-            "policydb "
-            "-run_echo_server=true "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "policydb " "-run_echo_server=true " "-logtostderr=true " "-v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-policydb-operator/src/charm.py
+++ b/orc8r-policydb-operator/src/charm.py
@@ -38,9 +38,7 @@ class MagmaOrc8rPolicydbCharm(CharmBase):
             },
         )
         startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/policydb "
+            "policydb "
             "-run_echo_server=true "
             "-logtostderr=true "
             "-v=0"

--- a/orc8r-smsd-operator/README.md
+++ b/orc8r-smsd-operator/README.md
@@ -21,4 +21,4 @@ The current setup has only been tested with relation to the `postgresql-k8s` cha
 
 ## OCI Images
 
-Default: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+Default: ghcr.io/canonical/magma-lte-controller:1.8.0

--- a/orc8r-smsd-operator/metadata.yaml
+++ b/orc8r-smsd-operator/metadata.yaml
@@ -15,7 +15,7 @@ containers:
 resources:
   magma-orc8r-smsd-image:
     type: oci-image
-    description: OCI image for magma-orc8r-smsd (ghcr.io/canonical/magma-lte-controller:1.8.0)
+    description: OCI image for magma-orc8r-smsd
     upstream-source: ghcr.io/canonical/magma-lte-controller:1.8.0
 
 provides:

--- a/orc8r-smsd-operator/metadata.yaml
+++ b/orc8r-smsd-operator/metadata.yaml
@@ -15,8 +15,8 @@ containers:
 resources:
   magma-orc8r-smsd-image:
     type: oci-image
-    description: OCI image for magma-orc8r-smsd
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+    description: OCI image for magma-orc8r-smsd (ghcr.io/canonical/magma-lte-controller:1.8.0)
+    upstream-source: ghcr.io/canonical/magma-lte-controller:1.8.0
 
 provides:
   magma-orc8r-smsd:

--- a/orc8r-smsd-operator/src/charm.py
+++ b/orc8r-smsd-operator/src/charm.py
@@ -35,7 +35,7 @@ class MagmaOrc8rSmsdCharm(CharmBase):
                 "orc8r.io/obsidian_handlers_path_prefixes": "/magma/v1/lte/:network_id/sms"
             },
         )
-        startup_command = "smsd " "-logtostderr=true " "-run_echo_server=true " "-v=0"
+        startup_command = "smsd -logtostderr=true -run_echo_server=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-smsd-operator/src/charm.py
+++ b/orc8r-smsd-operator/src/charm.py
@@ -35,12 +35,7 @@ class MagmaOrc8rSmsdCharm(CharmBase):
                 "orc8r.io/obsidian_handlers_path_prefixes": "/magma/v1/lte/:network_id/sms"
             },
         )
-        startup_command = (
-            "smsd "
-            "-logtostderr=true "
-            "-run_echo_server=true "
-            "-v=0"
-        )
+        startup_command = "smsd " "-logtostderr=true " "-run_echo_server=true " "-v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-smsd-operator/src/charm.py
+++ b/orc8r-smsd-operator/src/charm.py
@@ -36,9 +36,7 @@ class MagmaOrc8rSmsdCharm(CharmBase):
             },
         )
         startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/smsd "
+            "smsd "
             "-logtostderr=true "
             "-run_echo_server=true "
             "-v=0"

--- a/orc8r-subscriberdb-cache-operator/README.md
+++ b/orc8r-subscriberdb-cache-operator/README.md
@@ -21,5 +21,5 @@ The current setup has only been tested with relation to the `postgresql-k8s` cha
 
 ## OCI Images
 
-Default: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+Default: ghcr.io/canonical/magma-lte-controller:1.8.0
 

--- a/orc8r-subscriberdb-cache-operator/metadata.yaml
+++ b/orc8r-subscriberdb-cache-operator/metadata.yaml
@@ -15,8 +15,8 @@ containers:
 resources:
   magma-orc8r-subscriberdb-cache-image:
     type: oci-image
-    description: OCI image for magma-orc8r-subscriberdb-cache (linuxfoundation.jfrog.io/magma-docker/controller:1.8.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+    description: OCI image for magma-orc8r-subscriberdb-cache (ghcr.io/canonical/magma-lte-controller:1.8.0)
+    upstream-source: ghcr.io/canonical/magma-lte-controller:1.8.0
 
 provides:
   magma-orc8r-subscriberdb-cache:

--- a/orc8r-subscriberdb-cache-operator/metadata.yaml
+++ b/orc8r-subscriberdb-cache-operator/metadata.yaml
@@ -15,7 +15,7 @@ containers:
 resources:
   magma-orc8r-subscriberdb-cache-image:
     type: oci-image
-    description: OCI image for magma-orc8r-subscriberdb-cache (ghcr.io/canonical/magma-lte-controller:1.8.0)
+    description: OCI image for magma-orc8r-subscriberdb-cache
     upstream-source: ghcr.io/canonical/magma-lte-controller:1.8.0
 
 provides:

--- a/orc8r-subscriberdb-cache-operator/src/charm.py
+++ b/orc8r-subscriberdb-cache-operator/src/charm.py
@@ -28,10 +28,7 @@ class MagmaOrc8rSubscriberdbcacheCharm(CharmBase):
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
         startup_command = (
-            "subscriberdb_cache "
-            "-run_echo_server=true "
-            "-logtostderr=true "
-            "-v=0"
+            "subscriberdb_cache " "-run_echo_server=true " "-logtostderr=true " "-v=0"
         )
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 

--- a/orc8r-subscriberdb-cache-operator/src/charm.py
+++ b/orc8r-subscriberdb-cache-operator/src/charm.py
@@ -28,7 +28,7 @@ class MagmaOrc8rSubscriberdbcacheCharm(CharmBase):
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
         startup_command = (
-            "subscriberdb_cache " "-run_echo_server=true " "-logtostderr=true " "-v=0"
+            "subscriberdb_cache -run_echo_server=true -logtostderr=true -v=0"
         )
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 

--- a/orc8r-subscriberdb-cache-operator/src/charm.py
+++ b/orc8r-subscriberdb-cache-operator/src/charm.py
@@ -28,9 +28,7 @@ class MagmaOrc8rSubscriberdbcacheCharm(CharmBase):
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
         startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/subscriberdb_cache "
+            "subscriberdb_cache "
             "-run_echo_server=true "
             "-logtostderr=true "
             "-v=0"

--- a/orc8r-subscriberdb-cache-operator/src/charm.py
+++ b/orc8r-subscriberdb-cache-operator/src/charm.py
@@ -27,9 +27,7 @@ class MagmaOrc8rSubscriberdbcacheCharm(CharmBase):
             ],
             additional_labels={"app.kubernetes.io/part-of": "orc8r-app"},
         )
-        startup_command = (
-            "subscriberdb_cache -run_echo_server=true -logtostderr=true -v=0"
-        )
+        startup_command = "subscriberdb_cache -run_echo_server=true -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-subscriberdb-operator/README.md
+++ b/orc8r-subscriberdb-operator/README.md
@@ -21,5 +21,5 @@ The current setup has only been tested with relation to the `postgresql-k8s` cha
 
 ## OCI Images
 
-Default: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+Default: ghcr.io/canonical/magma-lte-controller:1.8.0
 

--- a/orc8r-subscriberdb-operator/metadata.yaml
+++ b/orc8r-subscriberdb-operator/metadata.yaml
@@ -15,7 +15,7 @@ containers:
 resources:
   magma-orc8r-subscriberdb-image:
     type: oci-image
-    description: OCI image for magma-orc8r-subscriberdb (ghcr.io/canonical/magma-lte-controller:1.8.0)
+    description: OCI image for magma-orc8r-subscriberdb
     upstream-source: ghcr.io/canonical/magma-lte-controller:1.8.0
 
 provides:

--- a/orc8r-subscriberdb-operator/metadata.yaml
+++ b/orc8r-subscriberdb-operator/metadata.yaml
@@ -15,8 +15,8 @@ containers:
 resources:
   magma-orc8r-subscriberdb-image:
     type: oci-image
-    description: OCI image for magma-orc8r-subscriberdb (linuxfoundation.jfrog.io/magma-docker/controller:1.8.0)
-    upstream-source: linuxfoundation.jfrog.io/magma-docker/controller:1.8.0
+    description: OCI image for magma-orc8r-subscriberdb (ghcr.io/canonical/magma-lte-controller:1.8.0)
+    upstream-source: ghcr.io/canonical/magma-lte-controller:1.8.0
 
 provides:
   magma-orc8r-subscriberdb:

--- a/orc8r-subscriberdb-operator/src/charm.py
+++ b/orc8r-subscriberdb-operator/src/charm.py
@@ -42,9 +42,7 @@ class MagmaOrc8rSubscriberdbCharm(CharmBase):
             },
         )
         startup_command = (
-            "/usr/bin/envdir "
-            "/var/opt/magma/envdir "
-            "/var/opt/magma/bin/subscriberdb "
+            "subscriberdb "
             "-run_echo_server=true "
             "-logtostderr=true "
             "-v=0"

--- a/orc8r-subscriberdb-operator/src/charm.py
+++ b/orc8r-subscriberdb-operator/src/charm.py
@@ -41,7 +41,7 @@ class MagmaOrc8rSubscriberdbCharm(CharmBase):
                 "/magma/v1/lte/:network_id/subscribers_v2,",
             },
         )
-        startup_command = "subscriberdb " "-run_echo_server=true " "-logtostderr=true " "-v=0"
+        startup_command = "subscriberdb -run_echo_server=true -logtostderr=true -v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 

--- a/orc8r-subscriberdb-operator/src/charm.py
+++ b/orc8r-subscriberdb-operator/src/charm.py
@@ -41,12 +41,7 @@ class MagmaOrc8rSubscriberdbCharm(CharmBase):
                 "/magma/v1/lte/:network_id/subscribers_v2,",
             },
         )
-        startup_command = (
-            "subscriberdb "
-            "-run_echo_server=true "
-            "-logtostderr=true "
-            "-v=0"
-        )
+        startup_command = "subscriberdb " "-run_echo_server=true " "-logtostderr=true " "-v=0"
         self._orc8r_base = Orc8rBase(self, startup_command=startup_command)
 
 


### PR DESCRIPTION
# Description

⚠️ **DON'T MERGE before this [PR](https://github.com/canonical/magma-lte-controller-rock/pull/2) is merged and the CI has had enough time to upload the rock to Github's registry.**

Sets Orc8r LTE rock from `ghcr.io/canonical/magma-lte-controller:1.8.0` as the workload container and removes `envdir` from startup commands for the following services:
- `orc8r-lte`
- `orc8r-ha`
- `orc8r-smsd`
- `orc8r-policydb`
- `orc8r-subscriberdb`
- `orc8r-subscriberdb-cache`

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
