### PR TITLE
Use new data platform lib in nms-magmalte

### DIFF
--- a/nms-magmalte-operator/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/nms-magmalte-operator/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -1,0 +1,1170 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Library to manage the relation for the data-platform products.
+
+This library contains the Requires and Provides classes for handling the relation
+between an application and multiple managed application supported by the data-team:
+MySQL, Postgresql, MongoDB, Redis, and Kafka.
+
+### Database (MySQL, Postgresql, MongoDB, and Redis)
+
+#### Requires Charm
+This library is a uniform interface to a selection of common database
+metadata, with added custom events that add convenience to database management,
+and methods to consume the application related data.
+
+
+Following an example of using the DatabaseCreatedEvent, in the context of the
+application charm code:
+
+```python
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseCreatedEvent,
+    DatabaseRequires,
+)
+
+class ApplicationCharm(CharmBase):
+    # Application charm that connects to database charms.
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        # Charm events defined in the database requires charm library.
+        self.database = DatabaseRequires(self, relation_name="database", database_name="database")
+        self.framework.observe(self.database.on.database_created, self._on_database_created)
+
+    def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
+        # Handle the created database
+
+        # Create configuration file for app
+        config_file = self._render_app_config_file(
+            event.username,
+            event.password,
+            event.endpoints,
+        )
+
+        # Start application with rendered configuration
+        self._start_application(config_file)
+
+        # Set active status
+        self.unit.status = ActiveStatus("received database credentials")
+```
+
+As shown above, the library provides some custom events to handle specific situations,
+which are listed below:
+
+-  database_created: event emitted when the requested database is created.
+-  endpoints_changed: event emitted when the read/write endpoints of the database have changed.
+-  read_only_endpoints_changed: event emitted when the read-only endpoints of the database
+  have changed. Event is not triggered if read/write endpoints changed too.
+
+If it is needed to connect multiple database clusters to the same relation endpoint
+the application charm can implement the same code as if it would connect to only
+one database cluster (like the above code example).
+
+To differentiate multiple clusters connected to the same relation endpoint
+the application charm can use the name of the remote application:
+
+```python
+
+def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
+    # Get the remote app name of the cluster that triggered this event
+    cluster = event.relation.app.name
+```
+
+It is also possible to provide an alias for each different database cluster/relation.
+
+So, it is possible to differentiate the clusters in two ways.
+The first is to use the remote application name, i.e., `event.relation.app.name`, as above.
+
+The second way is to use different event handlers to handle each cluster events.
+The implementation would be something like the following code:
+
+```python
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseCreatedEvent,
+    DatabaseRequires,
+)
+
+class ApplicationCharm(CharmBase):
+    # Application charm that connects to database charms.
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        # Define the cluster aliases and one handler for each cluster database created event.
+        self.database = DatabaseRequires(
+            self,
+            relation_name="database",
+            database_name="database",
+            relations_aliases = ["cluster1", "cluster2"],
+        )
+        self.framework.observe(
+            self.database.on.cluster1_database_created, self._on_cluster1_database_created
+        )
+        self.framework.observe(
+            self.database.on.cluster2_database_created, self._on_cluster2_database_created
+        )
+
+    def _on_cluster1_database_created(self, event: DatabaseCreatedEvent) -> None:
+        # Handle the created database on the cluster named cluster1
+
+        # Create configuration file for app
+        config_file = self._render_app_config_file(
+            event.username,
+            event.password,
+            event.endpoints,
+        )
+        ...
+
+    def _on_cluster2_database_created(self, event: DatabaseCreatedEvent) -> None:
+        # Handle the created database on the cluster named cluster2
+
+        # Create configuration file for app
+        config_file = self._render_app_config_file(
+            event.username,
+            event.password,
+            event.endpoints,
+        )
+        ...
+
+```
+
+### Provider Charm
+
+Following an example of using the DatabaseRequestedEvent, in the context of the
+database charm code:
+
+```python
+from charms.data_platform_libs.v0.data_interfaces import DatabaseProvides
+
+class SampleCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        # Charm events defined in the database provides charm library.
+        self.provided_database = DatabaseProvides(self, relation_name="database")
+        self.framework.observe(self.provided_database.on.database_requested,
+            self._on_database_requested)
+        # Database generic helper
+        self.database = DatabaseHelper()
+
+    def _on_database_requested(self, event: DatabaseRequestedEvent) -> None:
+        # Handle the event triggered by a new database requested in the relation
+        # Retrieve the database name using the charm library.
+        db_name = event.database
+        # generate a new user credential
+        username = self.database.generate_user()
+        password = self.database.generate_password()
+        # set the credentials for the relation
+        self.provided_database.set_credentials(event.relation.id, username, password)
+        # set other variables for the relation event.set_tls("False")
+```
+As shown above, the library provides a custom event (database_requested) to handle
+the situation when an application charm requests a new database to be created.
+It's preferred to subscribe to this event instead of relation changed event to avoid
+creating a new database when other information other than a database name is
+exchanged in the relation databag.
+
+### Kafka
+
+This library is the interface to use and interact with the Kafka charm. This library contains
+custom events that add convenience to manage Kafka, and provides methods to consume the
+application related data.
+
+#### Requirer Charm
+
+```python
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    BootstrapServerChangedEvent,
+    KafkaRequires,
+    TopicCreatedEvent,
+)
+
+class ApplicationCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.kafka = KafkaRequires(self, "kafka_client", "test-topic")
+        self.framework.observe(
+            self.kafka.on.bootstrap_server_changed, self._on_kafka_bootstrap_server_changed
+        )
+        self.framework.observe(
+            self.kafka.on.topic_created, self._on_kafka_topic_created
+        )
+
+    def _on_kafka_bootstrap_server_changed(self, event: BootstrapServerChangedEvent):
+        # Event triggered when a bootstrap server was changed for this application
+
+        new_bootstrap_server = event.bootstrap_server
+        ...
+
+    def _on_kafka_topic_created(self, event: TopicCreatedEvent):
+        # Event triggered when a topic was created for this application
+        username = event.username
+        password = event.password
+        tls = event.tls
+        tls_ca= event.tls_ca
+        bootstrap_server event.bootstrap_server
+        consumer_group_prefic = event.consumer_group_prefix
+        zookeeper_uris = event.zookeeper_uris
+        ...
+
+```
+
+As shown above, the library provides some custom events to handle specific situations,
+which are listed below:
+
+- topic_created: event emitted when the requested topic is created.
+- bootstrap_server_changed: event emitted when the bootstrap server have changed.
+- credential_changed: event emitted when the credentials of Kafka changed.
+
+### Provider Charm
+
+Following the previous example, this is an example of the provider charm.
+
+```python
+class SampleCharm(CharmBase):
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    KafkaProvides,
+    TopicRequestedEvent,
+)
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        # Default charm events.
+        self.framework.observe(self.on.start, self._on_start)
+
+        # Charm events defined in the Kafka Provides charm library.
+        self.kafka_provider = KafkaProvides(self, relation_name="kafka_client")
+        self.framework.observe(self.kafka_provider.on.topic_requested, self._on_topic_requested)
+        # Kafka generic helper
+        self.kafka = KafkaHelper()
+
+    def _on_topic_requested(self, event: TopicRequestedEvent):
+        # Handle the on_topic_requested event.
+
+        topic = event.topic
+        relation_id = event.relation.id
+        # set connection info in the databag relation
+        self.kafka_provider.set_bootstrap_server(relation_id, self.kafka.get_bootstrap_server())
+        self.kafka_provider.set_credentials(relation_id, username=username, password=password)
+        self.kafka_provider.set_consumer_group_prefix(relation_id, ...)
+        self.kafka_provider.set_tls(relation_id, "False")
+        self.kafka_provider.set_zookeeper_uris(relation_id, ...)
+
+```
+As shown above, the library provides a custom event (topic_requested) to handle
+the situation when an application charm requests a new topic to be created.
+It is preferred to subscribe to this event instead of relation changed event to avoid
+creating a new topic when other information other than a topic name is
+exchanged in the relation databag.
+"""
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from collections import namedtuple
+from datetime import datetime
+from typing import List, Optional
+
+from ops.charm import (
+    CharmBase,
+    CharmEvents,
+    RelationChangedEvent,
+    RelationEvent,
+    RelationJoinedEvent,
+)
+from ops.framework import EventSource, Object
+from ops.model import Relation
+
+# The unique Charmhub library identifier, never change it
+LIBID = "6c3e6b6680d64e9c89e611d1a15f65be"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 9
+
+PYDEPS = ["ops>=2.0.0"]
+
+logger = logging.getLogger(__name__)
+
+Diff = namedtuple("Diff", "added changed deleted")
+Diff.__doc__ = """
+A tuple for storing the diff between two data mappings.
+
+added - keys that were added
+changed - keys that still exist but have new values
+deleted - key that were deleted"""
+
+
+def diff(event: RelationChangedEvent, bucket: str) -> Diff:
+    """Retrieves the diff of the data in the relation changed databag.
+
+    Args:
+        event: relation changed event.
+        bucket: bucket of the databag (app or unit)
+
+    Returns:
+        a Diff instance containing the added, deleted and changed
+            keys from the event relation databag.
+    """
+    # Retrieve the old data from the data key in the application relation databag.
+    old_data = json.loads(event.relation.data[bucket].get("data", "{}"))
+    # Retrieve the new data from the event relation databag.
+    new_data = {
+        key: value for key, value in event.relation.data[event.app].items() if key != "data"
+    }
+
+    # These are the keys that were added to the databag and triggered this event.
+    added = new_data.keys() - old_data.keys()
+    # These are the keys that were removed from the databag and triggered this event.
+    deleted = old_data.keys() - new_data.keys()
+    # These are the keys that already existed in the databag,
+    # but had their values changed.
+    changed = {key for key in old_data.keys() & new_data.keys() if old_data[key] != new_data[key]}
+    # Convert the new_data to a serializable format and save it for a next diff check.
+    event.relation.data[bucket].update({"data": json.dumps(new_data)})
+
+    # Return the diff with all possible changes.
+    return Diff(added, changed, deleted)
+
+
+# Base DataProvides and DataRequires
+
+
+class DataProvides(Object, ABC):
+    """Base provides-side of the data products relation."""
+
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.local_app = self.charm.model.app
+        self.local_unit = self.charm.unit
+        self.relation_name = relation_name
+        self.framework.observe(
+            charm.on[relation_name].relation_changed,
+            self._on_relation_changed,
+        )
+
+    def _diff(self, event: RelationChangedEvent) -> Diff:
+        """Retrieves the diff of the data in the relation changed databag.
+
+        Args:
+            event: relation changed event.
+
+        Returns:
+            a Diff instance containing the added, deleted and changed
+                keys from the event relation databag.
+        """
+        return diff(event, self.local_app)
+
+    @abstractmethod
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation data has changed."""
+        raise NotImplementedError
+
+    def fetch_relation_data(self) -> dict:
+        """Retrieves data from relation.
+
+        This function can be used to retrieve data from a relation
+        in the charm code when outside an event callback.
+
+        Returns:
+            a dict of the values stored in the relation data bag
+                for all relation instances (indexed by the relation id).
+        """
+        data = {}
+        for relation in self.relations:
+            data[relation.id] = {
+                key: value for key, value in relation.data[relation.app].items() if key != "data"
+            }
+        return data
+
+    def _update_relation_data(self, relation_id: int, data: dict) -> None:
+        """Updates a set of key-value pairs in the relation.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            data: dict containing the key-value pairs
+                that should be updated in the relation.
+        """
+        if self.local_unit.is_leader():
+            relation = self.charm.model.get_relation(self.relation_name, relation_id)
+            relation.data[self.local_app].update(data)
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The list of Relation instances associated with this relation_name."""
+        return list(self.charm.model.relations[self.relation_name])
+
+    def set_credentials(self, relation_id: int, username: str, password: str) -> None:
+        """Set credentials.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            username: user that was created.
+            password: password of the created user.
+        """
+        self._update_relation_data(
+            relation_id,
+            {
+                "username": username,
+                "password": password,
+            },
+        )
+
+    def set_tls(self, relation_id: int, tls: str) -> None:
+        """Set whether TLS is enabled.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            tls: whether tls is enabled (True or False).
+        """
+        self._update_relation_data(relation_id, {"tls": tls})
+
+    def set_tls_ca(self, relation_id: int, tls_ca: str) -> None:
+        """Set the TLS CA in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            tls_ca: TLS certification authority.
+        """
+        self._update_relation_data(relation_id, {"tls_ca": tls_ca})
+
+
+class DataRequires(Object, ABC):
+    """Requires-side of the relation."""
+
+    def __init__(
+        self,
+        charm,
+        relation_name: str,
+        extra_user_roles: str = None,
+    ):
+        """Manager of base client relations."""
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.extra_user_roles = extra_user_roles
+        self.local_app = self.charm.model.app
+        self.local_unit = self.charm.unit
+        self.relation_name = relation_name
+        self.framework.observe(
+            self.charm.on[relation_name].relation_joined, self._on_relation_joined_event
+        )
+        self.framework.observe(
+            self.charm.on[relation_name].relation_changed, self._on_relation_changed_event
+        )
+
+    @abstractmethod
+    def _on_relation_joined_event(self, event: RelationJoinedEvent) -> None:
+        """Event emitted when the application joins the relation."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        raise NotImplementedError
+
+    def fetch_relation_data(self) -> dict:
+        """Retrieves data from relation.
+
+        This function can be used to retrieve data from a relation
+        in the charm code when outside an event callback.
+        Function cannot be used in `*-relation-broken` events and will raise an exception.
+
+        Returns:
+            a dict of the values stored in the relation data bag
+                for all relation instances (indexed by the relation ID).
+        """
+        data = {}
+        for relation in self.relations:
+            data[relation.id] = {
+                key: value for key, value in relation.data[relation.app].items() if key != "data"
+            }
+        return data
+
+    def _update_relation_data(self, relation_id: int, data: dict) -> None:
+        """Updates a set of key-value pairs in the relation.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            data: dict containing the key-value pairs
+                that should be updated in the relation.
+        """
+        if self.local_unit.is_leader():
+            relation = self.charm.model.get_relation(self.relation_name, relation_id)
+            relation.data[self.local_app].update(data)
+
+    def _diff(self, event: RelationChangedEvent) -> Diff:
+        """Retrieves the diff of the data in the relation changed databag.
+
+        Args:
+            event: relation changed event.
+
+        Returns:
+            a Diff instance containing the added, deleted and changed
+                keys from the event relation databag.
+        """
+        return diff(event, self.local_unit)
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The list of Relation instances associated with this relation_name."""
+        return [
+            relation
+            for relation in self.charm.model.relations[self.relation_name]
+            if self._is_relation_active(relation)
+        ]
+
+    @staticmethod
+    def _is_relation_active(relation: Relation):
+        try:
+            _ = repr(relation.data)
+            return True
+        except RuntimeError:
+            return False
+
+    @staticmethod
+    def _is_resource_created_for_relation(relation: Relation):
+        return (
+            "username" in relation.data[relation.app] and "password" in relation.data[relation.app]
+        )
+
+    def is_resource_created(self, relation_id: Optional[int] = None) -> bool:
+        """Check if the resource has been created.
+
+        This function can be used to check if the Provider answered with data in the charm code
+        when outside an event callback.
+
+        Args:
+            relation_id (int, optional): When provided the check is done only for the relation id
+                provided, otherwise the check is done for all relations
+
+        Returns:
+            True or False
+
+        Raises:
+            IndexError: If relation_id is provided but that relation does not exist
+        """
+        if relation_id is not None:
+            try:
+                relation = [relation for relation in self.relations if relation.id == relation_id][
+                    0
+                ]
+                return self._is_resource_created_for_relation(relation)
+            except IndexError:
+                raise IndexError(f"relation id {relation_id} cannot be accessed")
+        else:
+            return (
+                all(
+                    [
+                        self._is_resource_created_for_relation(relation)
+                        for relation in self.relations
+                    ]
+                )
+                if self.relations
+                else False
+            )
+
+
+# General events
+
+
+class ExtraRoleEvent(RelationEvent):
+    """Base class for data events."""
+
+    @property
+    def extra_user_roles(self) -> Optional[str]:
+        """Returns the extra user roles that were requested."""
+        return self.relation.data[self.relation.app].get("extra-user-roles")
+
+
+class AuthenticationEvent(RelationEvent):
+    """Base class for authentication fields for events."""
+
+    @property
+    def username(self) -> Optional[str]:
+        """Returns the created username."""
+        return self.relation.data[self.relation.app].get("username")
+
+    @property
+    def password(self) -> Optional[str]:
+        """Returns the password for the created user."""
+        return self.relation.data[self.relation.app].get("password")
+
+    @property
+    def tls(self) -> Optional[str]:
+        """Returns whether TLS is configured."""
+        return self.relation.data[self.relation.app].get("tls")
+
+    @property
+    def tls_ca(self) -> Optional[str]:
+        """Returns TLS CA."""
+        return self.relation.data[self.relation.app].get("tls-ca")
+
+
+# Database related events and fields
+
+
+class DatabaseProvidesEvent(RelationEvent):
+    """Base class for database events."""
+
+    @property
+    def database(self) -> Optional[str]:
+        """Returns the database that was requested."""
+        return self.relation.data[self.relation.app].get("database")
+
+
+class DatabaseRequestedEvent(DatabaseProvidesEvent, ExtraRoleEvent):
+    """Event emitted when a new database is requested for use on this relation."""
+
+
+class DatabaseProvidesEvents(CharmEvents):
+    """Database events.
+
+    This class defines the events that the database can emit.
+    """
+
+    database_requested = EventSource(DatabaseRequestedEvent)
+
+
+class DatabaseRequiresEvent(RelationEvent):
+    """Base class for database events."""
+
+    @property
+    def database(self) -> Optional[str]:
+        """Returns the database name."""
+        return self.relation.data[self.relation.app].get("database")
+
+    @property
+    def endpoints(self) -> Optional[str]:
+        """Returns a comma separated list of read/write endpoints."""
+        return self.relation.data[self.relation.app].get("endpoints")
+
+    @property
+    def read_only_endpoints(self) -> Optional[str]:
+        """Returns a comma separated list of read only endpoints."""
+        return self.relation.data[self.relation.app].get("read-only-endpoints")
+
+    @property
+    def replset(self) -> Optional[str]:
+        """Returns the replicaset name.
+
+        MongoDB only.
+        """
+        return self.relation.data[self.relation.app].get("replset")
+
+    @property
+    def uris(self) -> Optional[str]:
+        """Returns the connection URIs.
+
+        MongoDB, Redis, OpenSearch.
+        """
+        return self.relation.data[self.relation.app].get("uris")
+
+    @property
+    def version(self) -> Optional[str]:
+        """Returns the version of the database.
+
+        Version as informed by the database daemon.
+        """
+        return self.relation.data[self.relation.app].get("version")
+
+
+class DatabaseCreatedEvent(AuthenticationEvent, DatabaseRequiresEvent):
+    """Event emitted when a new database is created for use on this relation."""
+
+
+class DatabaseEndpointsChangedEvent(AuthenticationEvent, DatabaseRequiresEvent):
+    """Event emitted when the read/write endpoints are changed."""
+
+
+class DatabaseReadOnlyEndpointsChangedEvent(AuthenticationEvent, DatabaseRequiresEvent):
+    """Event emitted when the read only endpoints are changed."""
+
+
+class DatabaseRequiresEvents(CharmEvents):
+    """Database events.
+
+    This class defines the events that the database can emit.
+    """
+
+    database_created = EventSource(DatabaseCreatedEvent)
+    endpoints_changed = EventSource(DatabaseEndpointsChangedEvent)
+    read_only_endpoints_changed = EventSource(DatabaseReadOnlyEndpointsChangedEvent)
+
+
+# Database Provider and Requires
+
+
+class DatabaseProvides(DataProvides):
+    """Provider-side of the database relations."""
+
+    on = DatabaseProvidesEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        super().__init__(charm, relation_name)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed."""
+        # Only the leader should handle this event.
+        if not self.local_unit.is_leader():
+            return
+
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Emit a database requested event if the setup key (database name and optional
+        # extra user roles) was added to the relation databag by the application.
+        if "database" in diff.added:
+            self.on.database_requested.emit(event.relation, app=event.app, unit=event.unit)
+
+    def set_database(self, relation_id: int, database_name: str) -> None:
+        """Set database name.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            database_name: database name.
+        """
+        self._update_relation_data(relation_id, {"database": database_name})
+
+    def set_endpoints(self, relation_id: int, connection_strings: str) -> None:
+        """Set database primary connections.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            connection_strings: database hosts and ports comma separated list.
+        """
+        self._update_relation_data(relation_id, {"endpoints": connection_strings})
+
+    def set_read_only_endpoints(self, relation_id: int, connection_strings: str) -> None:
+        """Set database replicas connection strings.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            connection_strings: database hosts and ports comma separated list.
+        """
+        self._update_relation_data(relation_id, {"read-only-endpoints": connection_strings})
+
+    def set_replset(self, relation_id: int, replset: str) -> None:
+        """Set replica set name in the application relation databag.
+
+        MongoDB only.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            replset: replica set name.
+        """
+        self._update_relation_data(relation_id, {"replset": replset})
+
+    def set_uris(self, relation_id: int, uris: str) -> None:
+        """Set the database connection URIs in the application relation databag.
+
+        MongoDB, Redis, and OpenSearch only.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            uris: connection URIs.
+        """
+        self._update_relation_data(relation_id, {"uris": uris})
+
+    def set_version(self, relation_id: int, version: str) -> None:
+        """Set the database version in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            version: database version.
+        """
+        self._update_relation_data(relation_id, {"version": version})
+
+
+class DatabaseRequires(DataRequires):
+    """Requires-side of the database relation."""
+
+    on = DatabaseRequiresEvents()
+
+    def __init__(
+        self,
+        charm,
+        relation_name: str,
+        database_name: str,
+        extra_user_roles: str = None,
+        relations_aliases: List[str] = None,
+    ):
+        """Manager of database client relations."""
+        super().__init__(charm, relation_name, extra_user_roles)
+        self.database = database_name
+        self.relations_aliases = relations_aliases
+
+        # Define custom event names for each alias.
+        if relations_aliases:
+            # Ensure the number of aliases does not exceed the maximum
+            # of connections allowed in the specific relation.
+            relation_connection_limit = self.charm.meta.requires[relation_name].limit
+            if len(relations_aliases) != relation_connection_limit:
+                raise ValueError(
+                    f"The number of aliases must match the maximum number of connections allowed in the relation. "
+                    f"Expected {relation_connection_limit}, got {len(relations_aliases)}"
+                )
+
+            for relation_alias in relations_aliases:
+                self.on.define_event(f"{relation_alias}_database_created", DatabaseCreatedEvent)
+                self.on.define_event(
+                    f"{relation_alias}_endpoints_changed", DatabaseEndpointsChangedEvent
+                )
+                self.on.define_event(
+                    f"{relation_alias}_read_only_endpoints_changed",
+                    DatabaseReadOnlyEndpointsChangedEvent,
+                )
+
+    def _assign_relation_alias(self, relation_id: int) -> None:
+        """Assigns an alias to a relation.
+
+        This function writes in the unit data bag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+        """
+        # If no aliases were provided, return immediately.
+        if not self.relations_aliases:
+            return
+
+        # Return if an alias was already assigned to this relation
+        # (like when there are more than one unit joining the relation).
+        if (
+            self.charm.model.get_relation(self.relation_name, relation_id)
+            .data[self.local_unit]
+            .get("alias")
+        ):
+            return
+
+        # Retrieve the available aliases (the ones that weren't assigned to any relation).
+        available_aliases = self.relations_aliases[:]
+        for relation in self.charm.model.relations[self.relation_name]:
+            alias = relation.data[self.local_unit].get("alias")
+            if alias:
+                logger.debug("Alias %s was already assigned to relation %d", alias, relation.id)
+                available_aliases.remove(alias)
+
+        # Set the alias in the unit relation databag of the specific relation.
+        relation = self.charm.model.get_relation(self.relation_name, relation_id)
+        relation.data[self.local_unit].update({"alias": available_aliases[0]})
+
+    def _emit_aliased_event(self, event: RelationChangedEvent, event_name: str) -> None:
+        """Emit an aliased event to a particular relation if it has an alias.
+
+        Args:
+            event: the relation changed event that was received.
+            event_name: the name of the event to emit.
+        """
+        alias = self._get_relation_alias(event.relation.id)
+        if alias:
+            getattr(self.on, f"{alias}_{event_name}").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+    def _get_relation_alias(self, relation_id: int) -> Optional[str]:
+        """Returns the relation alias.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+
+        Returns:
+            the relation alias or None if the relation was not found.
+        """
+        for relation in self.charm.model.relations[self.relation_name]:
+            if relation.id == relation_id:
+                return relation.data[self.local_unit].get("alias")
+        return None
+
+    def _on_relation_joined_event(self, event: RelationJoinedEvent) -> None:
+        """Event emitted when the application joins the database relation."""
+        # If relations aliases were provided, assign one to the relation.
+        self._assign_relation_alias(event.relation.id)
+
+        # Sets both database and extra user roles in the relation
+        # if the roles are provided. Otherwise, sets only the database.
+        if self.extra_user_roles:
+            self._update_relation_data(
+                event.relation.id,
+                {
+                    "database": self.database,
+                    "extra-user-roles": self.extra_user_roles,
+                },
+            )
+        else:
+            self._update_relation_data(event.relation.id, {"database": self.database})
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the database relation has changed."""
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Check if the database is created
+        # (the database charm shared the credentials).
+        if "username" in diff.added and "password" in diff.added:
+            # Emit the default event (the one without an alias).
+            logger.info("database created at %s", datetime.now())
+            self.on.database_created.emit(event.relation, app=event.app, unit=event.unit)
+
+            # Emit the aliased event (if any).
+            self._emit_aliased_event(event, "database_created")
+
+            # To avoid unnecessary application restarts do not trigger
+            # “endpoints_changed“ event if “database_created“ is triggered.
+            return
+
+        # Emit an endpoints changed event if the database
+        # added or changed this info in the relation databag.
+        if "endpoints" in diff.added or "endpoints" in diff.changed:
+            # Emit the default event (the one without an alias).
+            logger.info("endpoints changed on %s", datetime.now())
+            self.on.endpoints_changed.emit(event.relation, app=event.app, unit=event.unit)
+
+            # Emit the aliased event (if any).
+            self._emit_aliased_event(event, "endpoints_changed")
+
+            # To avoid unnecessary application restarts do not trigger
+            # “read_only_endpoints_changed“ event if “endpoints_changed“ is triggered.
+            return
+
+        # Emit a read only endpoints changed event if the database
+        # added or changed this info in the relation databag.
+        if "read-only-endpoints" in diff.added or "read-only-endpoints" in diff.changed:
+            # Emit the default event (the one without an alias).
+            logger.info("read-only-endpoints changed on %s", datetime.now())
+            self.on.read_only_endpoints_changed.emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # Emit the aliased event (if any).
+            self._emit_aliased_event(event, "read_only_endpoints_changed")
+
+
+# Kafka related events
+
+
+class KafkaProvidesEvent(RelationEvent):
+    """Base class for Kafka events."""
+
+    @property
+    def topic(self) -> Optional[str]:
+        """Returns the topic that was requested."""
+        return self.relation.data[self.relation.app].get("topic")
+
+    @property
+    def consumer_group_prefix(self) -> Optional[str]:
+        """Returns the consumer-group-prefix that was requested."""
+        return self.relation.data[self.relation.app].get("consumer-group-prefix")
+
+
+class TopicRequestedEvent(KafkaProvidesEvent, ExtraRoleEvent):
+    """Event emitted when a new topic is requested for use on this relation."""
+
+
+class KafkaProvidesEvents(CharmEvents):
+    """Kafka events.
+
+    This class defines the events that the Kafka can emit.
+    """
+
+    topic_requested = EventSource(TopicRequestedEvent)
+
+
+class KafkaRequiresEvent(RelationEvent):
+    """Base class for Kafka events."""
+
+    @property
+    def topic(self) -> Optional[str]:
+        """Returns the topic."""
+        return self.relation.data[self.relation.app].get("topic")
+
+    @property
+    def bootstrap_server(self) -> Optional[str]:
+        """Returns a a comma-seperated list of broker uris."""
+        return self.relation.data[self.relation.app].get("endpoints")
+
+    @property
+    def consumer_group_prefix(self) -> Optional[str]:
+        """Returns the consumer-group-prefix."""
+        return self.relation.data[self.relation.app].get("consumer-group-prefix")
+
+    @property
+    def zookeeper_uris(self) -> Optional[str]:
+        """Returns a comma separated list of Zookeeper uris."""
+        return self.relation.data[self.relation.app].get("zookeeper-uris")
+
+
+class TopicCreatedEvent(AuthenticationEvent, KafkaRequiresEvent):
+    """Event emitted when a new topic is created for use on this relation."""
+
+
+class BootstrapServerChangedEvent(AuthenticationEvent, KafkaRequiresEvent):
+    """Event emitted when the bootstrap server is changed."""
+
+
+class KafkaRequiresEvents(CharmEvents):
+    """Kafka events.
+
+    This class defines the events that the Kafka can emit.
+    """
+
+    topic_created = EventSource(TopicCreatedEvent)
+    bootstrap_server_changed = EventSource(BootstrapServerChangedEvent)
+
+
+# Kafka Provides and Requires
+
+
+class KafkaProvides(DataProvides):
+    """Provider-side of the Kafka relation."""
+
+    on = KafkaProvidesEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        super().__init__(charm, relation_name)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed."""
+        # Only the leader should handle this event.
+        if not self.local_unit.is_leader():
+            return
+
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Emit a topic requested event if the setup key (topic name and optional
+        # extra user roles) was added to the relation databag by the application.
+        if "topic" in diff.added:
+            self.on.topic_requested.emit(event.relation, app=event.app, unit=event.unit)
+
+    def set_topic(self, relation_id: int, topic: str) -> None:
+        """Set topic name in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            topic: the topic name.
+        """
+        self._update_relation_data(relation_id, {"topic": topic})
+
+    def set_bootstrap_server(self, relation_id: int, bootstrap_server: str) -> None:
+        """Set the bootstrap server in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            bootstrap_server: the bootstrap server address.
+        """
+        self._update_relation_data(relation_id, {"endpoints": bootstrap_server})
+
+    def set_consumer_group_prefix(self, relation_id: int, consumer_group_prefix: str) -> None:
+        """Set the consumer group prefix in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            consumer_group_prefix: the consumer group prefix string.
+        """
+        self._update_relation_data(relation_id, {"consumer-group-prefix": consumer_group_prefix})
+
+    def set_zookeeper_uris(self, relation_id: int, zookeeper_uris: str) -> None:
+        """Set the zookeeper uris in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            zookeeper_uris: comma-seperated list of ZooKeeper server uris.
+        """
+        self._update_relation_data(relation_id, {"zookeeper-uris": zookeeper_uris})
+
+
+class KafkaRequires(DataRequires):
+    """Requires-side of the Kafka relation."""
+
+    on = KafkaRequiresEvents()
+
+    def __init__(
+        self,
+        charm,
+        relation_name: str,
+        topic: str,
+        extra_user_roles: Optional[str] = None,
+        consumer_group_prefix: Optional[str] = None,
+    ):
+        """Manager of Kafka client relations."""
+        # super().__init__(charm, relation_name)
+        super().__init__(charm, relation_name, extra_user_roles)
+        self.charm = charm
+        self.topic = topic
+        self.consumer_group_prefix = consumer_group_prefix or ""
+
+    def _on_relation_joined_event(self, event: RelationJoinedEvent) -> None:
+        """Event emitted when the application joins the Kafka relation."""
+        # Sets topic, extra user roles, and "consumer-group-prefix" in the relation
+        relation_data = {
+            f: getattr(self, f.replace("-", "_"), "")
+            for f in ["consumer-group-prefix", "extra-user-roles", "topic"]
+        }
+
+        self._update_relation_data(event.relation.id, relation_data)
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the Kafka relation has changed."""
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Check if the topic is created
+        # (the Kafka charm shared the credentials).
+        if "username" in diff.added and "password" in diff.added:
+            # Emit the default event (the one without an alias).
+            logger.info("topic created at %s", datetime.now())
+            self.on.topic_created.emit(event.relation, app=event.app, unit=event.unit)
+
+            # To avoid unnecessary application restarts do not trigger
+            # “endpoints_changed“ event if “topic_created“ is triggered.
+            return
+
+        # Emit an endpoints (bootstap-server) changed event if the Kafka endpoints
+        # added or changed this info in the relation databag.
+        if "endpoints" in diff.added or "endpoints" in diff.changed:
+            # Emit the default event (the one without an alias).
+            logger.info("endpoints changed on %s", datetime.now())
+            self.on.bootstrap_server_changed.emit(
+                event.relation, app=event.app, unit=event.unit
+            )  # here check if this is the right design
+            return

--- a/nms-magmalte-operator/metadata.yaml
+++ b/nms-magmalte-operator/metadata.yaml
@@ -43,7 +43,7 @@ provides:
 
 requires:
   db:
-    interface: pgsql
+    interface: postgresql_client
     limit: 1
   cert-admin-operator:
     interface: cert-admin-operator

--- a/nms-magmalte-operator/metadata.yaml
+++ b/nms-magmalte-operator/metadata.yaml
@@ -42,7 +42,7 @@ provides:
     interface: grafana_auth
 
 requires:
-  db:
+  database:
     interface: postgresql_client
     limit: 1
   cert-admin-operator:

--- a/nms-magmalte-operator/requirements.txt
+++ b/nms-magmalte-operator/requirements.txt
@@ -1,5 +1,5 @@
 ops
-ops-lib-pgsql
+pgconnstr
 psycopg2-binary  # Package only used for testing, charm uses charm-binary-python-packages from charmcraft.yaml
 lightkube
 lightkube-models

--- a/nms-magmalte-operator/src/charm.py
+++ b/nms-magmalte-operator/src/charm.py
@@ -93,10 +93,10 @@ class MagmaNmsMagmalteCharm(CharmBase):
             self, auto_sign_up=False, relation_name=self.GRAFANA_AUTH_RELATION
         )
         self.framework.observe(
-            self.on.magma_nms_magmalte_pebble_ready, self._on_magma_nms_magmalte_pebble_ready
+            self.on.magma_nms_magmalte_pebble_ready, self._configure_workload
         )
         self.framework.observe(
-            self._database.on.database_created, self._on_magma_nms_magmalte_pebble_ready
+            self._database.on.database_created, self._configure_workload
         )
         self.framework.observe(self.on.db_relation_broken, self._on_database_relation_broken)
         self.framework.observe(
@@ -311,9 +311,9 @@ class MagmaNmsMagmalteCharm(CharmBase):
         self._container.push(
             path=f"{self.BASE_CERTS_PATH}/admin_operator.key.pem", source=event.private_key
         )
-        self._on_magma_nms_magmalte_pebble_ready(event)
+        self._configure_workload(event)
 
-    def _on_magma_nms_magmalte_pebble_ready(
+    def _configure_workload(
         self,
         event: Union[
             PebbleReadyEvent, CertificateAvailableEvent, UrlsAvailableEvent, RelationJoinedEvent
@@ -596,7 +596,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
         """
         app_data = self.model.get_relation("replicas").data[self.app]  # type: ignore[union-attr]  # noqa: E501
         app_data.update({"grafana_url": event.urls[0]})
-        self._on_magma_nms_magmalte_pebble_ready(event)
+        self._configure_workload(event)
 
     def _on_grafana_relation_broken(self, event: RelationBrokenEvent):
         self.unit.status = BlockedStatus("Waiting for grafana relation to be created")

--- a/nms-magmalte-operator/src/charm.py
+++ b/nms-magmalte-operator/src/charm.py
@@ -73,7 +73,9 @@ class MagmaNmsMagmalteCharm(CharmBase):
         super().__init__(*args)
         self._container_name = self._service_name = "magma-nms-magmalte"
         self._container = self.unit.get_container(self._container_name)
-        self._database = DatabaseRequires(self, relation_name="db", database_name=self.DB_NAME)
+        self._database = DatabaseRequires(
+            self, relation_name="database", database_name=self.DB_NAME
+        )
         self.admin_operator = CertAdminOperatorRequires(self, self.CERT_ADMIN_OPERATOR_RELATION)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
@@ -94,7 +96,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
         )
         self.framework.observe(self.on.magma_nms_magmalte_pebble_ready, self._configure_workload)
         self.framework.observe(self._database.on.database_created, self._configure_workload)
-        self.framework.observe(self.on.db_relation_broken, self._on_database_relation_broken)
+        self.framework.observe(self.on.database_relation_broken, self._on_database_relation_broken)
         self.framework.observe(
             self.on.magma_nms_magmalte_relation_joined,
             self._on_magma_nms_magmalte_relation_joined,
@@ -252,7 +254,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
         Returns:
             bool: True/False
         """
-        return self._relation_created("db")
+        return self._relation_created("database")
 
     @property
     def _cert_admin_operator_relation_created(self) -> bool:
@@ -327,7 +329,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
             None
         """
         if not self._db_relation_created:
-            self.unit.status = BlockedStatus("Waiting for db relation to be created")
+            self.unit.status = BlockedStatus("Waiting for database relation to be created")
             event.defer()
             return
         if not self._cert_admin_operator_relation_created:
@@ -343,7 +345,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
             event.defer()
             return
         if not self._db_relation_established:
-            self.unit.status = WaitingStatus("Waiting for db relation to be ready")
+            self.unit.status = WaitingStatus("Waiting for database relation to be ready")
             event.defer()
             return
         if not self._certs_are_stored:
@@ -395,7 +397,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
         Returns:
             None
         """
-        self.unit.status = BlockedStatus("Waiting for db relation to be created")
+        self.unit.status = BlockedStatus("Waiting for database relation to be created")
 
     def _on_magma_nms_magmalte_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Triggered when requirers join the nms_magmalte relation.

--- a/nms-magmalte-operator/src/charm.py
+++ b/nms-magmalte-operator/src/charm.py
@@ -229,7 +229,8 @@ class MagmaNmsMagmalteCharm(CharmBase):
                 "dbname": relation_data["database"],
                 "user": relation_data["username"],
                 "password": relation_data["password"],
-                "host": relation_data["endpoints"],
+                "host": relation_data["endpoints"].split(":")[0],
+                "port": relation_data["endpoints"].split(":")[1].split(",")[0],
             }
             return ConnectionString(**connection_info)
         except (AttributeError, KeyError):

--- a/nms-magmalte-operator/src/charm.py
+++ b/nms-magmalte-operator/src/charm.py
@@ -92,12 +92,8 @@ class MagmaNmsMagmalteCharm(CharmBase):
         self._grafana_auth_provider = GrafanaAuthProxyProvider(
             self, auto_sign_up=False, relation_name=self.GRAFANA_AUTH_RELATION
         )
-        self.framework.observe(
-            self.on.magma_nms_magmalte_pebble_ready, self._configure_workload
-        )
-        self.framework.observe(
-            self._database.on.database_created, self._configure_workload
-        )
+        self.framework.observe(self.on.magma_nms_magmalte_pebble_ready, self._configure_workload)
+        self.framework.observe(self._database.on.database_created, self._configure_workload)
         self.framework.observe(self.on.db_relation_broken, self._on_database_relation_broken)
         self.framework.observe(
             self.on.magma_nms_magmalte_relation_joined,

--- a/nms-magmalte-operator/src/charm.py
+++ b/nms-magmalte-operator/src/charm.py
@@ -15,8 +15,8 @@ import string
 import time
 from typing import Optional, Union
 
-import ops.lib
 import psycopg2  # type: ignore[import]
+from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires
 from charms.grafana_k8s.v0.grafana_auth import (
     GrafanaAuthProxyProvider,
     UrlsAvailableEvent,
@@ -45,11 +45,10 @@ from ops.model import (
     Relation,
     WaitingStatus,
 )
-from ops.pebble import ExecError, Layer
+from ops.pebble import ConnectionError, ExecError, Layer
 from pgconnstr import ConnectionString  # type: ignore[import]
 
 logger = logging.getLogger(__name__)
-pgsql = ops.lib.use("pgsql", 1, "postgresql-charmers@lists.launchpad.net")
 
 
 class ServiceNotRunningError(Exception):
@@ -74,7 +73,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
         super().__init__(*args)
         self._container_name = self._service_name = "magma-nms-magmalte"
         self._container = self.unit.get_container(self._container_name)
-        self._db = pgsql.PostgreSQLClient(self, "db")
+        self._database = DatabaseRequires(self, relation_name="db", database_name=self.DB_NAME)
         self.admin_operator = CertAdminOperatorRequires(self, self.CERT_ADMIN_OPERATOR_RELATION)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
@@ -97,7 +96,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
             self.on.magma_nms_magmalte_pebble_ready, self._on_magma_nms_magmalte_pebble_ready
         )
         self.framework.observe(
-            self._db.on.database_relation_joined, self._on_database_relation_joined
+            self._database.on.database_created, self._on_magma_nms_magmalte_pebble_ready
         )
         self.framework.observe(self.on.db_relation_broken, self._on_database_relation_broken)
         self.framework.observe(
@@ -229,8 +228,14 @@ class MagmaNmsMagmalteCharm(CharmBase):
             ConnectionString: pgconnstr ConnectionString object.
         """
         try:
-            db_relation = self.model.get_relation("db")
-            return ConnectionString(db_relation.data[db_relation.app]["master"])  # type: ignore[union-attr, index]  # noqa: E501
+            relation_data = next(iter(self._database.fetch_relation_data().values()))
+            connection_info = {
+                "dbname": relation_data["database"],
+                "user": relation_data["username"],
+                "password": relation_data["password"],
+                "host": relation_data["endpoints"],
+            }
+            return ConnectionString(**connection_info)
         except (AttributeError, KeyError):
             return None
 
@@ -385,26 +390,6 @@ class MagmaNmsMagmalteCharm(CharmBase):
         logger.info(message)
         raise TimeoutError(message)
 
-    def _on_database_relation_joined(self, event: RelationJoinedEvent) -> None:
-        """Event handler for database relation change.
-
-        - Sets the event.database field on the database joined event.
-        - Required because setting the database name is only possible
-          from inside the event handler per https://github.com/canonical/ops-lib-pgsql/issues/2
-        - Sets our database parameters based on what was provided
-          in the relation event.
-
-        Args:
-            event (RelationJoinedEvent): Juju event
-
-        Returns:
-            None
-        """
-        if not self.unit.is_leader():
-            return
-        event.database = self.DB_NAME  # type: ignore[attr-defined]
-        self._on_magma_nms_magmalte_pebble_ready(event)
-
     def _on_database_relation_broken(self, event: RelationBrokenEvent):
         """Event handler for database relation broken.
 
@@ -528,7 +513,7 @@ class MagmaNmsMagmalteCharm(CharmBase):
                     "admin-password": self._admin_password,
                 }
             )
-        except (ops.model.ModelError, ops.pebble.ConnectionError):
+        except (ModelError, ConnectionError):
             event.fail("Workload service is not yet running")
             return
         except Exception as e:

--- a/nms-magmalte-operator/tests/integration/test_integration.py
+++ b/nms-magmalte-operator/tests/integration/test_integration.py
@@ -125,7 +125,7 @@ class TestNmsMagmaLTE:
 
     async def test_relate_and_wait_for_idle(self, ops_test, setup, build_and_deploy_charm):
         await ops_test.model.add_relation(
-            relation1=APPLICATION_NAME, relation2="postgresql-k8s:db"
+            relation1=APPLICATION_NAME, relation2="postgresql-k8s:postgresql_client"
         )
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="orc8r-certifier:cert-admin-operator"

--- a/nms-magmalte-operator/tests/integration/test_integration.py
+++ b/nms-magmalte-operator/tests/integration/test_integration.py
@@ -47,6 +47,7 @@ class TestNmsMagmaLTE:
             "postgresql-k8s",
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @staticmethod

--- a/nms-magmalte-operator/tests/integration/test_integration.py
+++ b/nms-magmalte-operator/tests/integration/test_integration.py
@@ -125,7 +125,7 @@ class TestNmsMagmaLTE:
 
     async def test_relate_and_wait_for_idle(self, ops_test, setup, build_and_deploy_charm):
         await ops_test.model.add_relation(
-            relation1=APPLICATION_NAME, relation2="postgresql-k8s:postgresql_client"
+            relation1=APPLICATION_NAME, relation2="postgresql-k8s:database"
         )
         await ops_test.model.add_relation(
             relation1=APPLICATION_NAME, relation2="orc8r-certifier:cert-admin-operator"

--- a/nms-magmalte-operator/tests/unit/test_charm.py
+++ b/nms-magmalte-operator/tests/unit/test_charm.py
@@ -68,7 +68,7 @@ class TestCharm(unittest.TestCase):
         db_event.endpoints = f"{postgres_host}:{postgres_port}"
         return db_event
 
-    def test_given_db_relation_not_created_when_pebble_ready_then_unit_is_in_blocked_state(  # noqa: E501
+    def test_given_database_relation_not_created_when_pebble_ready_then_unit_is_in_blocked_state(  # noqa: E501
         self,
     ):
         self.harness.add_relation(
@@ -78,13 +78,13 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.charm.unit.status,
-            BlockedStatus("Waiting for db relation to be created"),
+            BlockedStatus("Waiting for database relation to be created"),
         )
 
     def test_given_cert_admin_operator_relation_not_created_when_pebble_ready_then_unit_is_in_blocked_state(  # noqa: E501
         self,
     ):
-        self.harness.add_relation(relation_name="db", remote_app="postgresql-k8s")
+        self.harness.add_relation(relation_name="database", remote_app="postgresql-k8s")
 
         self.harness.container_pebble_ready(container_name="magma-nms-magmalte")
 
@@ -99,7 +99,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="cert-admin-operator", remote_app="magma-orc8r-certifier"
         )
-        self.harness.add_relation(relation_name="db", remote_app="postgresql-k8s")
+        self.harness.add_relation(relation_name="database", remote_app="postgresql-k8s")
         self.harness.remove_relation(self.grafana_auth_rel_id)
 
         self.harness.container_pebble_ready(container_name="magma-nms-magmalte")
@@ -144,7 +144,9 @@ class TestCharm(unittest.TestCase):
         patch_file_exists.return_value = True
         container = self.harness.model.unit.get_container("magma-nms-magmalte")
         self.harness.set_can_connect(container=container, val=True)
-        db_relation_id = self.harness.add_relation(relation_name="db", remote_app="postgresql-k8s")
+        db_relation_id = self.harness.add_relation(
+            relation_name="database", remote_app="postgresql-k8s"
+        )
         self.harness.add_relation(
             relation_name="cert-admin-operator", remote_app="magma-orc8r-certifier"
         )
@@ -203,7 +205,9 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="cert-admin-operator", remote_app="magma-orc8r-certifier"
         )
-        db_relation_id = self.harness.add_relation(relation_name="db", remote_app="postgresql-k8s")
+        db_relation_id = self.harness.add_relation(
+            relation_name="database", remote_app="postgresql-k8s"
+        )
         self.harness.update_relation_data(
             relation_id=db_relation_id,
             key_values=self.DATABASE_DATABAG,
@@ -218,7 +222,7 @@ class TestCharm(unittest.TestCase):
     @patch("ops.model.Container.exec", new=Mock())
     @patch("ops.model.Container.exists")
     @patch("psycopg2.connect", new=Mock())
-    def test_given_pebble_ready_when_db_relation_broken_then_status_is_blocked(  # noqa: E501
+    def test_given_pebble_ready_when_database_relation_broken_then_status_is_blocked(  # noqa: E501
         self, patch_exists
     ):
         event = Mock()
@@ -230,7 +234,9 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="cert-admin-operator", remote_app="magma-orc8r-certifier"
         )
-        db_relation_id = self.harness.add_relation(relation_name="db", remote_app="postgresql-k8s")
+        db_relation_id = self.harness.add_relation(
+            relation_name="database", remote_app="postgresql-k8s"
+        )
         self.harness.update_relation_data(
             relation_id=db_relation_id,
             key_values=self.DATABASE_DATABAG,
@@ -239,7 +245,8 @@ class TestCharm(unittest.TestCase):
 
         self.harness.remove_relation(db_relation_id)
         self.assertEqual(
-            self.harness.charm.unit.status, BlockedStatus("Waiting for db relation to be created")
+            self.harness.charm.unit.status,
+            BlockedStatus("Waiting for database relation to be created"),
         )
 
     @patch("ops.model.Container.get_service", new=Mock())
@@ -434,7 +441,9 @@ class TestCharm(unittest.TestCase):
         patch_exists.return_value = True
         container = self.harness.model.unit.get_container(service_name)
         self.harness.set_can_connect(container=container, val=True)
-        db_relation_id = self.harness.add_relation(relation_name="db", remote_app="postgresql-k8s")
+        db_relation_id = self.harness.add_relation(
+            relation_name="database", remote_app="postgresql-k8s"
+        )
         self.harness.update_relation_data(
             relation_id=db_relation_id,
             key_values=self.DATABASE_DATABAG,
@@ -493,7 +502,9 @@ class TestCharm(unittest.TestCase):
         service_name = "magma-nms-magmalte"
         grafana_url_mock.return_value = self.GRAFANA_URLS[0]
         patch_exists.return_value = True
-        db_relation_id = self.harness.add_relation(relation_name="db", remote_app="postgresql-k8s")
+        db_relation_id = self.harness.add_relation(
+            relation_name="database", remote_app="postgresql-k8s"
+        )
         self.harness.update_relation_data(
             relation_id=db_relation_id,
             key_values=self.DATABASE_DATABAG,
@@ -546,7 +557,9 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="cert-admin-operator", remote_app="magma-orc8r-certifier"
         )
-        db_relation_id = self.harness.add_relation(relation_name="db", remote_app="postgresql-k8s")
+        db_relation_id = self.harness.add_relation(
+            relation_name="database", remote_app="postgresql-k8s"
+        )
         self.harness.update_relation_data(
             relation_id=db_relation_id,
             key_values=self.DATABASE_DATABAG,

--- a/nms-magmalte-operator/tests/unit/test_charm.py
+++ b/nms-magmalte-operator/tests/unit/test_charm.py
@@ -62,7 +62,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation_unit(self.peer_relation_id, self.harness.charm.unit.name)
 
     @staticmethod
-    def _fake_db_event(
+    def _fake_db_created_event(
         postgres_db_name: str,
         postgres_username: str,
         postgres_password: str,
@@ -73,7 +73,7 @@ class TestCharm(unittest.TestCase):
         db_event.database = postgres_db_name
         db_event.username = postgres_username
         db_event.password = postgres_password
-        db_event.host = f"{postgres_host}:{postgres_port}"
+        db_event.endpoints = f"{postgres_host}:{postgres_port}"
         return db_event
 
     def test_given_db_relation_not_created_when_pebble_ready_then_unit_is_in_blocked_state(  # noqa: E501
@@ -119,7 +119,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("charm.MagmaNmsMagmalteCharm.DB_NAME", new_callable=PropertyMock)
     @patch("ops.model.Unit.is_leader", Mock())
-    def test_given_pod_is_leader_when_database_relation_joined_event_then_database_is_set_correctly(  # noqa: E501
+    def test_given_pod_is_leader_when_database_created_event_then_database_is_set_correctly(  # noqa: E501
         self, mock_db_name
     ):
         mock_db_name.return_value = self.TEST_DB_NAME
@@ -129,14 +129,14 @@ class TestCharm(unittest.TestCase):
         postgres_username = "yeast"
         postgres_port = self.TEST_DB_PORT
 
-        db_event = self._fake_db_event(
+        db_event = self._fake_db_created_event(
             postgres_db_name,
             postgres_username,
             postgres_password,
             postgres_host,
             postgres_port,
         )
-        self.harness.charm._on_magma_nms_magmalte_pebble_ready(db_event)
+        self.harness.charm._configure_workload(db_event)
 
         self.assertEqual(db_event.database, self.TEST_DB_NAME)
 

--- a/nms-nginx-proxy-operator/tests/integration/test_integration.py
+++ b/nms-nginx-proxy-operator/tests/integration/test_integration.py
@@ -50,6 +50,7 @@ class TestNmsNginxProxy:
             "postgresql-k8s",
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @staticmethod

--- a/nms-nginx-proxy-operator/tests/integration/test_integration.py
+++ b/nms-nginx-proxy-operator/tests/integration/test_integration.py
@@ -125,7 +125,7 @@ class TestNmsNginxProxy:
             series="jammy",
         )
         await ops_test.model.add_relation(
-            relation1=NMS_MAGMALTE_APPLICATION_NAME, relation2=f"{DB_APPLICATION_NAME}:db"
+            relation1=NMS_MAGMALTE_APPLICATION_NAME, relation2=f"{DB_APPLICATION_NAME}:database"
         )
         await ops_test.model.add_relation(
             relation1=NMS_MAGMALTE_APPLICATION_NAME,

--- a/orc8r-accessd-operator/tests/integration/test_integration.py
+++ b/orc8r-accessd-operator/tests/integration/test_integration.py
@@ -28,6 +28,7 @@ class TestOrc8rAccessd:
             DB_APPLICATION_NAME,
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @pytest.fixture(scope="module")

--- a/orc8r-bootstrapper-operator/tests/integration/test_integration.py
+++ b/orc8r-bootstrapper-operator/tests/integration/test_integration.py
@@ -43,6 +43,7 @@ class TestOrc8rBootstrapper:
             "postgresql-k8s",
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @staticmethod

--- a/orc8r-bundle/bundle.yaml.j2
+++ b/orc8r-bundle/bundle.yaml.j2
@@ -361,7 +361,7 @@ relations:
 - - nms-magmalte
   - orc8r-certifier
 - - nms-magmalte:db
-  - postgresql-k8s:db
+  - postgresql-k8s:database
 - - nms-nginx-proxy
   - orc8r-certifier
 - - nms-nginx-proxy:magma-nms-magmalte

--- a/orc8r-bundle/bundle.yaml.j2
+++ b/orc8r-bundle/bundle.yaml.j2
@@ -356,87 +356,87 @@ applications:
     channel: edge
     scale: 1
 relations:
-- - fluentd
-  - orc8r-certifier:fluentd-certs
-- - nms-magmalte
-  - orc8r-certifier
-- - nms-magmalte:db
-  - postgresql-k8s:database
-- - nms-nginx-proxy
-  - orc8r-certifier
-- - nms-nginx-proxy:magma-nms-magmalte
-  - nms-magmalte:magma-nms-magmalte
-- - orc8r-accessd:database
-  - postgresql-k8s:database
-- - orc8r-alertmanager:remote-configuration
-  - orc8r-alertmanager-configurer:alertmanager
-- - orc8r-bootstrapper:database
-  - postgresql-k8s:database
-- - orc8r-bootstrapper:cert-root-ca
-  - orc8r-certifier:cert-root-ca
-- - orc8r-certifier
-  - tls-certificates-operator
-- - orc8r-certifier:database
-  - postgresql-k8s:database
-- - orc8r-configurator:database
-  - postgresql-k8s:database
-- - orc8r-ctraced:database
-  - postgresql-k8s:database
-- - orc8r-device:database
-  - postgresql-k8s:database
-- - orc8r-directoryd:database
-  - postgresql-k8s:database
-- - orc8r-lte:database
-  - postgresql-k8s:database
-- - orc8r-metricsd:alertmanager-k8s
-  - orc8r-alertmanager:alerting
-- - orc8r-metricsd:alertmanager-configurer-k8s
-  - orc8r-alertmanager-configurer:alertmanager-configurer
-- - orc8r-metricsd:magma-orc8r-orchestrator
-  - orc8r-orchestrator:magma-orc8r-orchestrator
-- - orc8r-metricsd:prometheus-k8s
-  - orc8r-prometheus:self-metrics-endpoint
-- - orc8r-metricsd:prometheus-configurer-k8s
-  - orc8r-prometheus-configurer:prometheus-configurer
-- - orc8r-nginx:magma-orc8r-bootstrapper
-  - orc8r-bootstrapper:magma-orc8r-bootstrapper
-- - orc8r-nginx:cert-certifier
-  - orc8r-certifier:cert-certifier
-- - orc8r-nginx:cert-controller
-  - orc8r-certifier:cert-controller
-- - orc8r-nginx:cert-root-ca
-  - orc8r-certifier:cert-root-ca
-- - orc8r-nginx:magma-orc8r-obsidian
-  - orc8r-obsidian:magma-orc8r-obsidian
-- - orc8r-orchestrator:cert-admin-operator
-  - orc8r-certifier:cert-admin-operator
-- - orc8r-orchestrator:magma-orc8r-certifier
-  - orc8r-certifier:magma-orc8r-certifier
-- - orc8r-orchestrator:magma-orc8r-accessd
-  - orc8r-accessd:magma-orc8r-accessd
-- - orc8r-orchestrator:magma-orc8r-service-registry
-  - orc8r-service-registry:magma-orc8r-service-registry
-- - orc8r-orchestrator:metrics-endpoint
-  - orc8r-prometheus-cache:metrics-endpoint
-- - orc8r-policydb:database
-  - postgresql-k8s:database
-- - orc8r-prometheus:alertmanager
-  - orc8r-alertmanager:alerting
-- - orc8r-prometheus:metrics-endpoint
-  - orc8r-prometheus-cache:metrics-endpoint
-- - orc8r-prometheus-configurer:prometheus
-  - orc8r-prometheus:receive-remote-write
-- - orc8r-smsd:database
-  - postgresql-k8s:database
-- - orc8r-state:database
-  - postgresql-k8s:database
-- - orc8r-subscriberdb-cache:database
-  - postgresql-k8s:database
-- - orc8r-subscriberdb:database
-  - postgresql-k8s:database
-- - orc8r-tenants:database
-  - postgresql-k8s:database
-- - orc8r-user-grafana:grafana-source
-  - orc8r-prometheus:grafana-source
-- - orc8r-user-grafana:grafana-auth
-  - nms-magmalte:grafana-auth
+  - - fluentd
+    - orc8r-certifier:fluentd-certs
+  - - nms-magmalte
+    - orc8r-certifier
+  - - nms-magmalte:database
+    - postgresql-k8s:database
+  - - nms-nginx-proxy
+    - orc8r-certifier
+  - - nms-nginx-proxy:magma-nms-magmalte
+    - nms-magmalte:magma-nms-magmalte
+  - - orc8r-accessd:database
+    - postgresql-k8s:database
+  - - orc8r-alertmanager:remote-configuration
+    - orc8r-alertmanager-configurer:alertmanager
+  - - orc8r-bootstrapper:database
+    - postgresql-k8s:database
+  - - orc8r-bootstrapper:cert-root-ca
+    - orc8r-certifier:cert-root-ca
+  - - orc8r-certifier
+    - tls-certificates-operator
+  - - orc8r-certifier:database
+    - postgresql-k8s:database
+  - - orc8r-configurator:database
+    - postgresql-k8s:database
+  - - orc8r-ctraced:database
+    - postgresql-k8s:database
+  - - orc8r-device:database
+    - postgresql-k8s:database
+  - - orc8r-directoryd:database
+    - postgresql-k8s:database
+  - - orc8r-lte:database
+    - postgresql-k8s:database
+  - - orc8r-metricsd:alertmanager-k8s
+    - orc8r-alertmanager:alerting
+  - - orc8r-metricsd:alertmanager-configurer-k8s
+    - orc8r-alertmanager-configurer:alertmanager-configurer
+  - - orc8r-metricsd:magma-orc8r-orchestrator
+    - orc8r-orchestrator:magma-orc8r-orchestrator
+  - - orc8r-metricsd:prometheus-k8s
+    - orc8r-prometheus:self-metrics-endpoint
+  - - orc8r-metricsd:prometheus-configurer-k8s
+    - orc8r-prometheus-configurer:prometheus-configurer
+  - - orc8r-nginx:magma-orc8r-bootstrapper
+    - orc8r-bootstrapper:magma-orc8r-bootstrapper
+  - - orc8r-nginx:cert-certifier
+    - orc8r-certifier:cert-certifier
+  - - orc8r-nginx:cert-controller
+    - orc8r-certifier:cert-controller
+  - - orc8r-nginx:cert-root-ca
+    - orc8r-certifier:cert-root-ca
+  - - orc8r-nginx:magma-orc8r-obsidian
+    - orc8r-obsidian:magma-orc8r-obsidian
+  - - orc8r-orchestrator:cert-admin-operator
+    - orc8r-certifier:cert-admin-operator
+  - - orc8r-orchestrator:magma-orc8r-certifier
+    - orc8r-certifier:magma-orc8r-certifier
+  - - orc8r-orchestrator:magma-orc8r-accessd
+    - orc8r-accessd:magma-orc8r-accessd
+  - - orc8r-orchestrator:magma-orc8r-service-registry
+    - orc8r-service-registry:magma-orc8r-service-registry
+  - - orc8r-orchestrator:metrics-endpoint
+    - orc8r-prometheus-cache:metrics-endpoint
+  - - orc8r-policydb:database
+    - postgresql-k8s:database
+  - - orc8r-prometheus:alertmanager
+    - orc8r-alertmanager:alerting
+  - - orc8r-prometheus:metrics-endpoint
+    - orc8r-prometheus-cache:metrics-endpoint
+  - - orc8r-prometheus-configurer:prometheus
+    - orc8r-prometheus:receive-remote-write
+  - - orc8r-smsd:database
+    - postgresql-k8s:database
+  - - orc8r-state:database
+    - postgresql-k8s:database
+  - - orc8r-subscriberdb-cache:database
+    - postgresql-k8s:database
+  - - orc8r-subscriberdb:database
+    - postgresql-k8s:database
+  - - orc8r-tenants:database
+    - postgresql-k8s:database
+  - - orc8r-user-grafana:grafana-source
+    - orc8r-prometheus:grafana-source
+  - - orc8r-user-grafana:grafana-auth
+    - nms-magmalte:grafana-auth

--- a/orc8r-bundle/tests/integration/orchestrator.py
+++ b/orc8r-bundle/tests/integration/orchestrator.py
@@ -7,7 +7,7 @@ from tempfile import NamedTemporaryFile
 from typing import Iterator
 
 import requests  # type: ignore[import]
-import urllib3  # type: ignore[import]
+import urllib3
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
     NoEncryption,

--- a/orc8r-bundle/tests/unit/expected_bundles/charmhub_edge.yaml
+++ b/orc8r-bundle/tests/unit/expected_bundles/charmhub_edge.yaml
@@ -205,7 +205,7 @@ relations:
   - - nms-magmalte
     - orc8r-certifier
   - - nms-magmalte:db
-    - postgresql-k8s:db
+    - postgresql-k8s:database
   - - nms-nginx-proxy
     - orc8r-certifier
   - - nms-nginx-proxy:magma-nms-magmalte

--- a/orc8r-bundle/tests/unit/expected_bundles/local.yaml
+++ b/orc8r-bundle/tests/unit/expected_bundles/local.yaml
@@ -231,7 +231,7 @@ relations:
   - - nms-magmalte
     - orc8r-certifier
   - - nms-magmalte:db
-    - postgresql-k8s:db
+    - postgresql-k8s:database
   - - nms-nginx-proxy
     - orc8r-certifier
   - - nms-nginx-proxy:magma-nms-magmalte

--- a/orc8r-bundle/tests/unit/test_render_bundle.py
+++ b/orc8r-bundle/tests/unit/test_render_bundle.py
@@ -41,7 +41,7 @@ def test_given_channel_is_edge_when_render_bundle_then_bundle_is_rendered_correc
     with open("tests/unit/expected_bundles/charmhub_edge.yaml") as expected_bundle_file:
         expected_bundle = expected_bundle_file.read()
 
-    assert rendered_bundle == expected_bundle
+    assert rendered_bundle == expected_bundle.strip()
 
 
 def test_given_local_charms_when_render_bundle_then_bundle_is_rendered_correctly():
@@ -57,4 +57,4 @@ def test_given_local_charms_when_render_bundle_then_bundle_is_rendered_correctly
     with open("tests/unit/expected_bundles/local.yaml") as expected_bundle_file:
         expected_bundle = expected_bundle_file.read()
 
-    assert rendered_bundle == expected_bundle
+    assert rendered_bundle == expected_bundle.strip()

--- a/orc8r-certifier-operator/tests/integration/test_integration.py
+++ b/orc8r-certifier-operator/tests/integration/test_integration.py
@@ -30,6 +30,7 @@ class TestOrc8rCertifier:
             DB_APPLICATION_NAME,
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @staticmethod

--- a/orc8r-configurator-operator/tests/integration/test_integration.py
+++ b/orc8r-configurator-operator/tests/integration/test_integration.py
@@ -28,6 +28,7 @@ class TestOrc8rConfigurator:
             DB_APPLICATION_NAME,
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @pytest.fixture(scope="module")

--- a/orc8r-ctraced-operator/tests/integration/test_integration.py
+++ b/orc8r-ctraced-operator/tests/integration/test_integration.py
@@ -28,6 +28,7 @@ class TestOrc8rCtraced:
             DB_APPLICATION_NAME,
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @pytest.fixture(scope="module")

--- a/orc8r-device-operator/tests/integration/test_integration.py
+++ b/orc8r-device-operator/tests/integration/test_integration.py
@@ -28,6 +28,7 @@ class TestOrc8rDevice:
             DB_APPLICATION_NAME,
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @pytest.fixture(scope="module")

--- a/orc8r-directoryd-operator/tests/integration/test_integration.py
+++ b/orc8r-directoryd-operator/tests/integration/test_integration.py
@@ -28,6 +28,7 @@ class TestOrc8rDirectoryd:
             DB_APPLICATION_NAME,
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @pytest.fixture(scope="module")

--- a/orc8r-lte-operator/tests/integration/test_integration.py
+++ b/orc8r-lte-operator/tests/integration/test_integration.py
@@ -28,6 +28,7 @@ class TestOrc8rLte:
             DB_APPLICATION_NAME,
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @pytest.fixture(scope="module")

--- a/orc8r-metricsd-operator/tests/integration/test_integration.py
+++ b/orc8r-metricsd-operator/tests/integration/test_integration.py
@@ -70,6 +70,7 @@ class TestOrc8rMetricsd:
             "postgresql-k8s",
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @staticmethod

--- a/orc8r-nginx-operator/tests/integration/test_integration.py
+++ b/orc8r-nginx-operator/tests/integration/test_integration.py
@@ -56,6 +56,7 @@ class TestOrc8rNginx:
             "postgresql-k8s",
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     async def _deploy_orc8r_certifier(self, ops_test):

--- a/orc8r-policydb-operator/tests/integration/test_integration.py
+++ b/orc8r-policydb-operator/tests/integration/test_integration.py
@@ -28,6 +28,7 @@ class TestOrc8rPolicyDB:
             DB_APPLICATION_NAME,
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @pytest.fixture(scope="module")

--- a/orc8r-smsd-operator/tests/integration/test_integration.py
+++ b/orc8r-smsd-operator/tests/integration/test_integration.py
@@ -28,6 +28,7 @@ class TestOrc8rSmsd:
             DB_APPLICATION_NAME,
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @pytest.fixture(scope="module")

--- a/orc8r-state-operator/tests/integration/test_integration.py
+++ b/orc8r-state-operator/tests/integration/test_integration.py
@@ -28,6 +28,7 @@ class TestOrc8rState:
             DB_APPLICATION_NAME,
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @pytest.fixture(scope="module")

--- a/orc8r-subscriberdb-cache-operator/tests/integration/test_integration.py
+++ b/orc8r-subscriberdb-cache-operator/tests/integration/test_integration.py
@@ -28,6 +28,7 @@ class TestOrc8rSubscriberDBCache:
             DB_APPLICATION_NAME,
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @pytest.fixture(scope="module")

--- a/orc8r-subscriberdb-operator/tests/integration/test_integration.py
+++ b/orc8r-subscriberdb-operator/tests/integration/test_integration.py
@@ -28,6 +28,7 @@ class TestOrc8rSubscriberDB:
             DB_APPLICATION_NAME,
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @pytest.fixture(scope="module")

--- a/orc8r-tenants-operator/tests/integration/test_integration.py
+++ b/orc8r-tenants-operator/tests/integration/test_integration.py
@@ -28,6 +28,7 @@ class TestOrc8rTenants:
             "postgresql-k8s",
             application_name=DB_APPLICATION_NAME,
             channel="14/stable",
+            trust=True,
         )
 
     @pytest.fixture(scope="module")


### PR DESCRIPTION
# Description

Use new data platform library for postgresql integration in nms-magmalte-operator, replacing the deprecated `ops-lib-pgsql`.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
